### PR TITLE
Limit UI for MSP max-version supported

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -487,7 +487,8 @@ function writeChangesetId() {
     var versionJson = new stream.Readable;
     versionJson.push(JSON.stringify({
         gitChangesetId: gitChangeSetId,
-        version: pkg.version
+        version: pkg.version,
+        max_msp: pkg.max_msp
         }, undefined, 2));
     versionJson.push(null);
     return versionJson

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -441,6 +441,9 @@
     "firmwareTypeNotSupported": {
         "message": "Non - Cleanflight/Emuflight firmware is <span class=\"message-negative\">not supported</span>, except for CLI mode."
     },
+    "firmwareMSPNotSupported": {
+        "message":"MSP version is not supported. Please upgrade EmuConfigurator."
+    },
     "firmwareUpgradeRequired": {
         "message": "The firmware on this device needs upgrading to a newer version. Use CLI for backup before flashing. CLI backup/restore procedure is in the documention.<br />Alternatively download and use an old version of the configurator if you are not ready to upgrade."
     },

--- a/manifest.json
+++ b/manifest.json
@@ -2,6 +2,8 @@
     "manifest_version": 2,
     "minimum_chrome_version": "49",
     "version": "0.3.5",
+    "max_msp": "1.50.0",
+    "COMMENT": "MAX_MSP required!!!!",
     "author": "Emuflight Team",
     "name": "Emuflight Configurator",
     "short_name": "EmuConfigurator",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,8 @@
   "name": "emuflight-configurator",
   "description": "Crossplatform configuration tool for Emuflight flight control system.",
   "version": "0.3.5",
+  "max_msp": "1.50.0",
+  "COMMENT": "MAX_MSP required!!!!",
   "main": "main.html",
   "chromium-args": "--disable-features=nw2",
   "bg-script": "js/eventPage.js",

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -84,11 +84,17 @@ $(document).ready(function () {
     $.getJSON('version.json', function(data) {
         CONFIGURATOR.version = data.version;
         CONFIGURATOR.gitChangesetId = data.gitChangesetId;
+        console.log("doc ready CONFIGURATOR.version "+CONFIGURATOR.version);
+        CONFIGURATOR.max_msp = data.max_msp;
+        console.log("doc ready CONFIGURATOR.max_msp "+CONFIGURATOR.max_msp);
 
         // Version in the ChromeApp's manifest takes precedence.
         if(chrome.runtime && chrome.runtime.getManifest) {
             var manifest = chrome.runtime.getManifest();
             CONFIGURATOR.version = manifest.version;
+            console.log("chrome runtime CONFIGURATOR.version "+CONFIGURATOR.version);
+            CONFIGURATOR.max_msp = manifest.max_msp;
+            console.log("chrome runtime CONFIGURATOR.max_msp "+CONFIGURATOR.max_msp);
             // manifest.json for ChromeApp can't have a version
             // with a prerelease tag eg 10.0.0-RC4
             // Work around is to specify the prerelease version in version_name

--- a/src/js/serial_backend.js
+++ b/src/js/serial_backend.js
@@ -226,7 +226,7 @@ function onOpen(openInfo) {
             if (semver.gte(CONFIG.apiVersion, CONFIGURATOR.apiVersionAccepted)) {
 
                 MSP.send_message(MSPCodes.MSP_FC_VARIANT, false, false, function () {
-                    if (CONFIG.flightControllerIdentifier === 'EMUF') {
+                    if (CONFIG.flightControllerIdentifier === 'EMUF' && semver.lte(CONFIG.apiVersion, CONFIGURATOR.max_msp) ){
                         MSP.send_message(MSPCodes.MSP_FC_VERSION, false, false, function () {
                             GUI.log(i18n.getMessage('fcInfoReceived', [CONFIG.flightControllerIdentifier, CONFIG.flightControllerVersion]));
                             updateStatusBarVersion(CONFIG.flightControllerVersion, CONFIG.flightControllerIdentifier);
@@ -263,7 +263,11 @@ function onOpen(openInfo) {
                     } else {
                         var dialog = $('.dialogConnectWarning')[0];
 
-                        $('.dialogConnectWarning-content').html(i18n.getMessage('firmwareTypeNotSupported'));
+                        if (semver.lte(CONFIG.apiVersion, CONFIGURATOR.max_msp)) {
+                            $('.dialogConnectWarning-content').html(i18n.getMessage('firmwareTypeNotSupported'));
+                        } else {
+                            $('.dialogConnectWarning-content').html(i18n.getMessage('firmwareMSPNotSupported'));
+                        }
 
                         $('.dialogConnectWarning-closebtn').click(function() {
                             dialog.close();


### PR DESCRIPTION
* Limits the EmuFlight MSP max-version allowed to access UI.
* This solves problem of broken configuring/saving on unsupported MSP versioned firmware.
* requires bumping `max_msp` value in `package.json` and `manifest.json` same as when bumping Configurator version.

UI presented when MSP not supported:
![MSP_MAX](https://user-images.githubusercontent.com/56646290/122791240-acb22380-d27e-11eb-9b75-5b0222a7516a.png)

package.json:
![image](https://user-images.githubusercontent.com/56646290/122791060-7ffe0c00-d27e-11eb-8c37-e78d1830a4da.png)

manifest.json:
![image](https://user-images.githubusercontent.com/56646290/122791102-88eedd80-d27e-11eb-85b8-cc4fc89cbdca.png)

