### PR TITLE
Fix: Correctly determine number of PID profiles

### DIFF
--- a/src/js/tabs/pid_tuning.js
+++ b/src/js/tabs/pid_tuning.js
@@ -1709,9 +1709,8 @@ TABS.pid_tuning.initialize = function(callback) {
 
         function loadProfilesList() {
             var numberOfProfiles = 3;
-            if (semver.gte(CONFIG.apiVersion, "1.20.0") &&
-                CONFIG.numProfiles === 2) {
-                numberOfProfiles = 2;
+            if (semver.gte(CONFIG.apiVersion, "1.20.0")) {
+                numberOfProfiles = CONFIG.numProfiles;
             }
 
             var profileElements = [];


### PR DESCRIPTION
The logic for determining the number of PID profiles was flawed, preventing users from copying to profile 3.

This commit corrects the logic to trust the `numProfiles` value from the firmware when available (API version >= 1.20.0), and falls back to a default of 3 for older versions. This ensures the correct number of profiles is displayed and the copy functionality works as expected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed PID tuning profile configuration to properly apply profile count settings when using newer API versions. Previously, an unnecessary restriction prevented correct profile settings from being applied in certain scenarios. The updated logic now enables proper profile handling with improved compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->