### PR TITLE
wait until usb port-list is populated before enabling flash/connect buttons

### DIFF
--- a/src/js/main.js
+++ b/src/js/main.js
@@ -579,8 +579,9 @@ function startProcess() {
         DarkTheme.setConfig(typeof result.darkTheme == 'undefined' || result.darkTheme);
     });
 
-    $('.connect_b a.connect').removeClass('disabled');
-    $('.firmware_b a.flash').removeClass('disabled');
+    //moved to port_handler.js -- allows disabled until ports list is populated
+    //$('.connect_b a.connect').removeClass('disabled');
+    //$('.firmware_b a.flash').removeClass('disabled');
 };
 
 function checkForConfiguratorUpdates() {

--- a/src/js/port_handler.js
+++ b/src/js/port_handler.js
@@ -142,6 +142,11 @@ PortHandler.check = function () {
         self.check_usb_devices();
 
         GUI.updateManualPortVisibility();
+
+        //moved from main.js
+        $('.connect_b a.connect').removeClass('disabled');
+        $('.firmware_b a.flash').removeClass('disabled');
+
         setTimeout(function () {
             self.check();
         }, TIMEOUT_CHECK);


### PR DESCRIPTION
* Currently, EmuConfig prematurely enables the flash/connect buttons.
* This delays enabling until after ports_handler.js populates the ports list
* https://youtu.be/DnUwE04Nswc

