### PR TITLE
bump version 0.3.6

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 2,
     "minimum_chrome_version": "49",
-    "version": "0.3.5",
+    "version": "0.3.6",
     "max_msp": "1.50.0",
     "COMMENT": "MAX_MSP required!!!!",
     "author": "Emuflight Team",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "emuflight-configurator",
   "description": "Crossplatform configuration tool for Emuflight flight control system.",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "max_msp": "1.50.0",
   "COMMENT": "MAX_MSP required!!!!",
   "main": "main.html",


### PR DESCRIPTION
* release all the minor fixes and dependencies to date in interim before 0.4.0
* will only allow CLI for future MSP versions, forcing alert to update to new Configurator release