### PR TITLE
Fix gps rescue/ dynamic filter toggle / dynamic_notch_min_hz min value

### DIFF
--- a/src/js/msp/MSPCodes.js
+++ b/src/js/msp/MSPCodes.js
@@ -111,7 +111,7 @@ var MSPCodes = {
     MSP_GPS_CONFIG:                 132,
     MSP_COMPASS_CONFIG:             133,
     MSP_GPS_RESCUE:                 135,
-
+    MSP_GPS_RESCUE_PIDS:            136,
     MSP_STATUS_EX:                  150,
 
     MSP_UID:                        160,
@@ -146,7 +146,17 @@ var MSPCodes = {
     MSP_SET_MOTOR_CONFIG:           222,
     MSP_SET_GPS_CONFIG:             223,
     MSP_SET_COMPASS_CONFIG:         224,
-    MSP_SET_GPS_RESCUE:             230,
+
+    MSP_FAST_KALMAN:                225,
+    MSP_SET_FAST_KALMAN:            226,
+    MSP_IMUF_CONFIG:                227,
+    MSP_SET_IMUF_CONFIG:            228,
+    MSP_IMUF_INFO:                  229,
+    MSP_EMUF:                       231,
+    MSP_SET_EMUF:                   232,
+
+    MSP_SET_GPS_RESCUE:             233,
+    MSP_SET_GPS_RESCUE_PIDS:        234,
 
     MSP_MODE_RANGES_EXTRA:          238,
     MSP_SET_ACC_TRIM:               239,
@@ -163,11 +173,5 @@ var MSPCodes = {
     MSP_DEBUGMSG:                   253, // Not used
     MSP_DEBUG:                      254,
 
-    MSP_FAST_KALMAN:                225,
-    MSP_SET_FAST_KALMAN:            226,
-    MSP_IMUF_CONFIG:                227,
-    MSP_SET_IMUF_CONFIG:            228,
-    MSP_IMUF_INFO:                  229,
-    MSP_EMUF:                       231,
-    MSP_SET_EMUF:                   232,
+
 };

--- a/src/js/msp/MSPHelper.js
+++ b/src/js/msp/MSPHelper.js
@@ -410,7 +410,7 @@ MspHelper.prototype.process_data = function(dataHandler) {
 
                 break;
             case MSPCodes.MSP_GPS_RESCUE:
-                GPS_RESCUE.angle             = data.readU16();
+                GPS_RESCUE.angle            = data.readU16();
                 GPS_RESCUE.initialAltitude  = data.readU16();
                 GPS_RESCUE.descentDistance  = data.readU16();
                 GPS_RESCUE.rescueGroundspeed = data.readU16();

--- a/src/js/tabs/pid_tuning.js
+++ b/src/js/tabs/pid_tuning.js
@@ -982,7 +982,7 @@ TABS.pid_tuning.initialize = function(callback) {
             FILTER_CONFIG.witchcraft_yaw       = parseFloat($('.smartDTermWitchBox input[name="witchcraftYaw"]').val());
         }
 
-        if ( semver.gte(CONFIG.apiVersion, "1.47.0")) {
+        if ( FEATURE_CONFIG.features.isEnabled('DYNAMIC_FILTER') && semver.gte(CONFIG.apiVersion, "1.47.0")) {
             FILTER_CONFIG.dynamic_gyro_notch_q  = parseFloat($('.pid_filter input[name="MatrixNotchQ"]').val());
             FILTER_CONFIG.dynamic_gyro_notch_min_hz = parseFloat($('.pid_filter input[name="MatrixNotchMin"]').val());
         }

--- a/src/tabs/pid_tuning.html
+++ b/src/tabs/pid_tuning.html
@@ -1153,7 +1153,7 @@
 
                                 <tr class="matrixFilter">
                                     <td>
-                                        <input type="number" class="nonProfile" name="MatrixNotchMin" step="1" min="1" max="1000"/>
+                                        <input type="number" class="nonProfile" name="MatrixNotchMin" step="1" min="30" max="1000"/>
                                     </td>
                                     <td>
                                         <div>
@@ -1163,7 +1163,7 @@
                                         </div>
                                     </td>
                                 </tr>
-                            
+
                         </table>
                     </div>
 


### PR DESCRIPTION
fixed failsafe settings/gps rescue not being settable from gui 
dynamic_filter toggle
dynamic_notch_min_hz min value to 30
and dynamic_notch_min_hz min value and q can't be set to zero anymore

