### PR TITLE
Fix travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,7 +72,7 @@ deploy:
     user: "${BINTRAY_USER}"
     key: "${BINTRAY_API_KEY}"
     file: bintray-conf.json
-    skip_cleanup: true # do not delete what has just been built
+    #skip_cleanup: true # do not delete what has just been built
     on:
       tags: true
 


### PR DESCRIPTION
* travis error: `deploy: deprecated key skip_cleanup (not supported in dpl v2, use cleanup)`
* needs tests before merge