### PR TITLE
fix crashing pid-tab for failing non-existent presets/internet

### DIFF
--- a/src/js/tabs/pid_tuning.js
+++ b/src/js/tabs/pid_tuning.js
@@ -1206,7 +1206,12 @@ TABS.pid_tuning.initialize = function(callback) {
         // This vars are used here for populate the profile (and rate profile) selector AND in the copy profile (and rate profile) window
         var selectRateProfileValues = loadRateProfilesList();
         var selectProfileValues = loadProfilesList();
-        var selectPresetValues = loadPresetsList();
+        var selectPresetValues;
+        if (presetJson) {
+            selectPresetValues = loadPresetsList();
+        } else {
+            selectPresetValues = [];
+        }
 
         function populateProfilesSelector(selectProfileValues) {
             var profileSelect = $('select[name="profile"]');


### PR DESCRIPTION
* fixes #49 
* presets `.json` are stored in system temp folder; therefore, if temp `.json` are non-existent, pid-tab would fail.
* solution is if `presetJson` variable is empty, then do not populate presets list, but instead set it empty.

![2020-05-23_15-01](https://user-images.githubusercontent.com/56646290/82739628-98f85e80-9d06-11ea-959e-1984fcf2033a.png)
