### PR TITLE
NFE on switch mod

### DIFF
--- a/src/js/tabs/pid_tuning.js
+++ b/src/js/tabs/pid_tuning.js
@@ -438,7 +438,7 @@ TABS.pid_tuning.initialize = function(callback) {
             }
 
             // nfe racer mode
-            if (semver.gte(CONFIG.apiVersion, "1.43.0")) {
+            if (semver.gte(CONFIG.apiVersion, "1.43.0") && semver.lt(CONFIG.flightControllerVersion, "0.3.3") ) {
                 $('input[id="nferacermode"]').prop('checked', ADVANCED_TUNING.nfe_racermode !== 0);
             } else {
                 $('.nferacermode').hide();


### PR DESCRIPTION
* hide old NFE for new versions (now on aux-modes tab)
* semver on flightware >= 0.3.3
* does not account for any future MSP or profile struct changes.

![2020-12-22_09-56](https://user-images.githubusercontent.com/56646290/102909516-b4634d80-443e-11eb-88a1-13611ddf5df5.png)

modes switch was automatic from flightware:
![2020-12-22_10-18](https://user-images.githubusercontent.com/56646290/102909784-19b73e80-443f-11eb-9162-cabbec9eecbf.png)


