### PR TITLE
fix help tips on pids tab and rates tab

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -4903,11 +4903,11 @@
     "pidTuningFilterTip": {
         "message": "<b>Gyro Soft Filter:</b> Lowpass filter for gyro. Use lower value for more filtering.<br><b>D Term Filter:</b> Lowpass filter for Dterm. Can affect D tuning. Use lower value for more filtering. <br><b>Yaw Filter:</b> Filters yaw output. It can help on setups with noisy yaw axis."
     },
-    "pidTuningPidTuningTip": {
-        "message": "<b>Proportional:</b> You will notice a very strong resistant force to any attempts to move the MultiRotor<br><b>Integral:</b> Increase the ability to hold overall initial position and reduce drift, but also increase the delay in returning to initial position.<br><b>Derivative:</b> Improves the speed at which deviations are recovered, but increases noise<br><b>Rates and Expo</b>: Determine your stick feel based on these parameters. Use the graph and live 3D model to find your favourite rate setting"
-    },
     "pidTuningPidTuningTipFeedforward": {
-        "message": "<b>Proportional:</b> You will notice a very strong resistant force to any attempts to move the MultiRotor<br><b>Integral:</b> Increase the ability to hold overall initial position and reduce drift, but also increase the delay in returning to initial position.<br><b>Derivative:</b> Improves the speed at which deviations are recovered, but increases noise<br><b>Feedforward:</b> Usually the PID controller reacts to the error. The Feedforward anticipates the error based on the stick input, giving responsiveness to the quad.<br><b>Rates and Expo</b>: Determine your stick feel based on these parameters. Use the graph and live 3D model to find your favourite rate setting"
+        "message": "<b>Proportional:</b> You will notice a very strong resistant force to any attempts to move the MultiRotor<br><b>Integral:</b> Increase the ability to hold overall initial position and reduce drift, but also increase the delay in returning to initial position.<br><b>Derivative:</b> Improves the speed at which deviations are recovered, but increases noise<br><b>Feedforward:</b> Usually the PID controller reacts to the error. The Feedforward anticipates the error based on the stick input, giving responsiveness to the quad.<br>"
+    },
+    "pidTuningRatesTuningHelp":{
+         "message":"<b>Rates and Expo</b>: Determine your stick feel based on these parameters. Use the graph and live 3D model to find your favourite rate setting"
     },
     "pidTuningRatesTip": {
         "message": "Play with the rates and see how those affect the stick curve"

--- a/src/tabs/pid_tuning.html
+++ b/src/tabs/pid_tuning.html
@@ -110,7 +110,6 @@
                                 <th colspan="6">
                                     <div class="pid_mode">
                                         <div i18n="pidTuningBasic" style="float:left;"></div>
-                                        <div class="helpicon cf_tip" i18n_title="pidTuningPidTuningTip"></div>
                                         <div class="helpicon cf_tip" i18n_title="pidTuningPidTuningTipFeedforward"></div>
                                     </div>
                                 </th>
@@ -477,7 +476,7 @@
 
                                     <span class="suboption">
                                         <select id="itermrelaxType">
-                                            <option i18n="pidTuningItermRelaxTypeOptionGyro"     value="0"/> 
+                                            <option i18n="pidTuningItermRelaxTypeOptionGyro"     value="0"/>
                                             <option i18n="pidTuningItermRelaxTypeOptionSetpoint" value="1"/>
                                         </select>
                                         <label for="itermrelaxType">
@@ -493,7 +492,7 @@
                                     </span>
                                 </td>
                             </tr>
-                            
+
                             <tr class="antigravity">
                                 <td><input type="checkbox" id="antiGravitySwitch" class="toggle" /></td>
                                 <td colspan="3">
@@ -529,7 +528,7 @@
                     </div>
                 </div>
             </div>
-            
+
             <!-- RATES SUBTAB -->
             <div class="subtab-rates" style="display: none;">
                 <div class="clear-both"></div>
@@ -900,8 +899,8 @@
                                 </td>
                             </tr>
                         </table>
-                    </div>        
-                                
+                    </div>
+
                     <!-- IMUF -->
 
                     <div class="gui_box grey topspacer pid_filter kalmanFilterSettingsPanel">
@@ -1077,7 +1076,7 @@
                                         <div i18n="pidTuningDTermLowpassFiltersGroup" />
                                         <div class="helpicon cf_tip" i18n_title="pidTuningLowpassFilterHelp" />
                                     </div>
-                                        
+
                                     </div>
                                 </th>
                             </tr>
@@ -1133,7 +1132,7 @@
                                         <div  i18n="pidTuningDTermNotchFiltersGroup" />
                                         <div class="helpicon cf_tip" i18n_title="pidTuningNotchFilterHelp" />
                                     </div>
-                                    
+
                                 </th>
                             </tr>
 
@@ -1224,7 +1223,7 @@
         </div>
         <div class="buttons">
             <a href="#" class="dialogCopyProfile-confirmbtn regular-button" i18n="dialogCopyProfileConfirm"></a>
-            <a href="#" class="dialogCopyProfile-cancelbtn regular-button" i18n="dialogCopyProfileClose"></a> 
+            <a href="#" class="dialogCopyProfile-cancelbtn regular-button" i18n="dialogCopyProfileClose"></a>
         </div>
     </dialog>
 


### PR DESCRIPTION
Removed duplicate `?` icon from pids tab.   Moved `Rates` help to rates tab `?` icon.