### PR TITLE
Bump marked to 3.0.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "jquery-throttle-debounce": "^1.0.0",
     "jquery-ui-npm": "1.12.0",
     "lru_map": "^0.3.3",
-    "marked": "^2.0.7",
+    "marked": "3.0.8",
     "object-hash": "^3.0.0",
     "request": "^2.88.2",
     "serialport": "^13.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3401,10 +3401,10 @@ map-age-cleaner@^0.1.1:
   dependencies:
     p-defer "^1.0.0"
 
-marked@^2.0.7:
-  version "2.1.3"
-  resolved "https://registry.yarnpkg.com/marked/-/marked-2.1.3.tgz#bd017cef6431724fd4b27e0657f5ceb14bff3753"
-  integrity sha512-/Q+7MGzaETqifOMWYEA7HVMaZb4XbcRfaOzcSsHZEith83KGlvaSG33u0SKu89Mj5h+T8V2hM+8O45Qc5XTgwA==
+marked@3.0.8:
+  version "3.0.8"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-3.0.8.tgz#2785f0dc79cbdc6034be4bb4f0f0a396bd3f8aeb"
+  integrity sha512-0gVrAjo5m0VZSJb4rpL59K1unJAMb/hm8HRXqasD8VeC8m91ytDPMritgFSlKonfdt+rRYYpP/JfLxgIX8yoSw==
 
 matcher@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
Upgrade marked to the highest available 3.x release and validate markdown rendering for firmware release notes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the marked library dependency to version 3.0.8.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->