### PR TITLE
Expert-Mode show/hide toggle for Angle, SPA, SDS, WC

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -3236,19 +3236,19 @@
         "message": "Gyro Dyn Filter"
     },
     "pidTuningGyroNotch1Frequency": {
-        "message": "Center"
+        "message": "Gyro Notch Filter 1 Center Frequency [Hz]"
     },
     "pidTuningGyroDynLpf": {
         "message": "Gyro Dynamic Filter"
     },
     "pidTuningGyroNotch2Frequency": {
-        "message": "Center"
+        "message": "Gyro Notch Filter 2 Center Frequency [Hz]"
     },
     "pidTuningGyroNotch1Cutoff": {
-        "message": "Cutoff"
+        "message": "Gyro Notch Filter 1 Cutoff Frequency [Hz]"
     },
     "pidTuningGyroNotch2Cutoff": {
-        "message": "Cutoff"
+        "message": "Gyro Notch Filter 2 Cutoff Frequency [Hz]"
     },
     "pidTuningNotchFilterHelp": {
         "message": "The Notch Filter has a Center and a Cutoff. The filter is symmetrical. The Center Frequency is the center of the filter and the Cutoff Frequency is where Notch filter starts. For example with Notch Cutoff of 160 and Notch Center of 260 it means the range is 160-360Hz with most attenuation around center"

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -3202,15 +3202,6 @@
     "pidTuningGyroNotch2": {
         "message": "Gyro Notch Filter 2 Frequency [Hz]"
     },
-    "pidTuningRoll": {
-        "message": " - Roll"
-    },
-    "pidTuningPitch": {
-        "message": " - Pitch"
-    },
-    "pidTuningYaw": {
-        "message": " - Yaw"
-    },
     "pidTuningGyroLowpassType": {
         "message": "Filter 1 Type"
     },
@@ -3228,6 +3219,24 @@
     },
     "pidTuningGyroLowpass2Type": {
         "message": "Filter 2 Type"
+    },
+    "gyroLowpassFrequencyRoll": {
+        "message": " Roll Gyro Lowpass 1 Cutoff Frequency [Hz]"
+    },
+    "gyroLowpassFrequencyPitch": {
+        "message": " Pitch Gyro Lowpass 1 Cutoff Frequency [Hz]"
+    },
+    "gyroLowpassFrequencyYaw": {
+        "message": " Yaw Gyro Lowpass 1 Cutoff Frequency [Hz]"
+    },
+    "gyroLowpass2FrequencyRoll": {
+        "message": " Roll Gyro Lowpass 2 Cutoff Frequency [Hz]"
+    },
+    "gyroLowpass2FrequencyPitch": {
+        "message": " Pitch Gyro Lowpass 2 Cutoff Frequency [Hz]"
+    },
+    "gyroLowpass2FrequencyYaw": {
+        "message": " Yaw Gyro Lowpass 2 Cutoff Frequency [Hz]"
     },
     "pidTuningGyroNotchFiltersGroup": {
         "message": "Gyro Notch Filters"
@@ -3306,6 +3315,24 @@
     },
     "pidTuningDTermLowpass2Type": {
         "message": "D Term Lowpass 2 Filter Type"
+    },
+    "dtermLowpassFrequencyRoll": {
+        "message": " Roll D-Term Lowpass 1 Cutoff Frequency [Hz]"
+    },
+    "dtermLowpassFrequencyPitch": {
+        "message": " Pitch D-Term Lowpass 1 Cutoff Frequency [Hz]"
+    },
+    "dtermLowpassFrequencyYaw": {
+        "message": " Yaw D-Term Lowpass 1 Cutoff Frequency [Hz]"
+    },
+    "dtermLowpass2FrequencyRoll": {
+        "message": " Roll D-Term Lowpass 2 Cutoff Frequency [Hz]"
+    },
+    "dtermLowpass2FrequencyPitch": {
+        "message": " Pitch D-Term Lowpass 2 Cutoff Frequency [Hz]"
+    },
+    "dtermLowpass2FrequencyYaw": {
+        "message": " Yaw D-Term Lowpass 2 Cutoff Frequency [Hz]"
     },
     "pidTuningDTermLowpassDynMinFrequency": {
         "message": "D Term Lowpass 1 Dynamic Min Cutoff Frequency [Hz]"

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -664,12 +664,18 @@ function updateTabList(features) {
             $('.dtermLowpassFrequency').show();
             $('.gyroLowpassFrequencyAxis').hide();
             $('.dtermLowpassFrequencyAxis').hide();
+            //synchronize the hidden simple version - not the best location, but fails inside pid_tuning.js
+            $('.pid_filter input[name="gyroLowpassFrequency"]').val(parseInt($('.pid_filter input[name="gyroLowpassFrequencyRoll"]').val()));
+            $('.pid_filter input[name="dtermLowpassFrequency"]').val(parseInt($('.pid_filter input[name="dtermLowpassFrequencyRoll"]').val()));
         }
         if (semver.gte(CONFIG.apiVersion, "1.39.0")) {
             $('.gyroLowpass2FrequencyAxis').hide();
             $('.dtermLowpass2FrequencyAxis').hide();
             $('.gyroLowpass2Frequency').show();
             $('.dtermLowpass2Frequency').show();
+            //synchronize the hidden simple version - not the best location, but fails inside pid_tuning.js
+            $('.pid_filter input[name="gyroLowpass2Frequency"]').val(parseInt($('.pid_filter input[name="gyroLowpass2FrequencyRoll"]').val()));
+            $('.pid_filter input[name="dtermLowpass2Frequency"]').val(parseInt($('.pid_filter input[name="dtermLowpass2FrequencyRoll"]').val()));
         }
     }
 }

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -644,6 +644,34 @@ function updateTabList(features) {
     } else {
         $('#tabs ul.mode-connected li.tab_vtx').hide();
     }
+
+    //experimental: show/hide with expert-mode
+    if (isExpertModeEnabled()) {  //expert
+        if (semver.gte(CONFIG.apiVersion, "1.44.0")) {
+            $('.gyroLowpassFrequencyAxis').show();
+            $('.dtermLowpassFrequencyAxis').show();
+            $('.gyroLowpassFrequency').hide();
+            $('.dtermLowpassFrequency').hide();
+
+            $('.gyroLowpass2FrequencyAxis').show();
+            $('.dtermLowpass2FrequencyAxis').show();
+            $('.gyroLowpass2Frequency').hide();
+            $('.dtermLowpass2Frequency').hide();
+        }
+    } else {   //basic
+        if (semver.gte(CONFIG.apiVersion, "1.16.0")) {
+            $('.gyroLowpassFrequency').show();
+            $('.dtermLowpassFrequency').show();
+            $('.gyroLowpassFrequencyAxis').hide();
+            $('.dtermLowpassFrequencyAxis').hide();
+        }
+        if (semver.gte(CONFIG.apiVersion, "1.39.0")) {
+            $('.gyroLowpass2FrequencyAxis').hide();
+            $('.dtermLowpass2FrequencyAxis').hide();
+            $('.gyroLowpass2Frequency').show();
+            $('.dtermLowpass2Frequency').show();
+        }
+    }
 }
 
 function zeroPad(value, width) {

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -673,6 +673,17 @@ function updateTabList(features) {
     } else {
         $('.isexpertmode').hide();
     }
+
+    //experimental: expert-mode undo show for old firmware that does not support.
+    if (semver.lt(CONFIG.apiVersion, "1.43.0")) {
+        $('.spa').hide();
+        $('.spa_roll').hide();
+        $('.spa_pitch').hide();
+        $('.spa_yaw').hide();
+    }
+    if ( semver.lt(CONFIG.apiVersion, "1.44.0") || semver.lt(CONFIG.flightControllerVersion, "0.2.35") ) {
+        $('.smartDTermWitchBox').hide();
+    }
 }
 
 function zeroPad(value, width) {

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -656,10 +656,10 @@ function updateTabList(features) {
         } else {
             $('.LPFPit').show();
             $('.LPFYaw').show();
-            $('#pid-tuning .gyroLowpassFrequencyAxis .LPFRol').text(i18n.getMessage("pidTuningRoll"));
-            $('#pid-tuning .gyroLowpass2FrequencyAxis .LPFRol').text(i18n.getMessage("pidTuningRoll"));
-            $('#pid-tuning .dtermLowpassFrequencyAxis .LPFRol').text(i18n.getMessage("pidTuningRoll"));
-            $('#pid-tuning .dtermLowpass2FrequencyAxis .LPFRol').text(i18n.getMessage("pidTuningRoll"));
+            $('#pid-tuning .gyroLowpassFrequencyAxis .LPFRol').text(i18n.getMessage("gyroLowpassFrequencyRoll"));
+            $('#pid-tuning .gyroLowpass2FrequencyAxis .LPFRol').text(i18n.getMessage("gyroLowpass2FrequencyRoll"));
+            $('#pid-tuning .dtermLowpassFrequencyAxis .LPFRol').text(i18n.getMessage("dtermLowpassFrequencyRoll"));
+            $('#pid-tuning .dtermLowpass2FrequencyAxis .LPFRol').text(i18n.getMessage("dtermLowpass2FrequencyRoll"));
         }
     }
 

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -645,39 +645,24 @@ function updateTabList(features) {
         $('#tabs ul.mode-connected li.tab_vtx').hide();
     }
 
