### PR TITLE
20200515 enable full chip erase default

### DIFF
--- a/src/js/tabs/firmware_flasher.js
+++ b/src/js/tabs/firmware_flasher.js
@@ -631,7 +631,7 @@ TABS.firmware_flasher.initialize = function (callback) {
             if (result.erase_chip) {
                 $('input.erase_chip').prop('checked', true);
             } else {
-                $('input.erase_chip').prop('checked', false);
+                $('input.erase_chip').prop('checked', true);   //force true because people flashing without regard for new configs
             }
 
             $('input.erase_chip').change(function () {


### PR DESCRIPTION
* Force check-mark enable the full-chip-erase option on flash-tab.
* Still able to turn off if needed, but will enable each reopening of the flash-tab.

![2020-05-15_13-39-07](https://user-images.githubusercontent.com/56646290/82084800-81d7c200-96b1-11ea-8f54-9a8ad34c1bfa.png)
