### PR TITLE
update GUI to use v2 fonts for msp 1.44+ [skip ci]

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -4616,10 +4616,10 @@
     },
 
     "osdDescribeFontVersion1": {
-        "message": "Font version: 1 (Emuflight 4.0 or older)"
+        "message": "Font version: 1 (MSP 1.43 or older)"
     },
     "osdDescribeFontVersion2": {
-        "message": "Font version: 2 (Emuflight 4.1 or newer)"
+        "message": "Font version: 2 (MSP 1.44 or newer)"
     },
     "osdDescribeFontVersionCUSTOM": {
         "message": "Font version: user provided"

--- a/src/js/tabs/osd.js
+++ b/src/js/tabs/osd.js
@@ -2587,6 +2587,9 @@ TABS.osd.initialize = function (callback) {
         fontPresetsElement.change(function (e) {
             var $font = $('.fontpresets option:selected');
             var fontver = 1;
+            if (semver.gte(CONFIG.apiVersion, "1.44.0")) {
+                fontver = 2;
+            }
             $('.font-manager-version-info').text(i18n.getMessage('osdDescribeFontVersion' + fontver));
             $.get('./resources/osd/' + fontver + '/' + $font.data('font-file') + '.mcm', function (data) {
                 FONT.parseMCMFontFile(data);


### PR DESCRIPTION
requires firmware branch named use_v2font_msp_1.44+. users will need to upload v2 fonts to flight controllers manually.