### PR TITLE
fix: add null check for BBL file save dialog cancellation

### DIFF
--- a/src/js/tabs/onboard_logging.js
+++ b/src/js/tabs/onboard_logging.js
@@ -484,6 +484,12 @@ TABS.onboard_logging.initialize = function (callback) {
                 return;
             }
             
+            // Handle user cancellation or missing fileEntry
+            if (!fileEntry) {
+                console.log('File dialog cancelled by user');
+                return;
+            }
+            
             // echo/console log path specified
             chrome.fileSystem.getDisplayPath(fileEntry, function(path) {
                 console.log('Dataflash dump file path: ' + path);


### PR DESCRIPTION
When users cancel the file save dialog, fileEntry is null, which causes a 'Cannot read properties of null (reading "createWriter")' error. This commit adds a null check to handle the cancellation gracefully by logging the action and returning early.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a bug in the onboarding logging process where cancelling the file selection dialog would cause the application to attempt subsequent file operations with invalid file data. The application now properly detects and handles cancelled file selections, gracefully stopping processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->