### PR TITLE
github actions workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,7 +96,7 @@ jobs:
       - name: list artifacts
         continue-on-error: true
         run: |
-          ls -lhr ./*
+          ls -lh ./*
       - name: draft release
         continue-on-error: true
         uses: softprops/action-gh-release@v1
@@ -151,14 +151,14 @@ jobs:
       - name: list artifacts
         continue-on-error: true
         run: |
-          ls -lh ./emuflight-configurator*
+          ls -lh ./emuflight-configurator*.???
       - name: rename with BuildNum and SHA
-        continue-on-error: false   #mod this to true?
+        continue-on-error: false   #bad rename breaks upload
         run: |
           sudo apt -y install rename
           export buildname="_Build_${{ github.RUN_NUMBER }}_${{ env.SHORT_SHA }}"
           rename "s/\.(?=[^.]*$)/${buildname}\./" emuflight-configurator*.???
-          ls -lh ./emuflight-configurator*
+          ls -lh ./emuflight-configurator*.???
       - name: upload to bintray
         continue-on-error: true
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -157,7 +157,7 @@ jobs:
         run: |
           sudo apt -y install rename
           export buildname="_Build_${{ github.RUN_NUMBER }}_${{ env.SHORT_SHA }}"
-          rename 's/\./${buildname}\./' emuflight-configurator*
+          rename "s/\./${buildname}\./" emuflight-configurator*
       - name: upload to bintray
         continue-on-error: true
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,170 @@
+on:
+  push:
+    tags:
+    - '*'
+    branches:
+    - '*'
+  pull_request:
+    branches:
+    - '*'
+  # repository_dispatch is a newer github-actions feature that will allow building from triggers other than code merge/PR
+  repository_dispatch:
+    types: [build]
+
+name: Build EmuConfigurator
+jobs:
+  build:
+    timeout-minutes: 40
+    continue-on-error: false
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: true
+      max-parallel: 3
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - name: git checkout
+        continue-on-error: false
+        uses: actions/checkout@master
+      - name: get tag
+        continue-on-error: true
+        run: |
+          echo "REVISION_TAG=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
+          echo "SHORT_SHA=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+      - name: setup node
+        continue-on-error: false
+        uses: actions/setup-node@v2
+        with:
+          node-version: '11'
+      # for debugging
+      - name: show variables
+        continue-on-error: true
+        run: |
+          echo "Build: ${{ github.RUN_NUMBER }}"
+          echo "Commit: ${{ github.SHA }}"
+          echo "Short: ${{ env.SHORT_SHA }}"
+          echo "Ref: ${{ github.REF}}"
+          echo "Tag: ${{ env.REVISION_TAG }}"
+          echo "Actor: ${{ github.ACTOR }}"
+          echo "Repo: ${{ github.REPOSITORY }}"
+      # build stuff
+      - name: yarn install
+        run: yarn install
+      - name: yarn gulp clean-release
+        run: yarn gulp clean-release
+      - name: yarn gulp release --linux64
+        continue-on-error: false
+        if: ${{ startsWith(matrix.os, 'ubuntu') }}
+        run: |
+          sudo apt install -y rpm
+          yarn gulp release --linux64
+      - name: yarn gulp release --osx64
+        continue-on-error: false
+        if: ${{ startsWith(matrix.os, 'macos') }}
+        run: |
+          yarn gulp release --osx64
+      - name: yarn gulp release  --win32 --win64
+        continue-on-error: false
+        if: ${{ startsWith(matrix.os, 'windows') }}
+        run: yarn gulp release  --win32 --win64
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@master
+        with:
+          name: EmuConfigurator-${{ github.ACTOR }}-${{ github.RUN_NUMBER }}
+          path: release/*
+  draft:
+    if: startsWith(github.ref, 'refs/tags/')
+    needs: build
+    timeout-minutes: 10
+    continue-on-error: true
+    runs-on: ubuntu-latest
+    steps:
+      # for debugging
+      - name: show variables
+        continue-on-error: true
+        run: |
+          echo "Build: ${{ github.RUN_NUMBER }}"
+          echo "Commit: ${{ github.SHA }}"
+          echo "Ref: ${{ github.REF}}"
+          echo "Actor: ${{ github.ACTOR }}"
+          echo "Repo: ${{ github.REPOSITORY }}"
+      - name: download artifacts
+        continue-on-error: false
+        uses: actions/download-artifact@master
+        with:
+          name: EmuConfigurator-${{ github.ACTOR }}-${{ github.RUN_NUMBER }}
+      - name: list artifacts
+        continue-on-error: true
+        run: |
+          ls -lhr ./*
+      - name: draft release
+        continue-on-error: true
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: ./emuflight-configurator*
+          draft: true
+          prerelease: true
+          tag_name: ${{ github.RUN_NUMBER }}   # use the build Number, but we manually change to version so that it creates a version-tag on release
+          name:  DRAFT / EmuConfigurator / GitHub Build ${{ github.RUN_NUMBER }}
+          body: |
+            ### Build: ${{ github.RUN_NUMBER }}
+            ### Commit: ${{ github.SHA }}
+            ### Ref: ${{ github.REF}}
+            ### Actor: ${{ github.ACTOR }}
+            ### Repo: ${{ github.REPOSITORY }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  # jfrog util easier on linux, so VM to download artifacts and upload bintray
+  bintray:
+    if: startsWith(github.ref, 'refs/tags/')
+    needs: build
+    timeout-minutes: 10
+    continue-on-error: true
+    runs-on: ubuntu-latest
+    steps:
+      # build job failing to pass environment variables, so recreate them from checkout :(
+      - name: git checkout
+        continue-on-error: false
+        uses: actions/checkout@master
+      - name: get tag
+        continue-on-error: true
+        run: |
+          echo "REVISION_TAG=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
+          echo "SHORT_SHA=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+      # for debugging
+      - name: show variables
+        continue-on-error: true
+        run: |
+          echo "Build: ${{ github.RUN_NUMBER }}"
+          echo "Commit: ${{ github.SHA }}"
+          echo "Short: ${{ env.SHORT_SHA }}"
+          echo "Ref: ${{ github.REF}}"
+          echo "Tag: ${{ env.REVISION_TAG }}"
+          echo "Actor: ${{ github.ACTOR }}"
+          echo "Repo: ${{ github.REPOSITORY }}"
+      - name: download artifacts
+        continue-on-error: false
+        uses: actions/download-artifact@master
+        with:
+          name: EmuConfigurator-${{ github.ACTOR }}-${{ github.RUN_NUMBER }}
+      - name: list artifacts
+        continue-on-error: true
+        run: |
+          ls -lhr ./*
+      - name: upload to bintray
+        continue-on-error: true
+        run: |
+          curl -fL https://getcli.jfrog.io | sh
+          export JFROG_CLI_OFFER_CONFIG=false
+          export CI=true
+          export JFROG_CLI_LOG_LEVEL=DEBUG
+          ./jfrog bt config --user=${{secrets.BINTRAYUSERNAME}} --key=${{secrets.BINTRAYAPIKEY}} --licenses=GPL-3.0
+          export revtag="${{ env.REVISION_TAG }}"
+          export shortsha="${{ env.SHORT_SHA }}"
+          export repo="emuflight-dev/dev_cfg"
+          export package="${{ env.REVISION_TAG }}"
+          export version="${{ github.RUN_NUMBER }}"
+          ./jfrog bt package-create --pub-dn=true --vcs-url="https://github.com/emuflight" "${repo}/${package}" || true
+          ./jfrog bt version-create "${repo}/${package}/${version}"  || true
+          ./jfrog bt upload --publish=true "./emuflight-configurator*" "${repo}/${package}/${version}" "EmuConfigurator_GitHub_Build_${version}_SHA_${shortsha}_${revtag}/" || true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
       - name: git checkout
         continue-on-error: false
         uses: actions/checkout@master
-      - name: get tag
+      - name: get tag & short-sha
         continue-on-error: true
         run: |
           echo "REVISION_TAG=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
@@ -96,13 +96,13 @@ jobs:
       - name: list artifacts
         continue-on-error: true
         run: |
-          ls -lh ./*
+          ls -lh ./*.???
       - name: draft release
         continue-on-error: true
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')
         with:
-          files: ./emuflight-configurator*
+          files: ./emuflight-configurator*.???
           draft: true
           prerelease: true
           tag_name: ${{ github.RUN_NUMBER }}   # use the build Number, but we manually change to version so that it creates a version-tag on release
@@ -152,8 +152,8 @@ jobs:
         continue-on-error: true
         run: |
           ls -lh ./emuflight-configurator*.???
-      - name: rename with BuildNum and SHA
-        continue-on-error: false   #bad rename breaks upload
+      - name: rename with build_num and sha
+        continue-on-error: false   #bad rename breaks upload to bintray
         run: |
           sudo apt -y install rename
           export buildname="_Build_${{ github.RUN_NUMBER }}_${{ env.SHORT_SHA }}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,6 +67,13 @@ jobs:
         continue-on-error: false
         if: ${{ startsWith(matrix.os, 'windows') }}
         run: yarn gulp release  --win32 --win64
+      - name: rename to build no and SHA    #will this even work non-Linux?
+        continue-on-error: false   #mod this to true?
+        run: |
+          sudo apt -y install rename
+          cd release
+          export buildname="_Build_${{ github.RUN_NUMBER }}_${{ env.SHORT_SHA }}"
+          rename rename 's/\./${buildname}\./' emuflight-configurator_*
       - name: Upload Artifacts
         uses: actions/upload-artifact@master
         with:
@@ -96,6 +103,12 @@ jobs:
       - name: list artifacts
         continue-on-error: true
         run: |
+          ls -lhr ./*
+      - name: rename artifacts
+        continue-on-error: false
+        run: |
+          sudo apt -y install rename
+          rename 's/_Build_.*\./\./' emuflight-configurator*
           ls -lhr ./*
       - name: draft release
         continue-on-error: true
@@ -165,6 +178,7 @@ jobs:
           export repo="emuflight-dev/dev_cfg"
           export package="${{ env.REVISION_TAG }}"
           export version="${{ github.RUN_NUMBER }}"
+          export datestring="$(date +"%Y-%m-%d")"
           ./jfrog bt package-create --pub-dn=true --vcs-url="https://github.com/emuflight" "${repo}/${package}" || true
           ./jfrog bt version-create "${repo}/${package}/${version}"  || true
-          ./jfrog bt upload --publish=true "./emuflight-configurator*" "${repo}/${package}/${version}" "EmuConfigurator_GitHub_Build_${version}_SHA_${shortsha}_${revtag}/" || true
+          ./jfrog bt upload --publish=true "./emuflight-configurator*" "${repo}/${package}/${version}" "${datestring}_EmuConfigurator_GitHub_Build_${version}_${revtag}/" || true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,13 +67,6 @@ jobs:
         continue-on-error: false
         if: ${{ startsWith(matrix.os, 'windows') }}
         run: yarn gulp release  --win32 --win64
-      - name: rename to build no and SHA    #will this even work non-Linux?
-        continue-on-error: false   #mod this to true?
-        run: |
-          sudo apt -y install rename
-          cd release
-          export buildname="_Build_${{ github.RUN_NUMBER }}_${{ env.SHORT_SHA }}"
-          rename rename 's/\./${buildname}\./' emuflight-configurator*
       - name: Upload Artifacts
         uses: actions/upload-artifact@master
         with:
@@ -103,12 +96,6 @@ jobs:
       - name: list artifacts
         continue-on-error: true
         run: |
-          ls -lhr ./*
-      - name: rename artifacts
-        continue-on-error: false
-        run: |
-          sudo apt -y install rename
-          rename 's/_Build_.*\./\./' emuflight-configurator*
           ls -lhr ./*
       - name: draft release
         continue-on-error: true
@@ -165,6 +152,13 @@ jobs:
         continue-on-error: true
         run: |
           ls -lhr ./*
+      - name: rename with BuildNum and SHA
+        continue-on-error: false   #mod this to true?
+        run: |
+          sudo apt -y install rename
+          cd release
+          export buildname="_Build_${{ github.RUN_NUMBER }}_${{ env.SHORT_SHA }}"
+          rename rename 's/\./${buildname}\./' emuflight-configurator*
       - name: upload to bintray
         continue-on-error: true
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -151,13 +151,14 @@ jobs:
       - name: list artifacts
         continue-on-error: true
         run: |
-          ls -lhr ./*
+          ls -lh ./emuflight-configurator*
       - name: rename with BuildNum and SHA
         continue-on-error: false   #mod this to true?
         run: |
           sudo apt -y install rename
           export buildname="_Build_${{ github.RUN_NUMBER }}_${{ env.SHORT_SHA }}"
-          rename "s/\./${buildname}\./" emuflight-configurator*
+          rename "s/\.(?=[^.]*$)/${buildname}\./" emuflight-configurator*.???
+          ls -lh ./emuflight-configurator*
       - name: upload to bintray
         continue-on-error: true
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -157,7 +157,7 @@ jobs:
         run: |
           sudo apt -y install rename
           export buildname="_Build_${{ github.RUN_NUMBER }}_${{ env.SHORT_SHA }}"
-          rename rename 's/\./${buildname}\./' emuflight-configurator*
+          rename 's/\./${buildname}\./' emuflight-configurator*
       - name: upload to bintray
         continue-on-error: true
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,7 +73,7 @@ jobs:
           sudo apt -y install rename
           cd release
           export buildname="_Build_${{ github.RUN_NUMBER }}_${{ env.SHORT_SHA }}"
-          rename rename 's/\./${buildname}\./' emuflight-configurator_*
+          rename rename 's/\./${buildname}\./' emuflight-configurator*
       - name: Upload Artifacts
         uses: actions/upload-artifact@master
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -156,7 +156,6 @@ jobs:
         continue-on-error: false   #mod this to true?
         run: |
           sudo apt -y install rename
-          cd release
           export buildname="_Build_${{ github.RUN_NUMBER }}_${{ env.SHORT_SHA }}"
           rename rename 's/\./${buildname}\./' emuflight-configurator*
       - name: upload to bintray


### PR DESCRIPTION
* builds and stores artifacts for all branches/tags.
* tags will create draft-release and upload to Bintray.
* 100% github workflow/vm's to compile Windows, OSX, Linux.
* upgraded to Node 11, but not 12 as such fails for OSX's `fs-xattr`.
* only caveat is that i'm unsure if a single OS build fail properly exits the workflow as a "fail", as such would be desired.
* requires EmuOrg>Settings>Secrets>BINTRAYUSERNAME & BINTRAYAPIKEY setup for valid Bintray user/rights. (already done.)

GitHub:
![2020-12-21_14-58](https://user-images.githubusercontent.com/56646290/102821639-0d7aa500-439d-11eb-93ec-44fc9243a78e.png)

BinTray:
![2020-12-21_14-57](https://user-images.githubusercontent.com/56646290/102821698-24b99280-439d-11eb-959b-53f693cc7179.png)
![2020-12-21_14-56](https://user-images.githubusercontent.com/56646290/102821713-2b480a00-439d-11eb-8c26-2b73ce5cf787.png)
![2020-12-21_14-56_1](https://user-images.githubusercontent.com/56646290/102821726-2daa6400-439d-11eb-8368-2d49fa4af591.png)

