### PR TITLE
rateDynamics correction minimum 10

### DIFF
--- a/src/tabs/pid_tuning.html
+++ b/src/tabs/pid_tuning.html
@@ -718,13 +718,13 @@
                                 <tr class="pid-tuning">
                                     <td>Rate Center</td>
                                     <td><input type="number" name="rateSensCenter" step="1" min="25" max="175"></td>
-                                    <td><input type="number" name="rateCorrectionCenter" step="1" min="0" max="95"></td>
+                                    <td><input type="number" name="rateCorrectionCenter" step="1" min="10" max="95"></td>
                                     <td><input type="number" name="rateWeightCenter" step="1" min="0" max="95"></td>
                                 </tr>
                                 <tr class="pid-tuning">
                                     <td>Rate End</td>
                                     <td><input type="number" name="rateSensEnd" step="1" min="25" max="175"></td>
-                                    <td><input type="number" name="rateCorrectionEnd" step="1" min="0" max="95"></td>
+                                    <td><input type="number" name="rateCorrectionEnd" step="1" min="10" max="95"></td>
                                     <td><input type="number" name="rateWeightEnd" step="1" min="0" max="95"></td>
                                 </tr>
                             </tbody>


### PR DESCRIPTION
* limit `rate_center_correction` & `rate_end_correction` minimum to `10`
as per @Quick-Flash 