### PR TITLE
KALMAN lowpass type only for MSP_API_VERSION lte 1.41.0

### DIFF
--- a/src/js/tabs/pid_tuning.js
+++ b/src/js/tabs/pid_tuning.js
@@ -1148,7 +1148,9 @@ TABS.pid_tuning.initialize = function (callback) {
             var filterTypeValues = [];
             filterTypeValues.push("PT1");
             filterTypeValues.push("BIQUAD");
-            filterTypeValues.push("KALMAN");
+            if (semver.lte(CONFIG.apiVersion, "1.41.0")) {
+                filterTypeValues.push("KALMAN");
+            }
             if (semver.lt(CONFIG.apiVersion, "1.39.0")) {
                 filterTypeValues.push("FIR");
             }


### PR DESCRIPTION
KALMAN lowpass type only for MSP_API_VERSION less-than-or-equal (<=) 1.41.0
i.e. remove KALMAN lowpass type for MSP_API_VERSION > 1.41.0 (Emu version 0.1.23+)