### PR TITLE
jQuery 3.5.0 broke OSD

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "i18next-xhr-backend": "^3.2.0",
     "inflection": "1.12.0",
     "jbox": "1.0.5",
-    "jquery": "3.5.0",
+    "jquery": "^3.4.1",
     "jquery-textcomplete": "^1.8.5",
     "jquery-ui-npm": "1.12.0",
     "lru_map": "^0.3.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3061,10 +3061,10 @@ jquery-ui-npm@1.12.0:
   resolved "https://registry.yarnpkg.com/jquery-ui-npm/-/jquery-ui-npm-1.12.0.tgz#3f2cae88195c7d48acf3786cfa900d0403814e4d"
   integrity sha1-PyyuiBlcfUis83hs+pANBAOBTk0=
 
-jquery@3.5.0, jquery@^3.4.1:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.5.0.tgz#9980b97d9e4194611c36530e7dc46a58d7340fc9"
-  integrity sha512-Xb7SVYMvygPxbFMpTFQiHh1J7HClEaThguL15N/Gg37Lri/qKyhRGZYzHRyLH8Stq3Aow0LsHO2O2ci86fCrNQ==
+jquery@3.4.1, jquery@^3.4.1:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.4.1.tgz#714f1f8d9dde4bdfa55764ba37ef214630d80ef2"
+  integrity sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw==
 
 js-yaml@3.13.1:
   version "3.13.1"


### PR DESCRIPTION
* jQuery 3.5.0 broke OSD mcm file retrieval
* may require `npm install jquery@3.4.1` to repair local environments
