### PR TITLE
ADD APM32 MCU USB_DFU

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -37,7 +37,12 @@
                 {
                     "vendorId": 10473,
                     "productId": 393
+                },
+                {
+                    "vendorId": 12619,
+                    "productId": 262
                 }
+                
             ]
         },
         "webview",

--- a/manifest.json
+++ b/manifest.json
@@ -42,7 +42,6 @@
                     "vendorId": 12619,
                     "productId": 262
                 }
-                
             ]
         },
         "webview",

--- a/src/js/port_handler.js
+++ b/src/js/port_handler.js
@@ -4,7 +4,8 @@ const TIMEOUT_CHECK = 500; // With 250 it seems that it produces a memory leak a
 
 var usbDevices = { filters: [
     {'vendorId': 1155, 'productId': 57105},
-    {'vendorId': 10473, 'productId': 393}
+    {'vendorId': 10473, 'productId': 393},
+    {'vendorId': 12619, 'productId': 262}// APM32 DFU Bootloader
 ] };
 
 var PortHandler = new function () {

--- a/src/js/port_handler.js
+++ b/src/js/port_handler.js
@@ -5,7 +5,7 @@ const TIMEOUT_CHECK = 500; // With 250 it seems that it produces a memory leak a
 var usbDevices = { filters: [
     {'vendorId': 1155, 'productId': 57105},
     {'vendorId': 10473, 'productId': 393},
-    {'vendorId': 12619, 'productId': 262}// APM32 DFU Bootloader
+    {'vendorId': 12619, 'productId': 262} // APM32 DFU Bootloader
 ] };
 
 var PortHandler = new function () {


### PR DESCRIPTION
By modifying port_handler.js and manifest.json, you can add the VendorID and ProductID corresponding to APM32 so that it can directly support the firmware download of APM32 series MCU，https://global.geehy.com/
Verified on APM32F405