### PR TITLE
quick and dirty hide removed features for 0.3.0

### DIFF
--- a/src/js/Features.js
+++ b/src/js/Features.js
@@ -83,8 +83,13 @@ var Features = function (config) {
         }
 
         if (semver.gte(CONFIG.apiVersion, "1.36.0")) {
+            //quick & dirty 0.3.0
+            if (semver.lt(CONFIG.flightControllerVersion, "0.3.0")) {
+                features.push(
+                    {bit: 28, group: 'other', name: 'ANTI_GRAVITY'}
+                );
+            }
             features.push(
-                {bit: 28, group: 'other', name: 'ANTI_GRAVITY'},
                 {bit: 29, group: 'other', name: 'DYNAMIC_FILTER'}
             );
         }

--- a/src/js/tabs/pid_tuning.js
+++ b/src/js/tabs/pid_tuning.js
@@ -277,7 +277,8 @@ TABS.pid_tuning.initialize = function(callback) {
             $('.antigravity input[name="itermThrottleThreshold"]').val(ADVANCED_TUNING.itermThrottleThreshold);
             $('.antigravity input[name="itermAcceleratorGain"]').val(ADVANCED_TUNING.itermAcceleratorGain / 1000);
 
-            if (FEATURE_CONFIG.features.isEnabled('ANTI_GRAVITY')) {
+            //quick & dirty 0.3.0
+            if (FEATURE_CONFIG.features.isEnabled('ANTI_GRAVITY') && semver.lt(CONFIG.flightControllerVersion, "0.3.0")) {
                 $('.antigravity').show();
             } else {
                 $('.antigravity').hide();
@@ -566,6 +567,12 @@ TABS.pid_tuning.initialize = function(callback) {
             $('#pid_main tr :nth-child(6)').hide();
 
             $('#pid-tuning .feedforwardTransition').hide();
+        }
+
+        //quick & dirty 0.3.0
+        if (semver.gte(CONFIG.flightControllerVersion, "0.3.0")) {
+            $('.absoluteControlGain').hide();
+            $('.itermrelax').hide();
         }
 
         //smart_dterm_smoothing, witchcraft_, table //first build with legit MSP144 is 0.2.35


### PR DESCRIPTION
* hide antigravity (configurator & pid-tuning tabs)
* hide absolute control (pid tuning)
* hide iTerm relax (pid tuning)

![2020-05-16_12-52](https://user-images.githubusercontent.com/56646290/82127051-74d0d680-9776-11ea-9d8d-61f8ec618370.png)
![2020-05-16_12-53](https://user-images.githubusercontent.com/56646290/82127059-83b78900-9776-11ea-9ab8-d0f24d15249e.png)
