### PR TITLE
auto-sort presets descending

### DIFF
--- a/src/js/tabs/pid_tuning.js
+++ b/src/js/tabs/pid_tuning.js
@@ -1317,6 +1317,8 @@ TABS.pid_tuning.initialize = function(callback) {
         function loadPresetsList() {
             var numberOfPresets = Object.keys(presetJson).length;
             var keys = Object.keys(presetJson);
+            keys.sort();
+            keys.reverse();
             var presetsElements = [];
             for (var i = 0; i < numberOfPresets; i++) {
                 presetsElements.push(keys[i]);


### PR DESCRIPTION
* alpha-sort presets descending order
* fixes our failures to order things proper when we add presets
* due to "alphabetical sorting", any preset for 10inch+ will break sorting, but i doubt we want those anyway

![Screenshot_2020-12-04_13-48-26](https://user-images.githubusercontent.com/56646290/101219207-aabda580-3649-11eb-8ea8-9dfafeb7acbd.png)
