### PR TITLE
Update: Discord invite link is invalid or has expired.

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ If you have 3D model animation problems, enable "Override software rendering lis
 
 If you need help __please__ reach out in [Emuflight support chat](https://discordapp.com/channels/547211754845765635/596913667447062547) on Discord before raising issues on Github.
 
-Please register and [join via this link](https://discord.gg/TM5hpcM).
+Please register and [join via this link](https://discord.gg/gdP9CwE).
 
 ### Issue trackers
 


### PR DESCRIPTION
Quick small update of the README.md.
The Discord invite link doesn't work anymore: _The invite is invalid or has expired._

I changed the old expired link with the link avalaible on the EmuFlight repository. It should now work!