-    //experimental: show/hide with expert-mode
-    if (isExpertModeEnabled()) {  //expert
-        if (semver.gte(CONFIG.apiVersion, "1.44.0")) {
-            $('.gyroLowpassFrequencyAxis').show();
-            $('.dtermLowpassFrequencyAxis').show();
-            $('.gyroLowpassFrequency').hide();
-            $('.dtermLowpassFrequency').hide();
-
-            $('.gyroLowpass2FrequencyAxis').show();
-            $('.dtermLowpass2FrequencyAxis').show();
-            $('.gyroLowpass2Frequency').hide();
-            $('.dtermLowpass2Frequency').hide();
-        }
-    } else {   //basic
-        if (semver.gte(CONFIG.apiVersion, "1.16.0")) {
-            $('.gyroLowpassFrequency').show();
-            $('.dtermLowpassFrequency').show();
-            $('.gyroLowpassFrequencyAxis').hide();
-            $('.dtermLowpassFrequencyAxis').hide();
-            //synchronize the hidden simple version - not the best location, but fails inside pid_tuning.js
-            $('.pid_filter input[name="gyroLowpassFrequency"]').val(parseInt($('.pid_filter input[name="gyroLowpassFrequencyRoll"]').val()));
-            $('.pid_filter input[name="dtermLowpassFrequency"]').val(parseInt($('.pid_filter input[name="dtermLowpassFrequencyRoll"]').val()));
-        }
-        if (semver.gte(CONFIG.apiVersion, "1.39.0")) {
-            $('.gyroLowpass2FrequencyAxis').hide();
-            $('.dtermLowpass2FrequencyAxis').hide();
-            $('.gyroLowpass2Frequency').show();
-            $('.dtermLowpass2Frequency').show();
-            //synchronize the hidden simple version - not the best location, but fails inside pid_tuning.js
-            $('.pid_filter input[name="gyroLowpass2Frequency"]').val(parseInt($('.pid_filter input[name="gyroLowpass2FrequencyRoll"]').val()));
-            $('.pid_filter input[name="dtermLowpass2Frequency"]').val(parseInt($('.pid_filter input[name="dtermLowpass2FrequencyRoll"]').val()));
+    if (semver.gte(CONFIG.apiVersion, "1.44.0")) {
+        if (!isExpertModeEnabled()) {
+            $('.LPFPit').hide();
+            $('.LPFYaw').hide();
+            $('#pid-tuning .gyroLowpassFrequencyAxis .LPFRol').text(i18n.getMessage("pidTuningGyroLowpassFrequency"));
+            $('#pid-tuning .gyroLowpass2FrequencyAxis .LPFRol').text(i18n.getMessage("pidTuningGyroLowpass2Frequency"));
+            $('#pid-tuning .dtermLowpassFrequencyAxis .LPFRol').text(i18n.getMessage("pidTuningDTermLowpassFrequency"));
+            $('#pid-tuning .dtermLowpass2FrequencyAxis .LPFRol').text(i18n.getMessage("pidTuningDTermLowpass2Frequency"));
+        } else {
+            $('.LPFPit').show();
+            $('.LPFYaw').show();
+            $('#pid-tuning .gyroLowpassFrequencyAxis .LPFRol').text(i18n.getMessage("pidTuningRoll"));
+            $('#pid-tuning .gyroLowpass2FrequencyAxis .LPFRol').text(i18n.getMessage("pidTuningRoll"));
+            $('#pid-tuning .dtermLowpassFrequencyAxis .LPFRol').text(i18n.getMessage("pidTuningRoll"));
+            $('#pid-tuning .dtermLowpass2FrequencyAxis .LPFRol').text(i18n.getMessage("pidTuningRoll"));
         }
     }
+
 }
 
 function zeroPad(value, width) {

--- a/src/js/tabs/pid_tuning.js
+++ b/src/js/tabs/pid_tuning.js
@@ -146,7 +146,7 @@ TABS.pid_tuning.initialize = function(callback) {
 
         if (semver.gte(CONFIG.apiVersion, "1.16.0")) {
             $('.pid_tuning input[name="rc_rate_yaw"]').val(RC_tuning.rcYawRate.toFixed(2));
-            if (semver.gte(CONFIG.apiVersion, "1.44.0")) {
+            if (semver.gte(CONFIG.apiVersion, "1.44.0") && (isExpertModeEnabled())) {
                 $('.pid_filter input[name="gyroLowpassFrequencyRoll"]').val(FILTER_CONFIG.gyro_lowpass_hz_roll);
                 $('.pid_filter input[name="gyroLowpassFrequencyPitch"]').val(FILTER_CONFIG.gyro_lowpass_hz_pitch);
                 $('.pid_filter input[name="gyroLowpassFrequencyYaw"]').val(FILTER_CONFIG.gyro_lowpass_hz_yaw);
@@ -159,8 +159,13 @@ TABS.pid_tuning.initialize = function(callback) {
             } else {
                 $('.gyroLowpassFrequencyAxis').hide();
                 $('.dtermLowpassFrequencyAxis').hide();
+                if (semver.gte(CONFIG.apiVersion, "1.44.0")){
+                  $('.pid_filter input[name="gyroLowpassFrequency"]').val(FILTER_CONFIG.gyro_lowpass_hz_roll);
+                  $('.pid_filter input[name="dtermLowpassFrequency"]').val(FILTER_CONFIG.gyro_lowpass_hz_pitch);
+                }else{
                 $('.pid_filter input[name="gyroLowpassFrequency"]').val(FILTER_CONFIG.gyro_lowpass_hz);
                 $('.pid_filter input[name="dtermLowpassFrequency"]').val(FILTER_CONFIG.dterm_lowpass_hz);
+              }
                 $('.pid_filter input[name="yawLowpassFrequency"]').val(FILTER_CONFIG.yaw_lowpass_hz);
             }
         } else {
@@ -312,15 +317,22 @@ TABS.pid_tuning.initialize = function(callback) {
                 $('.dtermLowpass2FrequencyAxis').hide();
                 $('.gyroLowpass2FrequencyAxis').hide();
             } else {
+                if( !isExpertModeEnabled()){
+                  $('.gyroLowpass2FrequencyAxis').hide();
+                  $('.dtermLowpass2FrequencyAxis').hide();
+                  $('.pid_filter input[name="gyroLowpass2Frequency"]').val(FILTER_CONFIG.gyro_lowpass2_hz_roll);
+                    $('.pid_filter input[name="dtermLowpass2Frequency"]').val(FILTER_CONFIG.dterm_lowpass2_hz_roll);
+                }else{
                 $('.gyroLowpass2Frequency').hide();
                 $('.dtermLowpass2Frequency').hide();
                 $('.pid_filter input[name="gyroLowpass2FrequencyRoll"]').val(FILTER_CONFIG.gyro_lowpass2_hz_roll);
                 $('.pid_filter input[name="gyroLowpass2FrequencyPitch"]').val(FILTER_CONFIG.gyro_lowpass2_hz_pitch);
                 $('.pid_filter input[name="gyroLowpass2FrequencyYaw"]').val(FILTER_CONFIG.gyro_lowpass2_hz_yaw);
-                console.log('dterm_lowpass2_hz_roll' + FILTER_CONFIG.dterm_lowpass2_hz_roll);
                 $('.pid_filter input[name="dtermLowpass2FrequencyRoll"]').val(FILTER_CONFIG.dterm_lowpass2_hz_roll);
                 $('.pid_filter input[name="dtermLowpass2FrequencyPitch"]').val(FILTER_CONFIG.dterm_lowpass2_hz_pitch);
                 $('.pid_filter input[name="dtermLowpass2FrequencyYaw"]').val(FILTER_CONFIG.dterm_lowpass2_hz_yaw);
+              }
+
             }
             //removes 5th column which is Feedforward
             $('#pid_main .pid_titlebar2 th').attr('colspan', 4);
@@ -578,7 +590,11 @@ TABS.pid_tuning.initialize = function(callback) {
 
             var type = (FILTER_CONFIG.gyro_lowpass_hz > 0 || FILTER_CONFIG.gyro_lowpass_hz_roll > 0) ? FILTER_CONFIG.gyro_lowpass_type : FILTER_DEFAULT.gyro_lowpass_type;
 
-            $('.pid_filter input[name="gyroLowpassFrequency"]').val((checked) ? cutoff : 0).attr('disabled', !checked);
+            if(!isExpertModeEnabled() && (semver.gte(CONFIG.apiVersion, "1.45.0"))) {
+            $('.pid_filter input[name="gyroLowpassFrequency"]').val((checked) ? cutoffRoll : 0).attr('disabled', !checked);
+          }else{
+              $('.pid_filter input[name="gyroLowpassFrequency"]').val((checked) ? cutoff : 0).attr('disabled', !checked);
+          }
             $('.pid_filter input[name="gyroLowpassFrequencyRoll"]').val((checked) ? cutoffRoll : 0).attr('disabled', !checked);
             $('.pid_filter input[name="gyroLowpassFrequencyPitch"]').val((checked) ? cutoffPitch : 0).attr('disabled', !checked);
             $('.pid_filter input[name="gyroLowpassFrequencyYaw"]').val((checked) ? cutoffYaw : 0).attr('disabled', !checked);
@@ -596,7 +612,11 @@ TABS.pid_tuning.initialize = function(callback) {
             var cutoffYaw = FILTER_CONFIG.gyro_lowpass2_hz_yaw > 0 ? FILTER_CONFIG.gyro_lowpass2_hz_yaw : FILTER_DEFAULT.gyro_lowpass2_hz;
             var type = (FILTER_CONFIG.gyro_lowpass2_hz > 0 || FILTER_CONFIG.gyro_lowpass2_hz_roll > 0) ? FILTER_CONFIG.gyro_lowpass2_type : FILTER_DEFAULT.gyro_lowpass2_type;
 
+            if(!isExpertModeEnabled() &&  (semver.gte(CONFIG.apiVersion, "1.45.0"))) {
+            $('.pid_filter input[name="gyroLowpass2Frequency"]').val(checked ? cutoffRoll : 0).attr('disabled', !checked);
+            }else{
             $('.pid_filter input[name="gyroLowpass2Frequency"]').val(checked ? cutoff : 0).attr('disabled', !checked);
+            }
             $('.pid_filter input[name="gyroLowpass2FrequencyRoll"]').val(checked ? cutoffRoll : 0).attr('disabled', !checked);
             $('.pid_filter input[name="gyroLowpass2FrequencyPitch"]').val(checked ? cutoffPitch : 0).attr('disabled', !checked);
             $('.pid_filter input[name="gyroLowpass2FrequencyYaw"]').val(checked ? cutoffYaw : 0).attr('disabled', !checked);
@@ -612,7 +632,11 @@ TABS.pid_tuning.initialize = function(callback) {
             var cutoffYaw = FILTER_CONFIG.dterm_lowpass_hz_yaw > 0 ? FILTER_CONFIG.dterm_lowpass_hz_yaw : FILTER_DEFAULT.dterm_lowpass_hz;
             var type = (FILTER_CONFIG.dterm_lowpass_hz > 0 || FILTER_CONFIG.dterm_lowpass_hz_roll > 0) ? FILTER_CONFIG.dterm_lowpass_type : FILTER_DEFAULT.dterm_lowpass_type;
 
+            if(!isExpertModeEnabled() &&  (semver.gte(CONFIG.apiVersion, "1.45.0"))) {
+            $('.pid_filter input[name="dtermLowpassFrequency"]').val((checked) ? cutoffRoll : 0).attr('disabled', !checked);
+            }else{
             $('.pid_filter input[name="dtermLowpassFrequency"]').val((checked) ? cutoff : 0).attr('disabled', !checked);
+            }
             $('.pid_filter input[name="dtermLowpassFrequencyRoll"]').val((checked) ? cutoffRoll : 0).attr('disabled', !checked);
             $('.pid_filter input[name="dtermLowpassFrequencyPitch"]').val((checked) ? cutoffPitch : 0).attr('disabled', !checked);
             $('.pid_filter input[name="dtermLowpassFrequencyYaw"]').val((checked) ? cutoffYaw : 0).attr('disabled', !checked);
@@ -629,7 +653,12 @@ TABS.pid_tuning.initialize = function(callback) {
             var cutoffPitch = FILTER_CONFIG.dterm_lowpass2_hz_pitch > 0 ? FILTER_CONFIG.dterm_lowpass2_hz_pitch : FILTER_DEFAULT.dterm_lowpass2_hz;
             var cutoffYaw = FILTER_CONFIG.dterm_lowpass2_hz_yaw > 0 ? FILTER_CONFIG.dterm_lowpass2_hz_yaw : FILTER_DEFAULT.dterm_lowpass2_hz;
 
+            if(!isExpertModeEnabled() &&  (semver.gte(CONFIG.apiVersion, "1.45.0"))) {
+            $('.pid_filter input[name="dtermLowpass2Frequency"]').val(checked ? cutoffRoll : 0).attr('disabled', !checked);
+            }else{
             $('.pid_filter input[name="dtermLowpass2Frequency"]').val(checked ? cutoff : 0).attr('disabled', !checked);
+            }
+
             $('.pid_filter input[name="dtermLowpass2FrequencyRoll"]').val(checked ? cutoffRoll : 0).attr('disabled', !checked);
             $('.pid_filter input[name="dtermLowpass2FrequencyPitch"]').val(checked ? cutoffPitch : 0).attr('disabled', !checked);
             $('.pid_filter input[name="dtermLowpass2FrequencyYaw"]').val(checked ? cutoffYaw : 0).attr('disabled', !checked);
@@ -737,12 +766,21 @@ TABS.pid_tuning.initialize = function(callback) {
             FILTER_CONFIG.dterm_lowpass_hz = parseInt($('.pid_filter input[name="dtermLowpassFrequency"]').val());
             FILTER_CONFIG.yaw_lowpass_hz = parseInt($('.pid_filter input[name="yawLowpassFrequency"]').val());
         } else {
+          if(!isExpertModeEnabled()) {
+            FILTER_CONFIG.gyro_lowpass_hz_roll = parseInt($('.pid_filter input[name="gyroLowpassFrequency"]').val());
+            FILTER_CONFIG.gyro_lowpass_hz_pitch = parseInt($('.pid_filter input[name="gyroLowpassFrequency"]').val());
+            FILTER_CONFIG.gyro_lowpass_hz_yaw = parseInt($('.pid_filter input[name="gyroLowpassFrequency"]').val());
+            FILTER_CONFIG.dterm_lowpass_hz_roll = parseInt($('.pid_filter input[name="dtermLowpassFrequency"]').val());
+            FILTER_CONFIG.dterm_lowpass_hz_pitch = parseInt($('.pid_filter input[name="dtermLowpassFrequency"]').val());
+            FILTER_CONFIG.dterm_lowpass_hz_yaw = parseInt($('.pid_filter input[name="dtermLowpassFrequency"]').val());
+          }else{
             FILTER_CONFIG.gyro_lowpass_hz_roll = parseInt($('.pid_filter input[name="gyroLowpassFrequencyRoll"]').val());
             FILTER_CONFIG.gyro_lowpass_hz_pitch = parseInt($('.pid_filter input[name="gyroLowpassFrequencyPitch"]').val());
             FILTER_CONFIG.gyro_lowpass_hz_yaw = parseInt($('.pid_filter input[name="gyroLowpassFrequencyYaw"]').val());
             FILTER_CONFIG.dterm_lowpass_hz_roll = parseInt($('.pid_filter input[name="dtermLowpassFrequencyRoll"]').val());
             FILTER_CONFIG.dterm_lowpass_hz_pitch = parseInt($('.pid_filter input[name="dtermLowpassFrequencyPitch"]').val());
             FILTER_CONFIG.dterm_lowpass_hz_yaw = parseInt($('.pid_filter input[name="dtermLowpassFrequencyYaw"]').val());
+          }
         }
 
         if (semver.gte(CONFIG.apiVersion, "1.16.0") && !semver.gte(CONFIG.apiVersion, "1.20.0")) {
@@ -791,13 +829,22 @@ TABS.pid_tuning.initialize = function(callback) {
         }
 
         if (semver.gte(CONFIG.apiVersion, "1.39.0")) {
-            if (semver.gte(CONFIG.apiVersion, "1.44.0")) {
+            if (semver.gte(CONFIG.apiVersion, "1.44.0") ) {
+                if(!isExpertModeEnabled()) {
+                  FILTER_CONFIG.gyro_lowpass2_hz_roll = parseInt($('.pid_filter input[name="gyroLowpass2Frequency"]').val());
+                  FILTER_CONFIG.gyro_lowpass2_hz_pitch = parseInt($('.pid_filter input[name="gyroLowpass2Frequency"]').val());
+                  FILTER_CONFIG.gyro_lowpass2_hz_yaw = parseInt($('.pid_filter input[name="gyroLowpass2Frequency"]').val());
+                  FILTER_CONFIG.dterm_lowpass2_hz_roll = parseInt($('.pid_filter input[name="dtermLowpass2Frequency"]').val());
+                  FILTER_CONFIG.dterm_lowpass2_hz_pitch = parseInt($('.pid_filter input[name="dtermLowpass2Frequency"]').val());
+                  FILTER_CONFIG.dterm_lowpass2_hz_yaw = parseInt($('.pid_filter input[name="dtermLowpass2Frequency"]').val());
+                }else{
                 FILTER_CONFIG.gyro_lowpass2_hz_roll = parseInt($('.pid_filter input[name="gyroLowpass2FrequencyRoll"]').val());
                 FILTER_CONFIG.gyro_lowpass2_hz_pitch = parseInt($('.pid_filter input[name="gyroLowpass2FrequencyPitch"]').val());
                 FILTER_CONFIG.gyro_lowpass2_hz_yaw = parseInt($('.pid_filter input[name="gyroLowpass2FrequencyYaw"]').val());
                 FILTER_CONFIG.dterm_lowpass2_hz_roll = parseInt($('.pid_filter input[name="dtermLowpass2FrequencyRoll"]').val());
                 FILTER_CONFIG.dterm_lowpass2_hz_pitch = parseInt($('.pid_filter input[name="dtermLowpass2FrequencyPitch"]').val());
                 FILTER_CONFIG.dterm_lowpass2_hz_yaw = parseInt($('.pid_filter input[name="dtermLowpass2FrequencyYaw"]').val());
+              }
             } else {
                 FILTER_CONFIG.gyro_lowpass2_hz = parseInt($('.pid_filter input[name="gyroLowpass2Frequency"]').val());
                 FILTER_CONFIG.dterm_lowpass2_hz = parseInt($('.pid_filter input[name="dtermLowpass2Frequency"]').val());

--- a/src/js/tabs/pid_tuning.js
+++ b/src/js/tabs/pid_tuning.js
@@ -745,6 +745,11 @@ TABS.pid_tuning.initialize = function(callback) {
             $('input[id="dtermLowpass2Enabled"]').prop('checked', FILTER_CONFIG.dterm_lowpass2_hz_pitch != 0).change();
             $('input[id="gyroLowpass2Enabled"]').prop('checked', FILTER_CONFIG.gyro_lowpass2_hz_pitch != 0).change();
         }
+
+        //experimental expert-mode show/hide SPA
+        if (!isExpertModeEnabled()) {
+            $('.isexpertmode').hide();
+        }
     } //pid_and_rc_to_form()
 
     function form_to_pid_and_rc() {
@@ -1935,7 +1940,7 @@ TABS.pid_tuning.initialize = function(callback) {
 
         GUI.content_ready(callback);
     }
-};
+}; //end TABS.pid_tuning.initialize = function
 
 TABS.pid_tuning.getRecieverData = function() {
     MSP.send_message(MSPCodes.MSP_RC, false, false);

--- a/src/js/tabs/pid_tuning.js
+++ b/src/js/tabs/pid_tuning.js
@@ -334,7 +334,6 @@ TABS.pid_tuning.initialize = function(callback) {
                 $('.pid_filter input[name="dtermLowpass2FrequencyPitch"]').val(FILTER_CONFIG.dterm_lowpass2_hz_pitch);
                 $('.pid_filter input[name="dtermLowpass2FrequencyYaw"]').val(FILTER_CONFIG.dterm_lowpass2_hz_yaw);
               }
-
             }
             //removes 5th column which is Feedforward
             $('#pid_main .pid_titlebar2 th').attr('colspan', 4);
@@ -344,6 +343,42 @@ TABS.pid_tuning.initialize = function(callback) {
             $('.dtermLowpass2').hide();
             $('#pid_main .pid_titlebar2 th').attr('colspan', 4);
         }
+
+        //synchronize the hidden values for users who toggle expert-mode
+        // set per axis from single
+        $('.pid_filter input[name="gyroLowpassFrequency"]').change(function() {
+            $('.pid_filter input[name="gyroLowpassFrequencyRoll"]').val(parseInt($('.pid_filter input[name="gyroLowpassFrequency"]').val()));
+            $('.pid_filter input[name="gyroLowpassFrequencyPitch"]').val(parseInt($('.pid_filter input[name="gyroLowpassFrequency"]').val()));
+            $('.pid_filter input[name="gyroLowpassFrequencyYaw"]').val(parseInt($('.pid_filter input[name="gyroLowpassFrequency"]').val()));
+        });
+        $('.pid_filter input[name="dtermLowpassFrequency"]').change(function() {
+            $('.pid_filter input[name="dtermLowpassFrequencyRoll"]').val(parseInt($('.pid_filter input[name="dtermLowpassFrequency"]').val()));
+            $('.pid_filter input[name="dtermLowpassFrequencyPitch"]').val(parseInt($('.pid_filter input[name="dtermLowpassFrequency"]').val()));
+            $('.pid_filter input[name="dtermLowpassFrequencyYaw"]').val(parseInt($('.pid_filter input[name="dtermLowpassFrequency"]').val()));
+        });
+        $('.pid_filter input[name="gyroLowpass2Frequency"]').change(function() {
+            $('.pid_filter input[name="gyroLowpass2FrequencyRoll"]').val(parseInt($('.pid_filter input[name="gyroLowpass2Frequency"]').val()));
+            $('.pid_filter input[name="gyroLowpass2FrequencyPitch"]').val(parseInt($('.pid_filter input[name="gyroLowpass2Frequency"]').val()));
+            $('.pid_filter input[name="gyroLowpass2FrequencyYaw"]').val(parseInt($('.pid_filter input[name="gyroLowpass2Frequency"]').val()));
+        });
+        $('.pid_filter input[name="dtermLowpass2Frequency"]').change(function() {
+            $('.pid_filter input[name="dtermLowpass2FrequencyRoll"]').val(parseInt($('.pid_filter input[name="dtermLowpass2Frequency"]').val()));
+            $('.pid_filter input[name="dtermLowpass2FrequencyPitch"]').val(parseInt($('.pid_filter input[name="dtermLowpass2Frequency"]').val()));
+            $('.pid_filter input[name="dtermLowpass2FrequencyYaw"]').val(parseInt($('.pid_filter input[name="dtermLowpass2Frequency"]').val()));
+        });
+        // set single from Roll
+        $('.pid_filter input[name="gyroLowpassFrequencyRoll"]').change(function() {
+            $('.pid_filter input[name="gyroLowpassFrequency"]').val(parseInt($('.pid_filter input[name="gyroLowpassFrequencyRoll"]').val()));
+        });
+        $('.pid_filter input[name="dtermLowpassFrequencyRoll"]').change(function() {
+            $('.pid_filter input[name="dtermLowpassFrequency"]').val(parseInt($('.pid_filter input[name="dtermLowpassFrequencyRoll"]').val()));
+        });
+        $('.pid_filter input[name="gyroLowpass2FrequencyRoll"]').change(function() {
+            $('.pid_filter input[name="gyroLowpass2Frequency"]').val(parseInt($('.pid_filter input[name="gyroLowpass2FrequencyRoll"]').val()));
+        });
+        $('.pid_filter input[name="dtermLowpass2FrequencyRoll"]').change(function() {
+            $('.pid_filter input[name="dtermLowpass2Frequency"]').val(parseInt($('.pid_filter input[name="dtermLowpass2FrequencyRoll"]').val()));
+        });
 
         if (semver.gte(CONFIG.apiVersion, "1.40.0")) {
 

--- a/src/js/tabs/pid_tuning.js
+++ b/src/js/tabs/pid_tuning.js
@@ -146,7 +146,7 @@ TABS.pid_tuning.initialize = function(callback) {
 
         if (semver.gte(CONFIG.apiVersion, "1.16.0")) {
             $('.pid_tuning input[name="rc_rate_yaw"]').val(RC_tuning.rcYawRate.toFixed(2));
-            if (semver.gte(CONFIG.apiVersion, "1.44.0") && (isExpertModeEnabled())) {
+            if (semver.gte(CONFIG.apiVersion, "1.44.0")) {
                 $('.pid_filter input[name="gyroLowpassFrequencyRoll"]').val(FILTER_CONFIG.gyro_lowpass_hz_roll);
                 $('.pid_filter input[name="gyroLowpassFrequencyPitch"]').val(FILTER_CONFIG.gyro_lowpass_hz_pitch);
                 $('.pid_filter input[name="gyroLowpassFrequencyYaw"]').val(FILTER_CONFIG.gyro_lowpass_hz_yaw);
@@ -156,25 +156,39 @@ TABS.pid_tuning.initialize = function(callback) {
                 $('.gyroLowpassFrequency').hide();
                 $('.dtermLowpassFrequency').hide();
                 $('.yawLowpassFrequency').hide();
+                //experimental expert-mode show/hide also in main.js
+                if (!isExpertModeEnabled()) {
+                    $('.LPFPit').hide();
+                    $('.LPFYaw').hide();
+                    $('#pid-tuning .gyroLowpassFrequencyAxis .LPFRol').text(i18n.getMessage("pidTuningGyroLowpassFrequency"));
+                    $('#pid-tuning .dtermLowpassFrequencyAxis .LPFRol').text(i18n.getMessage("pidTuningDTermLowpassFrequency"));
+                }
             } else {
                 $('.gyroLowpassFrequencyAxis').hide();
                 $('.dtermLowpassFrequencyAxis').hide();
-                if (semver.gte(CONFIG.apiVersion, "1.44.0")){
-                  $('.pid_filter input[name="gyroLowpassFrequency"]').val(FILTER_CONFIG.gyro_lowpass_hz_roll);
-                  $('.pid_filter input[name="dtermLowpassFrequency"]').val(FILTER_CONFIG.dterm_lowpass_hz_roll);
-                  $('.yawLowpassFrequency').hide();
-                }else{
                 $('.pid_filter input[name="gyroLowpassFrequency"]').val(FILTER_CONFIG.gyro_lowpass_hz);
                 $('.pid_filter input[name="dtermLowpassFrequency"]').val(FILTER_CONFIG.dterm_lowpass_hz);
                 $('.pid_filter input[name="yawLowpassFrequency"]').val(FILTER_CONFIG.yaw_lowpass_hz);
-              }
-
             }
         } else {
             $('.tab-pid_tuning .subtab-filter').hide();
             $('.tab-pid_tuning .tab_container').hide();
             $('.pid_tuning input[name="rc_rate_yaw"]').hide();
         }
+
+        //experimental expert-mode synchronize hidden Pitch/Yaw
+        $('.pid_filter input[name="gyroLowpassFrequencyRoll"]').change(function() {
+            if (!isExpertModeEnabled()) {
+                $('.pid_filter input[name="gyroLowpassFrequencyPitch"]').val(parseInt($('.pid_filter input[name="gyroLowpassFrequencyRoll"]').val()));
+                $('.pid_filter input[name="gyroLowpassFrequencyYaw"]').val(parseInt($('.pid_filter input[name="gyroLowpassFrequencyRoll"]').val()));
+            }
+        });
+        $('.pid_filter input[name="dtermLowpassFrequencyRoll"]').change(function() {
+            if (!isExpertModeEnabled()) {
+                $('.pid_filter input[name="dtermLowpassFrequencyPitch"]').val(parseInt($('.pid_filter input[name="dtermLowpassFrequencyRoll"]').val()));
+                $('.pid_filter input[name="dtermLowpassFrequencyYaw"]').val(parseInt($('.pid_filter input[name="dtermLowpassFrequencyRoll"]').val()));
+            }
+        });
 
         if (semver.gte(CONFIG.apiVersion, "1.20.0") ||
             semver.gte(CONFIG.apiVersion, "1.16.0") && FEATURE_CONFIG.features.isEnabled('SUPEREXPO_RATES')) {
@@ -318,22 +332,23 @@ TABS.pid_tuning.initialize = function(callback) {
                 $('.pid_filter input[name="gyroLowpassFrequency"]').val(FILTER_CONFIG.gyro_lowpass_hz);
                 $('.dtermLowpass2FrequencyAxis').hide();
                 $('.gyroLowpass2FrequencyAxis').hide();
-            } else {
-                if( !isExpertModeEnabled()){
-                  $('.gyroLowpass2FrequencyAxis').hide();
-                  $('.dtermLowpass2FrequencyAxis').hide();
-                  $('.pid_filter input[name="gyroLowpass2Frequency"]').val(FILTER_CONFIG.gyro_lowpass2_hz_roll);
-                  $('.pid_filter input[name="dtermLowpass2Frequency"]').val(FILTER_CONFIG.dterm_lowpass2_hz_roll);
-                }else{
+            } else {   //gte 1.44  - perAxis LPF
                 $('.gyroLowpass2Frequency').hide();
                 $('.dtermLowpass2Frequency').hide();
                 $('.pid_filter input[name="gyroLowpass2FrequencyRoll"]').val(FILTER_CONFIG.gyro_lowpass2_hz_roll);
                 $('.pid_filter input[name="gyroLowpass2FrequencyPitch"]').val(FILTER_CONFIG.gyro_lowpass2_hz_pitch);
                 $('.pid_filter input[name="gyroLowpass2FrequencyYaw"]').val(FILTER_CONFIG.gyro_lowpass2_hz_yaw);
+                console.log('dterm_lowpass2_hz_roll' + FILTER_CONFIG.dterm_lowpass2_hz_roll);
                 $('.pid_filter input[name="dtermLowpass2FrequencyRoll"]').val(FILTER_CONFIG.dterm_lowpass2_hz_roll);
                 $('.pid_filter input[name="dtermLowpass2FrequencyPitch"]').val(FILTER_CONFIG.dterm_lowpass2_hz_pitch);
                 $('.pid_filter input[name="dtermLowpass2FrequencyYaw"]').val(FILTER_CONFIG.dterm_lowpass2_hz_yaw);
-              }
+                //experimental expert-mode show/hid also in main.js
+                if (!isExpertModeEnabled()) {
+                    $('.LPFPit').hide();
+                    $('.LPFYaw').hide();
+                    $('#pid-tuning .gyroLowpass2FrequencyAxis .LPFRol').text(i18n.getMessage("pidTuningGyroLowpass2Frequency"));
+                    $('#pid-tuning .dtermLowpass2FrequencyAxis .LPFRol').text(i18n.getMessage("pidTuningDTermLowpass2Frequency"));
+                }
             }
             //removes 5th column which is Feedforward
             $('#pid_main .pid_titlebar2 th').attr('colspan', 4);
@@ -344,40 +359,18 @@ TABS.pid_tuning.initialize = function(callback) {
             $('#pid_main .pid_titlebar2 th').attr('colspan', 4);
         }
 
-        //synchronize the hidden values for users who toggle expert-mode
-        // set per axis from single
-        $('.pid_filter input[name="gyroLowpassFrequency"]').change(function() {
-            $('.pid_filter input[name="gyroLowpassFrequencyRoll"]').val(parseInt($('.pid_filter input[name="gyroLowpassFrequency"]').val()));
-            $('.pid_filter input[name="gyroLowpassFrequencyPitch"]').val(parseInt($('.pid_filter input[name="gyroLowpassFrequency"]').val()));
-            $('.pid_filter input[name="gyroLowpassFrequencyYaw"]').val(parseInt($('.pid_filter input[name="gyroLowpassFrequency"]').val()));
-        });
-        $('.pid_filter input[name="dtermLowpassFrequency"]').change(function() {
-            $('.pid_filter input[name="dtermLowpassFrequencyRoll"]').val(parseInt($('.pid_filter input[name="dtermLowpassFrequency"]').val()));
-            $('.pid_filter input[name="dtermLowpassFrequencyPitch"]').val(parseInt($('.pid_filter input[name="dtermLowpassFrequency"]').val()));
-            $('.pid_filter input[name="dtermLowpassFrequencyYaw"]').val(parseInt($('.pid_filter input[name="dtermLowpassFrequency"]').val()));
-        });
-        $('.pid_filter input[name="gyroLowpass2Frequency"]').change(function() {
-            $('.pid_filter input[name="gyroLowpass2FrequencyRoll"]').val(parseInt($('.pid_filter input[name="gyroLowpass2Frequency"]').val()));
-            $('.pid_filter input[name="gyroLowpass2FrequencyPitch"]').val(parseInt($('.pid_filter input[name="gyroLowpass2Frequency"]').val()));
-            $('.pid_filter input[name="gyroLowpass2FrequencyYaw"]').val(parseInt($('.pid_filter input[name="gyroLowpass2Frequency"]').val()));
-        });
-        $('.pid_filter input[name="dtermLowpass2Frequency"]').change(function() {
-            $('.pid_filter input[name="dtermLowpass2FrequencyRoll"]').val(parseInt($('.pid_filter input[name="dtermLowpass2Frequency"]').val()));
-            $('.pid_filter input[name="dtermLowpass2FrequencyPitch"]').val(parseInt($('.pid_filter input[name="dtermLowpass2Frequency"]').val()));
-            $('.pid_filter input[name="dtermLowpass2FrequencyYaw"]').val(parseInt($('.pid_filter input[name="dtermLowpass2Frequency"]').val()));
-        });
-        // set single from Roll
-        $('.pid_filter input[name="gyroLowpassFrequencyRoll"]').change(function() {
-            $('.pid_filter input[name="gyroLowpassFrequency"]').val(parseInt($('.pid_filter input[name="gyroLowpassFrequencyRoll"]').val()));
-        });
-        $('.pid_filter input[name="dtermLowpassFrequencyRoll"]').change(function() {
-            $('.pid_filter input[name="dtermLowpassFrequency"]').val(parseInt($('.pid_filter input[name="dtermLowpassFrequencyRoll"]').val()));
-        });
+        //experimental expert-mode synchronize hidden Pitch/Yaw
         $('.pid_filter input[name="gyroLowpass2FrequencyRoll"]').change(function() {
-            $('.pid_filter input[name="gyroLowpass2Frequency"]').val(parseInt($('.pid_filter input[name="gyroLowpass2FrequencyRoll"]').val()));
+            if (!isExpertModeEnabled()) {
+                $('.pid_filter input[name="gyroLowpass2FrequencyPitch"]').val(parseInt($('.pid_filter input[name="gyroLowpass2FrequencyRoll"]').val()));
+                $('.pid_filter input[name="gyroLowpass2FrequencyYaw"]').val(parseInt($('.pid_filter input[name="gyroLowpass2FrequencyRoll"]').val()));
+            }
         });
         $('.pid_filter input[name="dtermLowpass2FrequencyRoll"]').change(function() {
-            $('.pid_filter input[name="dtermLowpass2Frequency"]').val(parseInt($('.pid_filter input[name="dtermLowpass2FrequencyRoll"]').val()));
+            if (!isExpertModeEnabled()) {
+                $('.pid_filter input[name="dtermLowpass2FrequencyPitch"]').val(parseInt($('.pid_filter input[name="dtermLowpass2FrequencyRoll"]').val()));
+                $('.pid_filter input[name="dtermLowpass2FrequencyYaw"]').val(parseInt($('.pid_filter input[name="dtermLowpass2FrequencyRoll"]').val()));
+            }
         });
 
         if (semver.gte(CONFIG.apiVersion, "1.40.0")) {
@@ -803,21 +796,12 @@ TABS.pid_tuning.initialize = function(callback) {
             FILTER_CONFIG.dterm_lowpass_hz = parseInt($('.pid_filter input[name="dtermLowpassFrequency"]').val());
             FILTER_CONFIG.yaw_lowpass_hz = parseInt($('.pid_filter input[name="yawLowpassFrequency"]').val());
         } else {
-          if(!isExpertModeEnabled()) {
-            FILTER_CONFIG.gyro_lowpass_hz_roll = parseInt($('.pid_filter input[name="gyroLowpassFrequency"]').val());
-            FILTER_CONFIG.gyro_lowpass_hz_pitch = parseInt($('.pid_filter input[name="gyroLowpassFrequency"]').val());
-            FILTER_CONFIG.gyro_lowpass_hz_yaw = parseInt($('.pid_filter input[name="gyroLowpassFrequency"]').val());
-            FILTER_CONFIG.dterm_lowpass_hz_roll = parseInt($('.pid_filter input[name="dtermLowpassFrequency"]').val());
-            FILTER_CONFIG.dterm_lowpass_hz_pitch = parseInt($('.pid_filter input[name="dtermLowpassFrequency"]').val());
-            FILTER_CONFIG.dterm_lowpass_hz_yaw = parseInt($('.pid_filter input[name="dtermLowpassFrequency"]').val());
-          }else{
             FILTER_CONFIG.gyro_lowpass_hz_roll = parseInt($('.pid_filter input[name="gyroLowpassFrequencyRoll"]').val());
             FILTER_CONFIG.gyro_lowpass_hz_pitch = parseInt($('.pid_filter input[name="gyroLowpassFrequencyPitch"]').val());
             FILTER_CONFIG.gyro_lowpass_hz_yaw = parseInt($('.pid_filter input[name="gyroLowpassFrequencyYaw"]').val());
             FILTER_CONFIG.dterm_lowpass_hz_roll = parseInt($('.pid_filter input[name="dtermLowpassFrequencyRoll"]').val());
             FILTER_CONFIG.dterm_lowpass_hz_pitch = parseInt($('.pid_filter input[name="dtermLowpassFrequencyPitch"]').val());
             FILTER_CONFIG.dterm_lowpass_hz_yaw = parseInt($('.pid_filter input[name="dtermLowpassFrequencyYaw"]').val());
-          }
         }
 
         if (semver.gte(CONFIG.apiVersion, "1.16.0") && !semver.gte(CONFIG.apiVersion, "1.20.0")) {
@@ -866,22 +850,13 @@ TABS.pid_tuning.initialize = function(callback) {
         }
 
         if (semver.gte(CONFIG.apiVersion, "1.39.0")) {
-            if (semver.gte(CONFIG.apiVersion, "1.44.0") ) {
-                if(!isExpertModeEnabled()) {
-                  FILTER_CONFIG.gyro_lowpass2_hz_roll = parseInt($('.pid_filter input[name="gyroLowpass2Frequency"]').val());
-                  FILTER_CONFIG.gyro_lowpass2_hz_pitch = parseInt($('.pid_filter input[name="gyroLowpass2Frequency"]').val());
-                  FILTER_CONFIG.gyro_lowpass2_hz_yaw = parseInt($('.pid_filter input[name="gyroLowpass2Frequency"]').val());
-                  FILTER_CONFIG.dterm_lowpass2_hz_roll = parseInt($('.pid_filter input[name="dtermLowpass2Frequency"]').val());
-                  FILTER_CONFIG.dterm_lowpass2_hz_pitch = parseInt($('.pid_filter input[name="dtermLowpass2Frequency"]').val());
-                  FILTER_CONFIG.dterm_lowpass2_hz_yaw = parseInt($('.pid_filter input[name="dtermLowpass2Frequency"]').val());
-                }else{
+            if (semver.gte(CONFIG.apiVersion, "1.44.0")) {
                 FILTER_CONFIG.gyro_lowpass2_hz_roll = parseInt($('.pid_filter input[name="gyroLowpass2FrequencyRoll"]').val());
                 FILTER_CONFIG.gyro_lowpass2_hz_pitch = parseInt($('.pid_filter input[name="gyroLowpass2FrequencyPitch"]').val());
                 FILTER_CONFIG.gyro_lowpass2_hz_yaw = parseInt($('.pid_filter input[name="gyroLowpass2FrequencyYaw"]').val());
                 FILTER_CONFIG.dterm_lowpass2_hz_roll = parseInt($('.pid_filter input[name="dtermLowpass2FrequencyRoll"]').val());
                 FILTER_CONFIG.dterm_lowpass2_hz_pitch = parseInt($('.pid_filter input[name="dtermLowpass2FrequencyPitch"]').val());
                 FILTER_CONFIG.dterm_lowpass2_hz_yaw = parseInt($('.pid_filter input[name="dtermLowpass2FrequencyYaw"]').val());
-              }
             } else {
                 FILTER_CONFIG.gyro_lowpass2_hz = parseInt($('.pid_filter input[name="gyroLowpass2Frequency"]').val());
                 FILTER_CONFIG.dterm_lowpass2_hz = parseInt($('.pid_filter input[name="dtermLowpass2Frequency"]').val());

--- a/src/js/tabs/pid_tuning.js
+++ b/src/js/tabs/pid_tuning.js
@@ -162,11 +162,13 @@ TABS.pid_tuning.initialize = function(callback) {
                 if (semver.gte(CONFIG.apiVersion, "1.44.0")){
                   $('.pid_filter input[name="gyroLowpassFrequency"]').val(FILTER_CONFIG.gyro_lowpass_hz_roll);
                   $('.pid_filter input[name="dtermLowpassFrequency"]').val(FILTER_CONFIG.gyro_lowpass_hz_pitch);
+                  $('.yawLowpassFrequency').hide();
                 }else{
                 $('.pid_filter input[name="gyroLowpassFrequency"]').val(FILTER_CONFIG.gyro_lowpass_hz);
                 $('.pid_filter input[name="dtermLowpassFrequency"]').val(FILTER_CONFIG.dterm_lowpass_hz);
-              }
                 $('.pid_filter input[name="yawLowpassFrequency"]').val(FILTER_CONFIG.yaw_lowpass_hz);
+              }
+
             }
         } else {
             $('.tab-pid_tuning .subtab-filter').hide();

--- a/src/js/tabs/pid_tuning.js
+++ b/src/js/tabs/pid_tuning.js
@@ -161,7 +161,7 @@ TABS.pid_tuning.initialize = function(callback) {
                 $('.dtermLowpassFrequencyAxis').hide();
                 if (semver.gte(CONFIG.apiVersion, "1.44.0")){
                   $('.pid_filter input[name="gyroLowpassFrequency"]').val(FILTER_CONFIG.gyro_lowpass_hz_roll);
-                  $('.pid_filter input[name="dtermLowpassFrequency"]').val(FILTER_CONFIG.gyro_lowpass_hz_pitch);
+                  $('.pid_filter input[name="dtermLowpassFrequency"]').val(FILTER_CONFIG.dterm_lowpass_hz_roll);
                   $('.yawLowpassFrequency').hide();
                 }else{
                 $('.pid_filter input[name="gyroLowpassFrequency"]').val(FILTER_CONFIG.gyro_lowpass_hz);
@@ -323,7 +323,7 @@ TABS.pid_tuning.initialize = function(callback) {
                   $('.gyroLowpass2FrequencyAxis').hide();
                   $('.dtermLowpass2FrequencyAxis').hide();
                   $('.pid_filter input[name="gyroLowpass2Frequency"]').val(FILTER_CONFIG.gyro_lowpass2_hz_roll);
-                    $('.pid_filter input[name="dtermLowpass2Frequency"]').val(FILTER_CONFIG.dterm_lowpass2_hz_roll);
+                  $('.pid_filter input[name="dtermLowpass2Frequency"]').val(FILTER_CONFIG.dterm_lowpass2_hz_roll);
                 }else{
                 $('.gyroLowpass2Frequency').hide();
                 $('.dtermLowpass2Frequency').hide();

--- a/src/tabs/pid_tuning.html
+++ b/src/tabs/pid_tuning.html
@@ -914,14 +914,6 @@
                                 </th>
                             </tr>
                             <tr>
-                                <th colspan="2">
-                                    <div >
-                                        <div  i18n="pidTuningGyroLowpassFrequency" />
-
-                                    </div>
-                                </th>
-                            </tr>
-                            <tr>
                                 <td>
                                     <span class="groupSwitchValue">
                                         <span class="inputSwitch"><input type="checkbox" id="gyroLowpassEnabled" class="toggle" />
@@ -974,16 +966,12 @@
                                             <span i18n="gyroLowpassFrequencyYaw"></span>
                                         </label>
                                     </div>
-
-
                                 </td>
                             </tr>
-
                             <tr>
                                 <th colspan="2">
-                                    <div >
-                                        <div i18n="pidTuningGyroLowpass2Frequency" />
-
+                                    <div>
+                                        &nbsp;
                                     </div>
                                 </th>
                             </tr>
@@ -995,7 +983,6 @@
                                           <!--  Populated on execution -->
                                       </select>
                                       </span>
-
                                   </span>
                               </td>
                               <td>
@@ -1081,7 +1068,13 @@
                                     </div>
                                 </td>
                             </tr>
-
+                            <tr>
+                                <th colspan="2">
+                                    <div>
+                                        &nbsp;
+                                    </div>
+                                </th>
+                            </tr>
                             <tr class="newFilter gyroNotch2">
                                 <td>
                                     <span class="groupSwitchValue">
@@ -1358,14 +1351,6 @@
                                 </th>
                             </tr>
                             <tr>
-                                <th colspan="2">
-                                    <div >
-                                        <div i18n="pidTuningDTermLowpassFrequency" />
-
-                                    </div>
-                                </th>
-                            </tr>
-                            <tr>
                               <td>
                                   <span class="groupSwitchValue">
                                       <span class="inputSwitch"><input type="checkbox" id="dtermLowpassEnabled" class="toggle" />
@@ -1427,9 +1412,8 @@
 
                             <tr>
                                 <th colspan="2">
-                                    <div >
-                                        <div i18n="pidTuningDTermLowpass2Frequency" />
-
+                                    <div>
+                                        &nbsp;
                                     </div>
                                 </th>
                             </tr>

--- a/src/tabs/pid_tuning.html
+++ b/src/tabs/pid_tuning.html
@@ -947,8 +947,8 @@
                                         </div>
                                         <div class="gyroLowpassFrequencyAxis">
                                         <span class="inputValue"><input type="number" class="nonProfile" name="gyroLowpassFrequencyRoll" step="1" min="0" max="16000"/><br clear="all"></span>
-                                        <span class="inputValue"><input type="number" class="nonProfile" name="gyroLowpassFrequencyPitch" step="1" min="0" max="16000"/><br clear="all"></span>
-                                        <span class="inputValue"><input type="number" class="nonProfile" name="gyroLowpassFrequencyYaw" step="1" min="0" max="16000"/></span>
+                                        <span class="inputValue LPFPit"><input type="number" class="nonProfile" name="gyroLowpassFrequencyPitch" step="1" min="0" max="16000"/><br clear="all"></span>
+                                        <span class="inputValue LPFYaw"><input type="number" class="nonProfile" name="gyroLowpassFrequencyYaw" step="1" min="0" max="16000"/></span>
                                         </div>
 
                                 </td>
@@ -959,17 +959,17 @@
                                             <span i18n="pidTuningGyroLowpassFrequency"></span>
                                         </label>
                                     </div>
-                                    <div class="gyroLowpassFrequencyAxis">
+                                    <div class="gyroLowpassFrequencyAxis LPFRol">
                                         <label>
-                                            <span i18n="pidTuningRoll"></span>
+                                            <span class="LPFRol" i18n="pidTuningRoll"></span>
                                         </label>
                                     </div>
-                                    <div class="gyroLowpassFrequencyAxis">
+                                    <div class="gyroLowpassFrequencyAxis LPFPit">
                                         <label>
                                             <span i18n="pidTuningPitch"></span>
                                         </label>
                                     </div>
-                                    <div class="gyroLowpassFrequencyAxis">
+                                    <div class="gyroLowpassFrequencyAxis LPFYaw">
                                         <label>
                                             <span i18n="pidTuningYaw"></span>
                                         </label>
@@ -1015,8 +1015,8 @@
                                         </div>
                                         <div class="gyroLowpass2FrequencyAxis">
                                         <span class="inputValue"><input type="number" class="nonProfile" name="gyroLowpass2FrequencyRoll" step="1" min="0" max="16000"/><br clear="all"></span>
-                                        <span class="inputValue"><input type="number" class="nonProfile" name="gyroLowpass2FrequencyPitch" step="1" min="0" max="16000"/><br clear="all"></span>
-                                        <span class="inputValue"><input type="number" class="nonProfile" name="gyroLowpass2FrequencyYaw" step="1" min="0" max="16000"/></span>
+                                        <span class="inputValue LPFPit"><input type="number" class="nonProfile" name="gyroLowpass2FrequencyPitch" step="1" min="0" max="16000"/><br clear="all"></span>
+                                        <span class="inputValue LPFYaw"><input type="number" class="nonProfile" name="gyroLowpass2FrequencyYaw" step="1" min="0" max="16000"/></span>
                                         </div>
                                     </span>
                                 </td>
@@ -1026,28 +1026,23 @@
                                             <span i18n="pidTuningGyroLowpass2Frequency"></span>
                                         </label>
                                     </div>
-                                    <div class="gyroLowpass2FrequencyAxis">
+                                    <div class="gyroLowpass2FrequencyAxis LPFRol">
                                         <label>
-                                            <span i18n="pidTuningRoll"></span>
+                                            <span class="LPFRol" i18n="pidTuningRoll"></span>
                                         </label>
                                     </div>
-                                    <div class="gyroLowpass2FrequencyAxis">
+                                    <div class="gyroLowpass2FrequencyAxis LPFPit">
                                         <label>
                                             <span i18n="pidTuningPitch"></span>
                                         </label>
                                     </div>
-                                    <div class="gyroLowpass2FrequencyAxis">
+                                    <div class="gyroLowpass2FrequencyAxis LPFYaw">
                                         <label>
                                             <span i18n="pidTuningYaw"></span>
                                         </label>
                                     </div>
-
-
                                 </td>
                             </tr>
-
-
-
 
                             <tr>
                                 <th colspan="2">
@@ -1398,8 +1393,8 @@
                                         </div>
                                         <div class="dtermLowpassFrequencyAxis">
                                         <span class="inputValue"><input type="number" name="dtermLowpassFrequencyRoll" step="1" min="0" max="16000"/><br clear="all"></span>
-                                        <span class="inputValue"><input type="number" name="dtermLowpassFrequencyPitch" step="1" min="0" max="16000"/><br clear="all"></span>
-                                        <span class="inputValue"><input type="number" name="dtermLowpassFrequencyYaw" step="1" min="0" max="16000"/></span>
+                                        <span class="inputValue LPFPit"><input type="number" name="dtermLowpassFrequencyPitch" step="1" min="0" max="16000"/><br clear="all"></span>
+                                        <span class="inputValue LPFYaw"><input type="number" name="dtermLowpassFrequencyYaw" step="1" min="0" max="16000"/></span>
                                         </div>
                                     </span>
                                 </td>
@@ -1410,17 +1405,17 @@
                                             <span i18n="pidTuningDTermLowpassFrequency"></span>
                                         </label>
                                     </div>
-                                    <div class="dtermLowpassFrequencyAxis">
+                                    <div class="dtermLowpassFrequencyAxis LPFRol">
                                         <label>
-                                            <span i18n="pidTuningRoll"></span>
+                                            <span class="LPFRol" i18n="pidTuningRoll"></span>
                                         </label>
                                     </div>
-                                    <div class="dtermLowpassFrequencyAxis">
+                                    <div class="dtermLowpassFrequencyAxis LPFPit">
                                         <label>
                                             <span i18n="pidTuningPitch"></span>
                                         </label>
                                     </div>
-                                    <div class="dtermLowpassFrequencyAxis">
+                                    <div class="dtermLowpassFrequencyAxis LPFYaw">
                                         <label>
                                             <span i18n="pidTuningYaw"></span>
                                         </label>
@@ -1449,8 +1444,8 @@
                                         </div>
                                         <div class="dtermLowpass2FrequencyAxis">
                                         <span class="inputValue"><input type="number" name="dtermLowpass2FrequencyRoll" step="1" min="0" max="16000"/><br clear="all"></span>
-                                        <span class="inputValue"><input type="number" name="dtermLowpass2FrequencyPitch" step="1" min="0" max="16000"/><br clear="all"></span>
-                                        <span class="inputValue"><input type="number" name="dtermLowpass2FrequencyYaw" step="1" min="0" max="16000"/></span>
+                                        <span class="inputValue LPFPit"><input type="number" name="dtermLowpass2FrequencyPitch" step="1" min="0" max="16000"/><br clear="all"></span>
+                                        <span class="inputValue LPFYaw"><input type="number" name="dtermLowpass2FrequencyYaw" step="1" min="0" max="16000"/></span>
                                         </div>
                                     </span>
                                 </td>
@@ -1461,17 +1456,17 @@
                                             <span i18n="pidTuningDTermLowpass2Frequency"></span>
                                         </label>
                                     </div>
-                                    <div class="dtermLowpass2FrequencyAxis">
+                                    <div class="dtermLowpass2FrequencyAxis LPFRol">
                                         <label>
-                                            <span i18n="pidTuningRoll"></span>
+                                            <span class="LPFRol" i18n="pidTuningRoll"></span>
                                         </label>
                                     </div>
-                                    <div class="dtermLowpass2FrequencyAxis">
+                                    <div class="dtermLowpass2FrequencyAxis LPFPit">
                                         <label>
                                             <span i18n="pidTuningPitch"></span>
                                         </label>
                                     </div>
-                                    <div class="dtermLowpass2FrequencyAxis">
+                                    <div class="dtermLowpass2FrequencyAxis LPFYaw">
                                         <label>
                                             <span i18n="pidTuningYaw"></span>
                                         </label>

--- a/src/tabs/pid_tuning.html
+++ b/src/tabs/pid_tuning.html
@@ -153,7 +153,7 @@
                     <!-- BARO, MAG, GPS - Non-existent/Broken/Purged -->
 
                     <!-- ENTIRE ANGLE UI -->
-                    <div id="pid_accel" class="pid_optional needed_by_LEVEL gui_box grey topspacer pid_tuning">
+                    <div id="pid_accel" class="pid_optional needed_by_LEVEL gui_box grey topspacer pid_tuning isexpertmode">
                         <!-- show Angle/NFE/Horizon both old and new UI-->
                         <table id="pid_level" class="pid_tuning needed_by_LEVEL">
                             <tr class="needed_by_LEVEL">
@@ -702,7 +702,7 @@
                         <table id="rateDynamics" class="pid_tuning">
                             <tbody>
                                 <tr class="pid_titlebar">
-                                    <th colspan="4">
+                                    <th colspan="4" style="background-color:#22B7EB;">
                                         <div>
                                             <div i18n="pidTuningRateDynamics" style="float:left;"></div>
                                             <div class="helpicon cf_tip" i18n_title="pidTuningRateDynamicsHelp"></div>
@@ -753,7 +753,8 @@
                             </tbody>
                         </table>
                     </div>
-                    <div class="gui_box -grey -spa spacer_left">
+                    <!-- experimental: expert-mode will show/hide SPA -->
+                    <div class="gui_box -grey -spa spacer_left isexpertmode">
                         <table class="cf pid_tuning">
                             <thead>
                                 <tr colspan="4">
@@ -865,7 +866,7 @@
                         </table>
                     </div>
                 </div>
-                <div class="cf_column">
+                <div class="cf_column isexpertmode">
                     <div class="gui_box ratePreview grey spacer_left">
                         <table class="pid_titlebar">
                             <thead>
@@ -1281,7 +1282,8 @@
 
 
                         <!-- smartdterm witchcraft table -->
-                        <div class="smartDTermWitchBox" > <!-- class smartDTermWitchBox required -->
+                        <!-- insludes expertmode show/hide -->
+                        <div class="smartDTermWitchBox isexpertmode" > <!-- class smartDTermWitchBox required -->
                             <table class="cf pid_tuning topspacer"> <!-- class cf pid_tuning topspaceer required -->
                                 <thead>
                                     <tr colspan="4">

--- a/src/tabs/pid_tuning.html
+++ b/src/tabs/pid_tuning.html
@@ -906,10 +906,18 @@
 
                         <table class="filterTable">
                             <tr>
-                                <th colspan="3">
+                                <th colspan="2">
                                     <div class="pid_mode">
                                         <div i18n="pidTuningGyroLowpassFiltersGroup" />
                                         <div class="helpicon cf_tip" i18n_title="pidTuningLowpassFilterHelp" />
+                                    </div>
+                                </th>
+                            </tr>
+                            <tr>
+                                <th colspan="2">
+                                    <div >
+                                        <div  i18n="pidTuningGyroLowpassFrequency" />
+
                                     </div>
                                 </th>
                             </tr>
@@ -927,29 +935,30 @@
                                         </div>
                                     </span>
                                 </td>
+
                                 <td>
-                                    <div>
-                                        <label>
-                                            <span i18n="pidTuningRoll"></span>
-                                        </label>
-                                    </div>
-                                    <div>
-                                        <label>
-                                            <span i18n="pidTuningPitch"></span>
-                                        </label>
-                                    </div>
-                                    <div>
-                                        <label>
-                                            <span i18n="pidTuningYaw"></span>
-                                        </label>
-                                    </div>
-                                </td>
-                                <td>
-                                    <div>
+                                    <div class="gyroLowpassFrequency">
                                         <label>
                                             <span i18n="pidTuningGyroLowpassFrequency"></span>
                                         </label>
                                     </div>
+                                    <div class="gyroLowpassFrequencyAxis">
+                                        <label>
+                                            <span i18n="pidTuningRoll"></span>
+                                        </label>
+                                    </div>
+                                    <div class="gyroLowpassFrequencyAxis">
+                                        <label>
+                                            <span i18n="pidTuningPitch"></span>
+                                        </label>
+                                    </div>
+                                    <div class="gyroLowpassFrequencyAxis">
+                                        <label>
+                                            <span i18n="pidTuningYaw"></span>
+                                        </label>
+                                    </div>
+
+
                                 </td>
                             </tr>
                             <tr>
@@ -966,6 +975,14 @@
                                     </div>
                                 </td>
                             </tr>
+                            <tr>
+                                <th colspan="2">
+                                    <div >
+                                        <div i18n="pidTuningGyroLowpass2Frequency" />
+
+                                    </div>
+                                </th>
+                            </tr>
                             <tr class="gyroLowpass2">
                                 <td>
                                     <span class="groupSwitchValue">
@@ -981,28 +998,28 @@
                                     </span>
                                 </td>
                                 <td>
-                                    <div>
-                                        <label>
-                                            <span i18n="pidTuningRoll"></span>
-                                        </label>
-                                    </div>
-                                    <div>
-                                        <label>
-                                            <span i18n="pidTuningPitch"></span>
-                                        </label>
-                                    </div>
-                                    <div>
-                                        <label>
-                                            <span i18n="pidTuningYaw"></span>
-                                        </label>
-                                    </div>
-                                </td>
-                                <td>
-                                    <div>
+                                    <div class="gyroLowpass2Frequency">
                                         <label>
                                             <span i18n="pidTuningGyroLowpass2Frequency"></span>
                                         </label>
                                     </div>
+                                    <div class="gyroLowpass2FrequencyAxis">
+                                        <label>
+                                            <span i18n="pidTuningRoll"></span>
+                                        </label>
+                                    </div>
+                                    <div class="gyroLowpass2FrequencyAxis">
+                                        <label>
+                                            <span i18n="pidTuningPitch"></span>
+                                        </label>
+                                    </div>
+                                    <div class="gyroLowpass2FrequencyAxis">
+                                        <label>
+                                            <span i18n="pidTuningYaw"></span>
+                                        </label>
+                                    </div>
+
+
                                 </td>
                             </tr>
 
@@ -1023,7 +1040,7 @@
 
 
                             <tr>
-                                <th colspan="3">
+                                <th colspan="2">
                                     <div class="pid_mode">
                                         <div i18n="pidTuningGyroNotchFiltersGroup" />
                                         <div class="helpicon cf_tip" i18n_title="pidTuningNotchFilterHelp" />
@@ -1031,14 +1048,11 @@
                                 </th>
                             </tr>
 
-                            <tr >
+                            <tr class="newFilter">
                                 <td>
                                     <span class="groupSwitchValue">
-                                        <div>
                                         <span class="inputSwitch"><input type="checkbox" id="gyroNotch1Enabled" class="toggle" /></span>
                                         <span class="inputValue"><input type="number" class="nonProfile" name="gyroNotch1Frequency" step="1" min="1" max="16000"/></span>
-                                        <span class="inputValue"><input type="number" class="nonProfile" name="gyroNotch1Cutoff" step="1" min="0" max="16000"/></span>
-                                        </div>
                                     </span>
                                 </td>
                                 <td>
@@ -1047,29 +1061,27 @@
                                             <span i18n="pidTuningGyroNotch1Frequency"></span>
                                         </label>
                                     </div>
+                                </td>
+                            </tr>
+
+                            <tr class="newFilter">
+                                <td>
+                                    <input type="number" class="nonProfile" name="gyroNotch1Cutoff" step="1" min="0" max="16000"/>
+                                </td>
+                                <td>
                                     <div>
                                         <label>
                                             <span i18n="pidTuningGyroNotch1Cutoff"></span>
                                         </label>
                                     </div>
                                 </td>
-                                <td>
-                                    <div>
-                                        <label>
-                                            <span i18n="pidTuningGyroNotch1"></span>
-                                        </label>
-                                    </div>
-                                </td>
                             </tr>
 
-                            <tr >
+                            <tr class="newFilter gyroNotch2">
                                 <td>
                                     <span class="groupSwitchValue">
-                                        <div>
                                         <span class="inputSwitch"><input type="checkbox" id="gyroNotch2Enabled" class="toggle" /></span>
                                         <span class="inputValue"><input type="number" class="nonProfile" name="gyroNotch2Frequency" step="1" min="1" max="16000"/></span>
-                                        <span class="inputValue"><input type="number" class="nonProfile" name="gyroNotch2Cutoff" step="1" min="0" max="16000"/></span>
-                                        </div>
                                     </span>
                                 </td>
                                 <td>
@@ -1078,16 +1090,17 @@
                                             <span i18n="pidTuningGyroNotch2Frequency"></span>
                                         </label>
                                     </div>
-                                    <div>
-                                        <label>
-                                            <span i18n="pidTuningGyroNotch2Cutoff"></span>
-                                        </label>
-                                    </div>
+                                </td>
+                            </tr>
+
+                            <tr class="newFilter gyroNotch2">
+                                <td>
+                                    <input type="number" class="nonProfile" name="gyroNotch2Cutoff" step="1" min="0" max="16000"/>
                                 </td>
                                 <td>
                                     <div>
                                         <label>
-                                            <span i18n="pidTuningGyroNotch2"></span>
+                                            <span i18n="pidTuningGyroNotch2Cutoff"></span>
                                         </label>
                                     </div>
                                 </td>
@@ -1143,126 +1156,131 @@
                                 </tr>
                             </table>
                             <table>
-                            <th colspan="3"></th>
-                                <tr>
+                              <th colspan="2"></th>
+                                 <tr>
 
-                                    <td>
-                                        <div>
-                                        <input id="imuf_roll_q" type="number" name="imuf_roll_q" step="100" min="100" max="16000"/>
-                                        <input id="imuf_pitch_q" type="number" name="imuf_pitch_q" step="100" min="100" max="16000"/>
-                                        <input id="imuf_yaw_q" type="number" name="imuf_yaw_q" step="100" min="100" max="16000"/>
-                                        </div>
-                                    </td>
-                                    <td>
-                                        <div>
-                                            <label>
-                                                <span i18n="pidTuningRoll"></span>
-                                            </label>
-                                        </div>
-                                        <div>
-                                            <label>
-                                                <span i18n="pidTuningPitch"></span>
-                                            </label>
-                                        </div>
-                                        <div>
-                                            <label>
-                                                <span i18n="pidTuningYaw"></span>
-                                            </label>
-                                        </div>
-                                    </td>
-                                    <td>
-                                        <div>
-                                            <label>
-                                                <span i18n="pidTuningImufQ"></span>
-                                            </label>
-                                            <div class="helpicon cf_tip" i18n_title="pidTuningKalmanFilterQHelp"></div>
-                                        </div>
-                                    </td>
-                                </tr>
-                            
-                                <tr class="imuf_roll_lpf_cutoff_hz_tr">
-                                    <td>
-                                        <input id="imuf_roll_lpf_cutoff_hz" type="number" name="imuf_roll_lpf_cutoff_hz" step="1" min="0" max="450"/>
-                                        <input id="imuf_pitch_lpf_cutoff_hz" type="number" name="imuf_pitch_lpf_cutoff_hz" step="1" min="0" max="450"/>
-                                        <input id="imuf_yaw_lpf_cutoff_hz" type="number" name="imuf_yaw_lpf_cutoff_hz" step="1" min="0" max="450"/>
-                                    </td>
-                                    <td>
-                                        <div>
-                                            <label>
-                                                <span i18n="pidTuningRoll"></span>
-                                            </label>
-                                        </div>
-                                        <div>
-                                            <label>
-                                                <span i18n="pidTuningPitch"></span>
-                                            </label>
-                                        </div>
-                                        <div>
-                                            <label>
-                                                <span i18n="pidTuningYaw"></span>
-                                            </label>
-                                        </div>
-                                    </td>
-                                    <td>
-                                        <div>
-                                            <label>
-                                                <span i18n="pidTuningImuflpf"></span>
-                                            </label>
-                                            <div class="helpicon cf_tip" i18n_title="pidTuningImuflpfRollHelp"></div>
-                                        </div>
-                                    </td>
-                                </tr>
+                                     <td>
+                                         <input id="imuf_roll_q" type="number" name="imuf_roll_q" step="100" min="100" max="16000"/>
+                                     </td>
+                                     <td>
+                                         <div>
+                                             <label>
+                                                 <span i18n="pidTuningImufRollQ"></span>
+                                             </label>
+                                             <div class="helpicon cf_tip" i18n_title="pidTuningKalmanFilterQHelp"></div>
+                                         </div>
+                                     </td>
 
-                                <tr>
-                                    <td>
-                                        <input id="imuf_w" type="number" name="imuf_w" step="1" min="3" max="1024"/>
-                                    </td>
-                                    <td>
-                                        <div>
-                                            <label>
-                                                <span i18n="pidTuningImufW"></span>
-                                            </label>
-                                        </div>
-                                    </td>
-                                    <td>
-                                        <div class="helpicon cf_tip" i18n_title="pidTuningKalmanFilterWHelp"></div>
-                                    </td>
-                                </tr>
-                                <tr class="imufSharpness">
-                                    <td>
-                                        <input id="imuf_sharpness" type="number" name="imuf_sharpness" step="1" min="1" max="16000"/>
-                                    </td>
-                                    <td>
-                                        <div>
-                                            <label>
-                                                <span i18n="pidTuningImufSharpness"></span>
-                                            </label>
-                                        </div>
-                                    </td>
-                                    <td>
-                                        <div class="helpicon cf_tip" i18n_title="pidTuningKalmanFilterSharpnessHelp"></div>
-                                    </td>
-                                </tr>
-                                
-                                <tr class="imuf_acc_lpf_cutoff_hz_tr">
-                                    <td>
-                                        <input id="imuf_acc_lpf_cutoff_hz" type="number" name="imuf_acc_lpf_cutoff_hz" step="1" min="0" max="450"/>
-                                    </td>
-                                    <td>
-                                        <div>
-                                            <label>
-                                                <span i18n="pidTuningImuflpfAcc"></span>
-                                            </label>
-                                        </div>
-                                    </td>
-                                    <td>
-                                        <div class="helpicon cf_tip" i18n_title="pidTuningImuflpfAccHelp"></div>
-                                    </td>
-                                </tr>
+                                 </tr>
+                                 <tr>
+                                     <td>
+                                         <input id="imuf_pitch_q" type="number" name="imuf_pitch_q" step="100" min="100" max="16000"/>
+                                     </td>
+                                     <td>
+                                         <div>
+                                             <label>
+                                                 <span i18n="pidTuningImufPitchQ"></span>
+                                             </label>
+                                             <div class="helpicon cf_tip" i18n_title="pidTuningKalmanFilterQHelp"></div>
+                                         </div>
+                                     </td>
+                                 </tr>
+                                 <tr>
+                                     <td>
+                                         <input id="imuf_yaw_q" type="number" name="imuf_yaw_q" step="100" min="100" max="48000"/>
+                                     </td>
+                                     <td>
+                                         <div>
+                                             <label>
+                                                 <span i18n="pidTuningImufYawQ"></span>
+                                             </label>
+                                             <div class="helpicon cf_tip" i18n_title="pidTuningKalmanFilterQHelp"></div>
+                                         </div>
+                                     </td>
+                                 </tr>
+                                 <tr>
+                                     <td>
+                                         <input id="imuf_w" type="number" name="imuf_w" step="1" min="3" max="1024"/>
+                                     </td>
+                                     <td>
+                                         <div>
+                                             <label>
+                                                 <span i18n="pidTuningImufW"></span>
+                                             </label>
+                                             <div class="helpicon cf_tip" i18n_title="pidTuningKalmanFilterWHelp"></div>
+                                         </div>
+                                     </td>
+                                 </tr>
+                                 <tr class="imufSharpness">
+                                     <td>
+                                         <input id="imuf_sharpness" type="number" name="imuf_sharpness" step="1" min="1" max="16000"/>
+                                     </td>
+                                     <td>
+                                         <div>
+                                             <label>
+                                                 <span i18n="pidTuningImufSharpness"></span>
+                                             </label>
+                                             <div class="helpicon cf_tip" i18n_title="pidTuningKalmanFilterSharpnessHelp"></div>
+                                         </div>
+                                     </td>
+                                 </tr>
+                                 <tr class="imuf_roll_lpf_cutoff_hz_tr">
+                                     <td>
+                                         <input id="imuf_roll_lpf_cutoff_hz" type="number" name="imuf_roll_lpf_cutoff_hz" step="1" min="0" max="450"/>
+                                     </td>
+                                     <td>
+                                         <div>
+                                             <label>
+                                                 <span i18n="pidTuningImuflpfRoll"></span>
+                                             </label>
+                                             <div class="helpicon cf_tip" i18n_title="pidTuningImuflpfRollHelp"></div>
+                                         </div>
+                                     </td>
+                                 </tr>
+                                 <tr class="imuf_pitch_lpf_cutoff_hz_tr">
+                                     <td>
+                                         <input id="imuf_pitch_lpf_cutoff_hz" type="number" name="imuf_pitch_lpf_cutoff_hz" step="1" min="0" max="450"/>
+                                     </td>
+                                     <td>
+                                         <div>
+                                             <label>
+                                                 <span i18n="pidTuningImuflpfPitch"></span>
+                                             </label>
+                                             <div class="helpicon cf_tip" i18n_title="pidTuningImuflpfPitchHelp"></div>
+                                         </div>
+                                     </td>
+                                 </tr>
+                                 <tr class="imuf_yaw_lpf_cutoff_hz_tr">
+                                     <td>
+                                         <input id="imuf_yaw_lpf_cutoff_hz" type="number" name="imuf_yaw_lpf_cutoff_hz" step="1" min="0" max="450"/>
+                                     </td>
+                                     <td>
+                                         <div>
+                                             <label>
+                                                 <span i18n="pidTuningImuflpfYaw"></span>
+                                             </label>
+                                             <div class="helpicon cf_tip" i18n_title="pidTuningImuflpfYawHelp"></div>
+                                         </div>
+                                     </td>
+                                 </tr>
+                                 <tr class="imuf_acc_lpf_cutoff_hz_tr">
+                                     <td>
+                                         <input id="imuf_acc_lpf_cutoff_hz" type="number" name="imuf_acc_lpf_cutoff_hz" step="1" min="0" max="450"/>
+                                     </td>
+                                     <td>
+                                         <div>
+                                             <label>
+                                                 <span i18n="pidTuningImuflpfAcc"></span>
+                                             </label>
+                                             <div class="helpicon cf_tip" i18n_title="pidTuningImuflpfAccHelp"></div>
+                                         </div>
+                                     </td>
+                                 </tr>
 
-                            </table>
-                        </div>
-                        <!-- end IMUF-->
+                             </table>
+                         </div>
+                         <!-- end IMUF-->
+
 
                         <!-- smartdterm witchcraft table -->
                         <div class="smartDTermWitchBox" > <!-- class smartDTermWitchBox required -->
@@ -1334,7 +1352,14 @@
 
                                 </th>
                             </tr>
+                            <tr>
+                                <th colspan="2">
+                                    <div >
+                                        <div i18n="pidTuningDTermLowpassFrequency" />
 
+                                    </div>
+                                </th>
+                            </tr>
                             <tr>
                                 <td>
                                     <span class="groupSwitchValue">
@@ -1349,29 +1374,30 @@
                                         </div>
                                     </span>
                                 </td>
+
                                 <td>
-                                    <div>
-                                        <label>
-                                            <span i18n="pidTuningRoll"></span>
-                                        </label>
-                                    </div>
-                                    <div>
-                                        <label>
-                                            <span i18n="pidTuningPitch"></span>
-                                        </label>
-                                    </div>
-                                    <div>
-                                        <label>
-                                            <span i18n="pidTuningYaw"></span>
-                                        </label>
-                                    </div>
-                                </td>
-                                <td>
-                                    <div>
+                                    <div class="dtermLowpassFrequency">
                                         <label>
                                             <span i18n="pidTuningDTermLowpassFrequency"></span>
                                         </label>
                                     </div>
+                                    <div class="dtermLowpassFrequencyAxis">
+                                        <label>
+                                            <span i18n="pidTuningRoll"></span>
+                                        </label>
+                                    </div>
+                                    <div class="dtermLowpassFrequencyAxis">
+                                        <label>
+                                            <span i18n="pidTuningPitch"></span>
+                                        </label>
+                                    </div>
+                                    <div class="dtermLowpassFrequencyAxis">
+                                        <label>
+                                            <span i18n="pidTuningYaw"></span>
+                                        </label>
+                                    </div>
+
+
                                 </td>
                             </tr>
 
@@ -1389,7 +1415,14 @@
                                     </div>
                                 </td>
                             </tr>
+                            <tr>
+                                <th colspan="2">
+                                    <div >
+                                        <div i18n="pidTuningDTermLowpass2Frequency" />
 
+                                    </div>
+                                </th>
+                            </tr>
                             <tr class="dtermLowpass2">
                                 <td>
                                     <span class="groupSwitchValue">
@@ -1405,29 +1438,30 @@
                                         </div>
                                     </span>
                                 </td>
+
                                 <td>
-                                    <div>
-                                        <label>
-                                            <span i18n="pidTuningRoll"></span>
-                                        </label>
-                                    </div>
-                                    <div>
-                                        <label>
-                                            <span i18n="pidTuningPitch"></span>
-                                        </label>
-                                    </div>
-                                    <div>
-                                        <label>
-                                            <span i18n="pidTuningYaw"></span>
-                                        </label>
-                                    </div>
-                                </td>
-                                <td>
-                                    <div>
+                                    <div class="dtermLowpass2Frequency">
                                         <label>
                                             <span i18n="pidTuningDTermLowpass2Frequency"></span>
                                         </label>
                                     </div>
+                                    <div class="dtermLowpass2FrequencyAxis">
+                                        <label>
+                                            <span i18n="pidTuningRoll"></span>
+                                        </label>
+                                    </div>
+                                    <div class="dtermLowpass2FrequencyAxis">
+                                        <label>
+                                            <span i18n="pidTuningPitch"></span>
+                                        </label>
+                                    </div>
+                                    <div class="dtermLowpass2FrequencyAxis">
+                                        <label>
+                                            <span i18n="pidTuningYaw"></span>
+                                        </label>
+                                    </div>
+
+
                                 </td>
                             </tr>
                             <tr class="dtermNotch">

--- a/src/tabs/pid_tuning.html
+++ b/src/tabs/pid_tuning.html
@@ -943,12 +943,12 @@
                             <tr>
                                 <td>
                                         <div class="gyroLowpassFrequency">
-                                        <span class="inputValue"><input type="number" class="nonProfile" name="gyroLowpassFrequency" step="1" min="1" max="255"/></span>
+                                        <span class="inputValue"><input type="number" class="nonProfile" name="gyroLowpassFrequency" step="1" min="0" max="255"/></span>
                                         </div>
                                         <div class="gyroLowpassFrequencyAxis">
-                                        <span class="inputValue"><input type="number" class="nonProfile" name="gyroLowpassFrequencyRoll" step="1" min="1" max="16000"/><br clear="all"></span>
-                                        <span class="inputValue"><input type="number" class="nonProfile" name="gyroLowpassFrequencyPitch" step="1" min="1" max="16000"/><br clear="all"></span>
-                                        <span class="inputValue"><input type="number" class="nonProfile" name="gyroLowpassFrequencyYaw" step="1" min="1" max="16000"/></span>
+                                        <span class="inputValue"><input type="number" class="nonProfile" name="gyroLowpassFrequencyRoll" step="1" min="0" max="16000"/><br clear="all"></span>
+                                        <span class="inputValue"><input type="number" class="nonProfile" name="gyroLowpassFrequencyPitch" step="1" min="0" max="16000"/><br clear="all"></span>
+                                        <span class="inputValue"><input type="number" class="nonProfile" name="gyroLowpassFrequencyYaw" step="1" min="0" max="16000"/></span>
                                         </div>
 
                                 </td>
@@ -1011,12 +1011,12 @@
                                     <span class="groupSwitchValue">
 
                                         <div class="gyroLowpass2Frequency">
-                                        <span class="inputValue"><input type="number" class="nonProfile" name="gyroLowpass2Frequency" step="1" min="1" max="16000"/></span>
+                                        <span class="inputValue"><input type="number" class="nonProfile" name="gyroLowpass2Frequency" step="1" min="0" max="16000"/></span>
                                         </div>
                                         <div class="gyroLowpass2FrequencyAxis">
-                                        <span class="inputValue"><input type="number" class="nonProfile" name="gyroLowpass2FrequencyRoll" step="1" min="1" max="16000"/><br clear="all"></span>
-                                        <span class="inputValue"><input type="number" class="nonProfile" name="gyroLowpass2FrequencyPitch" step="1" min="1" max="16000"/><br clear="all"></span>
-                                        <span class="inputValue"><input type="number" class="nonProfile" name="gyroLowpass2FrequencyYaw" step="1" min="1" max="16000"/></span>
+                                        <span class="inputValue"><input type="number" class="nonProfile" name="gyroLowpass2FrequencyRoll" step="1" min="0" max="16000"/><br clear="all"></span>
+                                        <span class="inputValue"><input type="number" class="nonProfile" name="gyroLowpass2FrequencyPitch" step="1" min="0" max="16000"/><br clear="all"></span>
+                                        <span class="inputValue"><input type="number" class="nonProfile" name="gyroLowpass2FrequencyYaw" step="1" min="0" max="16000"/></span>
                                         </div>
                                     </span>
                                 </td>
@@ -1394,12 +1394,12 @@
                                     <span class="groupSwitchValue">
 
                                         <div class="dtermLowpassFrequency">
-                                        <span class="inputValue"><input type="number" name="dtermLowpassFrequency" step="1" min="1" max="16000"/></span>
+                                        <span class="inputValue"><input type="number" name="dtermLowpassFrequency" step="1" min="0" max="16000"/></span>
                                         </div>
                                         <div class="dtermLowpassFrequencyAxis">
-                                        <span class="inputValue"><input type="number" name="dtermLowpassFrequencyRoll" step="1" min="1" max="16000"/><br clear="all"></span>
-                                        <span class="inputValue"><input type="number" name="dtermLowpassFrequencyPitch" step="1" min="1" max="16000"/><br clear="all"></span>
-                                        <span class="inputValue"><input type="number" name="dtermLowpassFrequencyYaw" step="1" min="1" max="16000"/></span>
+                                        <span class="inputValue"><input type="number" name="dtermLowpassFrequencyRoll" step="1" min="0" max="16000"/><br clear="all"></span>
+                                        <span class="inputValue"><input type="number" name="dtermLowpassFrequencyPitch" step="1" min="0" max="16000"/><br clear="all"></span>
+                                        <span class="inputValue"><input type="number" name="dtermLowpassFrequencyYaw" step="1" min="0" max="16000"/></span>
                                         </div>
                                     </span>
                                 </td>
@@ -1445,12 +1445,12 @@
 
                                         <span class="inputSwitch"><input type="checkbox" id="dtermLowpass2Enabled" class="toggle" /></span>
                                         <div class="dtermLowpass2Frequency">
-                                        <span class="inputValue" id='test'><input type="number" name="dtermLowpass2Frequency" step="1" min="1" max="16000"/></span>
+                                        <span class="inputValue" id='test'><input type="number" name="dtermLowpass2Frequency" step="1" min="0" max="16000"/></span>
                                         </div>
                                         <div class="dtermLowpass2FrequencyAxis">
-                                        <span class="inputValue"><input type="number" name="dtermLowpass2FrequencyRoll" step="1" min="1" max="16000"/><br clear="all"></span>
-                                        <span class="inputValue"><input type="number" name="dtermLowpass2FrequencyPitch" step="1" min="1" max="16000"/><br clear="all"></span>
-                                        <span class="inputValue"><input type="number" name="dtermLowpass2FrequencyYaw" step="1" min="1" max="16000"/></span>
+                                        <span class="inputValue"><input type="number" name="dtermLowpass2FrequencyRoll" step="1" min="0" max="16000"/><br clear="all"></span>
+                                        <span class="inputValue"><input type="number" name="dtermLowpass2FrequencyPitch" step="1" min="0" max="16000"/><br clear="all"></span>
+                                        <span class="inputValue"><input type="number" name="dtermLowpass2FrequencyYaw" step="1" min="0" max="16000"/></span>
                                         </div>
                                     </span>
                                 </td>

--- a/src/tabs/pid_tuning.html
+++ b/src/tabs/pid_tuning.html
@@ -924,7 +924,24 @@
                             <tr>
                                 <td>
                                     <span class="groupSwitchValue">
-                                        <span class="inputSwitch"><input type="checkbox" id="gyroLowpassEnabled" class="toggle" /></span>
+                                        <span class="inputSwitch"><input type="checkbox" id="gyroLowpassEnabled" class="toggle" />
+                                          <select name="gyroLowpassType">
+                                            <!--  Populated on execution -->
+                                        </select>
+                                        </span>
+
+                                    </span>
+                                </td>
+                                <td>
+                                    <div>
+                                        <label>
+                                            <span i18n="pidTuningGyroLowpassType"></span>
+                                        </label>
+                                    </div>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td>
                                         <div class="gyroLowpassFrequency">
                                         <span class="inputValue"><input type="number" class="nonProfile" name="gyroLowpassFrequency" step="1" min="1" max="255"/></span>
                                         </div>
@@ -933,7 +950,7 @@
                                         <span class="inputValue"><input type="number" class="nonProfile" name="gyroLowpassFrequencyPitch" step="1" min="1" max="16000"/><br clear="all"></span>
                                         <span class="inputValue"><input type="number" class="nonProfile" name="gyroLowpassFrequencyYaw" step="1" min="1" max="16000"/></span>
                                         </div>
-                                    </span>
+
                                 </td>
 
                                 <td>
@@ -961,20 +978,7 @@
 
                                 </td>
                             </tr>
-                            <tr>
-                                <td>
-                                    <select name="gyroLowpassType">
-                                        <!--  Populated on execution -->
-                                    </select>
-                                </td>
-                                <td>
-                                    <div>
-                                        <label>
-                                            <span i18n="pidTuningGyroLowpassType"></span>
-                                        </label>
-                                    </div>
-                                </td>
-                            </tr>
+
                             <tr>
                                 <th colspan="2">
                                     <div >
@@ -984,9 +988,28 @@
                                 </th>
                             </tr>
                             <tr class="gyroLowpass2">
+                              <td>
+                                  <span class="groupSwitchValue">
+                                      <span class="inputSwitch"><input type="checkbox" id="gyroLowpass2Enabled" class="toggle" />
+                                        <select name="gyroLowpass2Type" >
+                                          <!--  Populated on execution -->
+                                      </select>
+                                      </span>
+
+                                  </span>
+                              </td>
+                              <td>
+                                  <div>
+                                      <label>
+                                          <span i18n="pidTuningGyroLowpass2Type"></span>
+                                      </label>
+                                  </div>
+                              </td>
+                          </tr>
+                          <tr>
                                 <td>
                                     <span class="groupSwitchValue">
-                                        <span class="inputSwitch"><input type="checkbox" id="gyroLowpass2Enabled" class="toggle" /></span>
+
                                         <div class="gyroLowpass2Frequency">
                                         <span class="inputValue"><input type="number" class="nonProfile" name="gyroLowpass2Frequency" step="1" min="1" max="16000"/></span>
                                         </div>
@@ -1023,20 +1046,7 @@
                                 </td>
                             </tr>
 
-                            <tr class="gyroLowpass2Type">
-                                <td>
-                                    <select name="gyroLowpass2Type">
-                                        <!--  Populated on execution -->
-                                    </select>
-                                </td>
-                                <td>
-                                    <div>
-                                        <label>
-                                            <span i18n="pidTuningGyroLowpass2Type"></span>
-                                        </label>
-                                    </div>
-                                </td>
-                            </tr>
+
 
 
                             <tr>
@@ -1361,9 +1371,28 @@
                                 </th>
                             </tr>
                             <tr>
+                              <td>
+                                  <span class="groupSwitchValue">
+                                      <span class="inputSwitch"><input type="checkbox" id="dtermLowpassEnabled" class="toggle" />
+                                        <select name="dtermLowpassType" >
+                                          <!--  Populated on execution -->
+                                      </select>
+                                      </span>
+
+                                  </span>
+                              </td>
+                              <td>
+                                  <div>
+                                      <label>
+                                          <span i18n="pidTuningDTermLowpassType"></span>
+                                      </label>
+                                  </div>
+                              </td>
+                          </tr>
+                          <tr>
                                 <td>
                                     <span class="groupSwitchValue">
-                                        <span class="inputSwitch"><input type="checkbox" id="dtermLowpassEnabled" class="toggle" /></span>
+
                                         <div class="dtermLowpassFrequency">
                                         <span class="inputValue"><input type="number" name="dtermLowpassFrequency" step="1" min="1" max="16000"/></span>
                                         </div>
@@ -1401,20 +1430,7 @@
                                 </td>
                             </tr>
 
-                            <tr>
-                                <td>
-                                    <select name="dtermLowpassType">
-                                        <!--  Populated on execution -->
-                                    </select>
-                                </td>
-                                <td>
-                                    <div>
-                                        <label>
-                                            <span i18n="pidTuningDTermLowpassType"></span>
-                                        </label>
-                                    </div>
-                                </td>
-                            </tr>
+
                             <tr>
                                 <th colspan="2">
                                     <div >

--- a/src/tabs/pid_tuning.html
+++ b/src/tabs/pid_tuning.html
@@ -961,17 +961,17 @@
                                     </div>
                                     <div class="gyroLowpassFrequencyAxis LPFRol">
                                         <label>
-                                            <span class="LPFRol" i18n="pidTuningRoll"></span>
+                                            <span class="LPFRol" i18n="gyroLowpassFrequencyRoll"></span>
                                         </label>
                                     </div>
                                     <div class="gyroLowpassFrequencyAxis LPFPit">
                                         <label>
-                                            <span i18n="pidTuningPitch"></span>
+                                            <span i18n="gyroLowpassFrequencyPitch"></span>
                                         </label>
                                     </div>
                                     <div class="gyroLowpassFrequencyAxis LPFYaw">
                                         <label>
-                                            <span i18n="pidTuningYaw"></span>
+                                            <span i18n="gyroLowpassFrequencyYaw"></span>
                                         </label>
                                     </div>
 
@@ -1028,17 +1028,17 @@
                                     </div>
                                     <div class="gyroLowpass2FrequencyAxis LPFRol">
                                         <label>
-                                            <span class="LPFRol" i18n="pidTuningRoll"></span>
+                                            <span class="LPFRol" i18n="gyroLowpass2FrequencyRoll"></span>
                                         </label>
                                     </div>
                                     <div class="gyroLowpass2FrequencyAxis LPFPit">
                                         <label>
-                                            <span i18n="pidTuningPitch"></span>
+                                            <span i18n="gyroLowpass2FrequencyPitch"></span>
                                         </label>
                                     </div>
                                     <div class="gyroLowpass2FrequencyAxis LPFYaw">
                                         <label>
-                                            <span i18n="pidTuningYaw"></span>
+                                            <span i18n="gyroLowpass2FrequencyYaw"></span>
                                         </label>
                                     </div>
                                 </td>
@@ -1407,24 +1407,23 @@
                                     </div>
                                     <div class="dtermLowpassFrequencyAxis LPFRol">
                                         <label>
-                                            <span class="LPFRol" i18n="pidTuningRoll"></span>
+                                            <span class="LPFRol" i18n="dtermLowpassFrequencyRoll"></span>
                                         </label>
                                     </div>
                                     <div class="dtermLowpassFrequencyAxis LPFPit">
                                         <label>
-                                            <span i18n="pidTuningPitch"></span>
+                                            <span i18n="dtermLowpassFrequencyPitch"></span>
                                         </label>
                                     </div>
                                     <div class="dtermLowpassFrequencyAxis LPFYaw">
                                         <label>
-                                            <span i18n="pidTuningYaw"></span>
+                                            <span i18n="dtermLowpassFrequencyYaw"></span>
                                         </label>
                                     </div>
 
 
                                 </td>
                             </tr>
-
 
                             <tr>
                                 <th colspan="2">
@@ -1437,7 +1436,6 @@
                             <tr class="dtermLowpass2">
                                 <td>
                                     <span class="groupSwitchValue">
-
                                         <span class="inputSwitch"><input type="checkbox" id="dtermLowpass2Enabled" class="toggle" /></span>
                                         <div class="dtermLowpass2Frequency">
                                         <span class="inputValue" id='test'><input type="number" name="dtermLowpass2Frequency" step="1" min="0" max="16000"/></span>
@@ -1458,21 +1456,19 @@
                                     </div>
                                     <div class="dtermLowpass2FrequencyAxis LPFRol">
                                         <label>
-                                            <span class="LPFRol" i18n="pidTuningRoll"></span>
+                                            <span class="LPFRol" i18n="dtermLowpass2FrequencyRoll"></span>
                                         </label>
                                     </div>
                                     <div class="dtermLowpass2FrequencyAxis LPFPit">
                                         <label>
-                                            <span i18n="pidTuningPitch"></span>
+                                            <span i18n="dtermLowpass2FrequencyPitch"></span>
                                         </label>
                                     </div>
                                     <div class="dtermLowpass2FrequencyAxis LPFYaw">
                                         <label>
-                                            <span i18n="pidTuningYaw"></span>
+                                            <span i18n="dtermLowpass2FrequencyYaw"></span>
                                         </label>
                                     </div>
-
-
                                 </td>
                             </tr>
                             <tr class="dtermNotch">


### PR DESCRIPTION
* branched from final `filter_tab_axis_names` PR #158 
* hides Angle/Horizon/NFE PIDS when not in expert-mode
* hides SPA when not in expert-mode
* hides smart-dterm-smoothing and witchcraft when not in expert-mode
* tested 2 FC's 0.2.0 and 0.2.52
* i was unable to test the quadcopter animation `rates preview` due to no RX on test FC's

should squash-merge when ready

https://youtu.be/uSWqaCUd9vQ