### PR TITLE
Upgrade marked to latest v18 with v4+ compatibility patch

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "jquery-throttle-debounce": "^1.0.0",
     "jquery-ui-npm": "1.12.0",
     "lru_map": "^0.3.3",
-    "marked": "^2.0.7",
+    "marked": "^18.0.0",
     "object-hash": "^3.0.0",
     "request": "^2.88.2",
     "serialport": "^13.0.0",

--- a/src/js/tabs/firmware_flasher.js
+++ b/src/js/tabs/firmware_flasher.js
@@ -69,7 +69,7 @@ TABS.firmware_flasher.initialize = function (callback) {
                     $('div.release_info .file').text(summary.file).prop('href', summary.url);
 
                     var formattedNotes = summary.notes.replace(/#(\d+)/g, '[#$1](https://github.com/emuflight/EmuFlight/pull/$1)');
-                    formattedNotes = marked(formattedNotes);
+                    formattedNotes = marked.parse(formattedNotes);
                     $('div.release_info .notes').html(formattedNotes);
                     $('div.release_info .notes').find('a').each(function() {
                         $(this).attr('target', '_blank');

--- a/src/main.html
+++ b/src/main.html
@@ -117,7 +117,7 @@
         }
 
         try {
-            window.marked = require('marked');
+            window.marked = require('marked').marked;
             console.log('[OK] marked loaded');
         } catch(e) {
             console.error('ERROR: Failed to load marked:', e.message);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3401,10 +3401,10 @@ map-age-cleaner@^0.1.1:
   dependencies:
     p-defer "^1.0.0"
 
-marked@^2.0.7:
-  version "2.1.3"
-  resolved "https://registry.yarnpkg.com/marked/-/marked-2.1.3.tgz#bd017cef6431724fd4b27e0657f5ceb14bff3753"
-  integrity sha512-/Q+7MGzaETqifOMWYEA7HVMaZb4XbcRfaOzcSsHZEith83KGlvaSG33u0SKu89Mj5h+T8V2hM+8O45Qc5XTgwA==
+marked@^18.0.0:
+  version "18.0.0"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-18.0.0.tgz#30c5b7629eb2253b8f6d83d94b376e63479076cc"
+  integrity sha512-2e7Qiv/HJSXj8rDEpgTvGKsP8yYtI9xXHKDnrftrmnrJPaFNM7VRb2YCzWaX4BP1iCJ/XPduzDJZMFoqTCcIMA==
 
 matcher@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
Bump marked to latest v18.0.0 and patch the loader and release note rendering path for marked (marked).marked and marked.parse().

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the markdown rendering library to a newer major version and adjusted code to ensure continued compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->