### PR TITLE
Scope mixercalc CSS selectors to prevent PID tab style bleed-through

### DIFF
--- a/src/css/tabs/mixercalc.css
+++ b/src/css/tabs/mixercalc.css
@@ -35,13 +35,13 @@ td {
   border-collapse: collapse;
 }
 
-th {
+#tab-static th {
   background-color: #eee;
   text-align: center;
   padding: 2px 6px 2px 6px;
 }
 
-td {
+#tab-static td {
   text-align: center;
   padding: 4px;
 }


### PR DESCRIPTION
This PR scopes the mixer calculator CSS table header and cell styles to the static tab container (#tab-static) so they no longer apply globally across all tabs. This fixes broken PID tab header styling after visiting the motor-mix tab.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined CSS styling scope to prevent unintended style application outside the intended container.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->