### PR TITLE
possible pidTab exit crash fix

### DIFF
--- a/src/js/tabs/pid_tuning.js
+++ b/src/js/tabs/pid_tuning.js
@@ -2391,3 +2391,8 @@ TABS.pid_tuning.updateFilterWarning = function() {
     }
 
 }
+
+TABS.pid_tuning.cleanup = function (callback) {
+    this.keepRendering = false;
+    if (callback) callback();
+};


### PR DESCRIPTION
* possible fix for #22
* no guarantee, stops rendering upon cleanup (similar to `receiver.js`)