### PR TITLE
Prevent target list from loading twice on app launch with show unstab…

### DIFF
--- a/src/js/tabs/firmware_flasher.js
+++ b/src/js/tabs/firmware_flasher.js
@@ -261,7 +261,6 @@ TABS.firmware_flasher.initialize = function (callback) {
             } else {
                 $('tr.build_type').hide();
                 $('tr.expert_mode').hide();
-                buildType_e.val(0).trigger('change');
             }
         }
 


### PR DESCRIPTION
Bug was: When show unstable releases is NOT selected on app load.. it runs buildBoardOptions() twice. 
when show unstable releases is selected on app load it runs correctly. 
Also if you toggle it then it works correctly on both sides.

I discovered that buildBoardOptions() was being run when buildtype_e.change() is run. It does this one time when the app is loaded, then again immediately after. I removed the initial buildtype_e.change()
I tested it and it works fine, but dont know if this is the real solution. betaflight-configurator still has this line present to this day. Our config differs slightly and i cant figure out after two hours another way to prevent it from happening.

Tested offline but did not test running the application for the first time with no internet. I don't know how to do that.

Hope its good