### PR TITLE
[gh actions] use date as tag for dev-unstable dev-master

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -152,6 +152,7 @@ jobs:
           echo "Repo: ${{ github.REPOSITORY }}"
           echo "outputs.buildtag: ${{ needs.build.outputs.buildtag }}"
           echo "outputs.shortsha: ${{ needs.build.outputs.shortsha }}"
+          echo "NOW=$(date +'%Y%m%d.%H%M%S')" >> $GITHUB_ENV
         continue-on-error: true
 
       - name: download artifacts
@@ -175,7 +176,7 @@ jobs:
           repo: dev-unstable
           owner: emuflight
           token: ${{ secrets.NC_PAT_EMUF }}
-          tag: "cfg-${{ github.run_number }}"
+          tag: "${{ env.NOW }}-cfg"
           draft: true
           prerelease: true
           allowUpdates: true
@@ -206,7 +207,7 @@ jobs:
           repo: dev-master
           owner: emuflight
           token: ${{ secrets.NC_PAT_EMUF }}
-          tag: "cfg-${{ github.run_number }}"
+          tag: "${{ env.NOW }}-cfg"
           draft: true
           prerelease: true
           allowUpdates: true


### PR DESCRIPTION
use date
![image](https://github.com/emuflight/EmuConfigurator/assets/56646290/0a84fdd8-6b0c-4499-b7b8-623bf1eb757f)

not build number which loses sorting
![image](https://github.com/emuflight/EmuConfigurator/assets/56646290/7e350f12-8794-4e51-9f14-77eae3c9ea3e)
