### PR TITLE
css styling fix for sliders

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -77,9 +77,9 @@ input[type=range]::-webkit-slider-thumb {
   -webkit-appearance: none;
   box-shadow: 0px 0px 0px #000000;
   border: 2px solid #2497E3;
-  height: 21px;
+  height: 22px;
   width: 7px;
-  border-radius: 0px;
+  border-radius: 7px;
   background: #22B7EB;
   cursor: pointer;
   margin-top: -10.5px;

--- a/src/css/tabs/motors.css
+++ b/src/css/tabs/motors.css
@@ -281,16 +281,41 @@
     width: calc(50% - 50px);
 }
 
+/*motor sliders*/
 .tab-motors .motor_testing .sliders input {
-    -webkit-appearance: slider-vertical;
-    width: calc((100% / 9) - 13px);
-    height: 73px;
-    margin-left: 10px;
+    /*-webkit-appearance: slider-vertical;*/
+    -webkit-appearance: none;
+    width: calc((100% / 9) - 5px);
+    height: 2px;
+    margin-left: 1px;
+    color: #22B7EB;
+    background: #BBBBBB;
+    border-radius: 0px;
+    border: 0px solid #000000;
 }
 
 .tab-motors .motor_testing .sliders input:first-child {
     margin-left: 0px;
 }
+
+.tab-motors .motor_testing .sliders input::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  box-shadow: 0px 0px 0px #000000;
+  border: 2px solid #2497E3;
+  height: 22px;
+  width: 7px;
+  border-radius: 7px;
+  background: #22B7EB;
+  cursor: pointer;
+  margin-top: -10.5px;
+}
+
+.tab-motors .motor_testing .sliders input:disabled::-webkit-slider-thumb {
+  /*gray thumb when disabled*/
+  border: 2px solid #999999;
+  background: #BBBBBB;
+}
+
 
 .tab-motors .motor_testing .values {
     margin-top: 5px;


### PR DESCRIPTION
* EmuConfigurator is essentially a chrome app
* chrome's vertical range slider does not allow proper styling due this bug:
* https://bugs.chromium.org/p/chromium/issues/detail?id=341071
* motor sliders were reverted to horizontal sliders

original pbefore chrome window manager dependency update:
![2020-05-31_16-53_original_motor_sliders](https://user-images.githubusercontent.com/56646290/83431908-b790e080-a3fd-11ea-93fc-cf9de2c04aa2.png)

after chrome window manager update:
![borked](https://user-images.githubusercontent.com/56646290/83431963-c6779300-a3fd-11ea-8e6b-ef186921f90e.png)

best effort fix:  (scale is be off due to screencap on different computer)
![2020-06-01_11-47-14_best_effort_horiz](https://user-images.githubusercontent.com/56646290/83432234-32f29200-a3fe-11ea-8c01-270f4683ea23.png)

