### PR TITLE
revert NW.js 0.42.6

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -41,9 +41,10 @@ var gitChangeSetId;
 
 // 0.45.6 Win7 connects; 0.42.3 fixed OSX Flashing; 0.46.X breaks Win7 connect
 // maybe serial/usb needs updating
+// revert to 0.42.6 due to Windows® users increased CLI-tab buffer/autocomplete issues.
 var nwBuilderOptions = {
     // FIXME: hardcoded version number
-    version: '0.45.6',
+    version: '0.42.6',
     files: './dist/**/*',
     macIcns: './assets/osx/app-icon.icns',
     macPlist: { 'CFBundleDisplayName': 'Emuflight Configurator'},


### PR DESCRIPTION
* revert to `NW.js` `v0.42.6` dated 30-Nov-2019`
* fixes some variants of Windows CLI-tab buffer issue.
* https://dl.nwjs.io/