### PR TITLE
fix(html): replace self-closing non-void tags with explicit closing tags

### DIFF
--- a/src/tabs/auxiliary.html
+++ b/src/tabs/auxiliary.html
@@ -13,7 +13,7 @@
         <div class="toolbox">
             <form>
                 <input type="checkbox" id="switch-toggle-unused" name="switch-toggle-unused" class="toggle"></input>
-                <label for="switch-toggle-unused"><span i18n="auxiliaryToggleUnused" /></label>
+                <label for="switch-toggle-unused"><span i18n="auxiliaryToggleUnused" ></span></label>
             </form>
         </div>
 

--- a/src/tabs/configuration.html
+++ b/src/tabs/configuration.html
@@ -320,7 +320,7 @@
                                         </label>
                                     </div>
                                     <div class="gyro_alignment_inputs gyro_alignment_inputs_notfound">
-                                        <span class="message-negative" i18n="configurationSensorGyroToUseNotFound"/>
+                                        <span class="message-negative" i18n="configurationSensorGyroToUseNotFound"></span>
                                     </div>
                                 </div>
                                 <div class="sensor_align_content">

--- a/src/tabs/led_strip.html
+++ b/src/tabs/led_strip.html
@@ -141,22 +141,22 @@
                     <option value="5" i18n="ledStripModeColorsModeBaro"></option>
                 </select>
 
-                <button class="mode_color-0-0 dir-n" i18n="ledStripDirN"/>
-                <button class="mode_color-0-1 dir-e" i18n="ledStripDirE"/>
-                <button class="mode_color-0-2 dir-s" i18n="ledStripDirS"/>
-                <button class="mode_color-0-3 dir-w" i18n="ledStripDirW"/>
-                <button class="mode_color-0-4 dir-u" i18n="ledStripDirU"/>
-                <button class="mode_color-0-5 dir-d" i18n="ledStripDirD"/>
+                <button class="mode_color-0-0 dir-n" i18n="ledStripDirN"></button>
+                <button class="mode_color-0-1 dir-e" i18n="ledStripDirE"></button>
+                <button class="mode_color-0-2 dir-s" i18n="ledStripDirS"></button>
+                <button class="mode_color-0-3 dir-w" i18n="ledStripDirW"></button>
+                <button class="mode_color-0-4 dir-u" i18n="ledStripDirU"></button>
+                <button class="mode_color-0-5 dir-d" i18n="ledStripDirD"></button>
             </div>
 
             <div class="section" i18n="ledStripModesOrientationTitle"></div>
             <div class="directions">
-                <button class="dir-n" i18n="ledStripDirN"/>
-                <button class="dir-e" i18n="ledStripDirE"/>
-                <button class="dir-s" i18n="ledStripDirS"/>
-                <button class="dir-w" i18n="ledStripDirW"/>
-                <button class="dir-u" i18n="ledStripDirU"/>
-                <button class="dir-d" i18n="ledStripDirD"/>
+                <button class="dir-n" i18n="ledStripDirN"></button>
+                <button class="dir-e" i18n="ledStripDirE"></button>
+                <button class="dir-s" i18n="ledStripDirS"></button>
+                <button class="dir-w" i18n="ledStripDirW"></button>
+                <button class="dir-u" i18n="ledStripDirU"></button>
+                <button class="dir-d" i18n="ledStripDirD"></button>
             </div>
 
             <div class="colors">
@@ -180,23 +180,23 @@
 
             <div class="special_colors mode_colors">
                 <div class="section" i18n="ledStripModesSpecialColorsTitle"></div>
-                <button class="mode_color-6-0" i18n_title="colorGreen" i18n="ledStripModeColorsModeDisarmed"/>
-                <button class="mode_color-6-1" i18n_title="colorBlue" i18n="ledStripModeColorsModeArmed"/>
-                <button class="mode_color-6-2" i18n_title="colorWhite" i18n="ledStripModeColorsModeAnimation"/>
+                <button class="mode_color-6-0" i18n_title="colorGreen" i18n="ledStripModeColorsModeDisarmed"></button>
+                <button class="mode_color-6-1" i18n_title="colorBlue" i18n="ledStripModeColorsModeArmed"></button>
+                <button class="mode_color-6-2" i18n_title="colorWhite" i18n="ledStripModeColorsModeAnimation"></button>
                 <!-- button class="mode_color-6-3" i18n_title="colorBlack">Background</button -->
-                <button class="mode_color-6-4" i18n_title="colorBlack" i18n="ledStripModeColorsModeBlinkBg"/>
-                <button class="mode_color-6-5" i18n_title="colorRed" i18n="ledStripModeColorsModeGPSNoSats"/>
-                <button class="mode_color-6-6" i18n_title="colorOrange" i18n="ledStripModeColorsModeGPSNoLock"/>
-                <button class="mode_color-6-7" i18n_title="colorGreen" i18n="ledStripModeColorsModeGPSLocked"/>
+                <button class="mode_color-6-4" i18n_title="colorBlack" i18n="ledStripModeColorsModeBlinkBg"></button>
+                <button class="mode_color-6-5" i18n_title="colorRed" i18n="ledStripModeColorsModeGPSNoSats"></button>
+                <button class="mode_color-6-6" i18n_title="colorOrange" i18n="ledStripModeColorsModeGPSNoLock"></button>
+                <button class="mode_color-6-7" i18n_title="colorGreen" i18n="ledStripModeColorsModeGPSLocked"></button>
             </div>
 
             <div class="section" i18n="ledStripWiring"></div>
             <div class="wiringMode">
-                <button class="funcWire w100" i18n="ledStripWiringMode"/>
+                <button class="funcWire w100" i18n="ledStripWiringMode"></button>
             </div>
             <div class="wiringControls">
-                <button class="funcWireClearSelect w50" i18n="ledStripWiringClearControl"/>
-                <button class="funcWireClear w50" i18n="ledStripWiringClearAllControl"/>
+                <button class="funcWireClearSelect w50" i18n="ledStripWiringClearControl"></button>
+                <button class="funcWireClear w50" i18n="ledStripWiringClearAllControl"></button>
             </div>
             <p i18n="ledStripWiringMessage"></p>
         </div>

--- a/src/tabs/led_strip.html
+++ b/src/tabs/led_strip.html
@@ -29,7 +29,7 @@
             <div class="block"></div>
         </div>
         <div class="colorDefineSliders">
-            <div class="" i18n="ledStripColorSetupTitle"/>
+            <div class="" i18n="ledStripColorSetupTitle"></div>
             <div class="colorDefineSliderContainer">
                 <Label class="colorDefineSliderLabel" i18n="ledStripH"></Label>
                 <input class="sliderHSV" type="range" min="0" max="359" value="0">
@@ -60,14 +60,14 @@
             <div class="select">
                 <span class="color_section" i18n="ledStripFunctionTitle"></span>
                 <select class="functionSelect">
-                    <option value="" i18n="ledStripFunctionNoneOption"/>
-                    <option value="function-c" class="" i18n="ledStripFunctionColorOption"/>
-                    <option value="function-f" class="" i18n="ledStripFunctionModesOption"/>
-                    <option value="function-a" class="" i18n="ledStripFunctionArmOption"/>
-                    <option value="function-l" class="extra_functions20" i18n="ledStripFunctionBatteryOption"/>
-                    <option value="function-s" class="extra_functions20" i18n="ledStripFunctionRSSIOption"/>
-                    <option value="function-g" class="extra_functions20" i18n="ledStripFunctionGPSOption"/>
-                    <option value="function-r" class="" i18n="ledStripFunctionRingOption"/>
+                    <option value="" i18n="ledStripFunctionNoneOption"></option>
+                    <option value="function-c" class="" i18n="ledStripFunctionColorOption"></option>
+                    <option value="function-f" class="" i18n="ledStripFunctionModesOption"></option>
+                    <option value="function-a" class="" i18n="ledStripFunctionArmOption"></option>
+                    <option value="function-l" class="extra_functions20" i18n="ledStripFunctionBatteryOption"></option>
+                    <option value="function-s" class="extra_functions20" i18n="ledStripFunctionRSSIOption"></option>
+                    <option value="function-g" class="extra_functions20" i18n="ledStripFunctionGPSOption"></option>
+                    <option value="function-r" class="" i18n="ledStripFunctionRingOption"></option>
                 </select>
             </div>
 
@@ -78,18 +78,18 @@
                     <input type="checkbox" name="ThrottleHue" class="toggle function-t" />
                     <label>
                         <select class="auxSelect">
-                            <option value="0" class="" i18n="controlAxisRoll"/>
-                            <option value="1" class="" i18n="controlAxisPitch"/>
-                            <option value="2" class="" i18n="controlAxisYaw"/>
-                            <option value="3" class="" i18n="controlAxisThrottle"/>
-                            <option value="4" class="" i18n="controlAxisAux1"/>
-                            <option value="5" class="" i18n="controlAxisAux2"/>
-                            <option value="6" class="" i18n="controlAxisAux3"/>
-                            <option value="7" class="" i18n="controlAxisAux4"/>
-                            <option value="8" class="" i18n="controlAxisAux5"/>
-                            <option value="9" class="" i18n="controlAxisAux6"/>
-                            <option value="10" class="" i18n="controlAxisAux7"/>
-                            <option value="11" class="" i18n="controlAxisAux8"/>
+                            <option value="0" class="" i18n="controlAxisRoll"></option>
+                            <option value="1" class="" i18n="controlAxisPitch"></option>
+                            <option value="2" class="" i18n="controlAxisYaw"></option>
+                            <option value="3" class="" i18n="controlAxisThrottle"></option>
+                            <option value="4" class="" i18n="controlAxisAux1"></option>
+                            <option value="5" class="" i18n="controlAxisAux2"></option>
+                            <option value="6" class="" i18n="controlAxisAux3"></option>
+                            <option value="7" class="" i18n="controlAxisAux4"></option>
+                            <option value="8" class="" i18n="controlAxisAux5"></option>
+                            <option value="9" class="" i18n="controlAxisAux6"></option>
+                            <option value="10" class="" i18n="controlAxisAux7"></option>
+                            <option value="11" class="" i18n="controlAxisAux8"></option>
                         </select>
                         <span class="labelSelect" i18n="controlAxisThrottle"></span>
                     </label>
@@ -130,15 +130,15 @@
             </div>
 
             <div class="mode_colors">
-                <div class="section" i18n="ledStripModeColorsTitle"/>
+                <div class="section" i18n="ledStripModeColorsTitle"></div>
 
                 <select class="modeSelect">
-                    <option value="0" i18n="ledStripModeColorsModeOrientation"/>
-                    <option value="1" i18n="ledStripModeColorsModeHeadfree"/>
-                    <option value="2" i18n="ledStripModeColorsModeHorizon"/>
-                    <option value="3" i18n="ledStripModeColorsModeAngle"/>
-                    <option value="4" i18n="ledStripModeColorsModeMag"/>
-                    <option value="5" i18n="ledStripModeColorsModeBaro"/>
+                    <option value="0" i18n="ledStripModeColorsModeOrientation"></option>
+                    <option value="1" i18n="ledStripModeColorsModeHeadfree"></option>
+                    <option value="2" i18n="ledStripModeColorsModeHorizon"></option>
+                    <option value="3" i18n="ledStripModeColorsModeAngle"></option>
+                    <option value="4" i18n="ledStripModeColorsModeMag"></option>
+                    <option value="5" i18n="ledStripModeColorsModeBaro"></option>
                 </select>
 
                 <button class="mode_color-0-0 dir-n" i18n="ledStripDirN"/>
@@ -149,7 +149,7 @@
                 <button class="mode_color-0-5 dir-d" i18n="ledStripDirD"/>
             </div>
 
-            <div class="section" i18n="ledStripModesOrientationTitle"/>
+            <div class="section" i18n="ledStripModesOrientationTitle"></div>
             <div class="directions">
                 <button class="dir-n" i18n="ledStripDirN"/>
                 <button class="dir-e" i18n="ledStripDirE"/>
@@ -179,7 +179,7 @@
             </div>
 
             <div class="special_colors mode_colors">
-                <div class="section" i18n="ledStripModesSpecialColorsTitle"/>
+                <div class="section" i18n="ledStripModesSpecialColorsTitle"></div>
                 <button class="mode_color-6-0" i18n_title="colorGreen" i18n="ledStripModeColorsModeDisarmed"/>
                 <button class="mode_color-6-1" i18n_title="colorBlue" i18n="ledStripModeColorsModeArmed"/>
                 <button class="mode_color-6-2" i18n_title="colorWhite" i18n="ledStripModeColorsModeAnimation"/>
@@ -190,7 +190,7 @@
                 <button class="mode_color-6-7" i18n_title="colorGreen" i18n="ledStripModeColorsModeGPSLocked"/>
             </div>
 
-            <div class="section" i18n="ledStripWiring"/>
+            <div class="section" i18n="ledStripWiring"></div>
             <div class="wiringMode">
                 <button class="funcWire w100" i18n="ledStripWiringMode"/>
             </div>
@@ -198,7 +198,7 @@
                 <button class="funcWireClearSelect w50" i18n="ledStripWiringClearControl"/>
                 <button class="funcWireClear w50" i18n="ledStripWiringClearAllControl"/>
             </div>
-            <p i18n="ledStripWiringMessage"/>
+            <p i18n="ledStripWiringMessage"></p>
         </div>
 
         <div class="colorControls">

--- a/src/tabs/osd.html
+++ b/src/tabs/osd.html
@@ -1,18 +1,18 @@
 <div class="tab-osd toolbar_fixed_bottom">
         <div class="content_wrapper">
             <h1 class="tab_title">
-                <span i18n="osdSetupTitle" />
+                <span i18n="osdSetupTitle" ></span>
             </h1>
             <div class="cf_doc_version_bt">
                 <a id="button-documentation" href="" target="_blank"></a>
             </div>
             <div class="unsupported hide">
-                <p class="note" i18n="osdSetupUnsupportedNote1" />
-                <p class="note" i18n="osdSetupUnsupportedNote2" />
+                <p class="note" i18n="osdSetupUnsupportedNote1" ></p>
+                <p class="note" i18n="osdSetupUnsupportedNote2" ></p>
             </div>
             <div class="supported hide">
                 <div style="margin-bottom: 20px;">
-                    <p class="note" i18n="osdSetupPreviewHelp" />
+                    <p class="note" i18n="osdSetupPreviewHelp" ></p>
                 </div>
                 <div class="cf_column third_left -third_left_osd elements requires-osd-feature">
                     <div class="spacer_right">
@@ -22,7 +22,7 @@
                                     <span class="osd-profiles-header cf_tip" i18n_title="osdSetupProfilesTitle" >
                                         <!--  Generated profiles header here -->
                                     </span>
-                                    <span i18n="osdSetupElementsTitle" />
+                                    <span i18n="osdSetupElementsTitle" ></span>
                                 </div>
                             </div>
                             <div class="spacer_box">
@@ -36,7 +36,7 @@
                         <div class="gui_box_titlebar image">
                             <div class="spacer_box_title">
                                <span class="cf_tip" i18n_title="osdSetupPreviewForTitle">
-                                   <label id="osdprofile-selector-label" i18n="osdSetupPreviewSelectProfileTitle"/>
+                                   <label id="osdprofile-selector-label" i18n="osdSetupPreviewSelectProfileTitle"></label>
                                    <select class="osdprofile-selector">
                                        <!--  Populated at runtime -->
                                    </select>
@@ -54,7 +54,7 @@
                         </div>
                         <div class="gui_box_bottombar">
                             <div class="spacer_box_title">
-                                <span i18n="osdSetupPreviewTitle" />
+                                <span i18n="osdSetupPreviewTitle" ></span>
                             </div>
                         </div>
                     </div>
@@ -62,10 +62,10 @@
                     <div class="cf_column third_right -third_right_osd" -style="width: calc(100% - 377px);">
                         <div class="gui_box osdprofile-selected-container grey requires-max7456">
                             <div class="gui_box_titlebar cf_tip">
-                                <div class="spacer_box_title" i18n="osdSetupSelectedProfileTitle" />
+                                <div class="spacer_box_title" i18n="osdSetupSelectedProfileTitle" ></div>
                             </div>
                             <div class="spacer_box">
-                                <label i18n="osdSetupSelectedProfileLabel"/>
+                                <label i18n="osdSetupSelectedProfileLabel"></label>
                                 <select class="osdprofile-active">
                                     <!--  Populated at runtime -->
                                 </select>
@@ -73,7 +73,7 @@
                         </div>
                         <div class="gui_box videomode-container grey requires-max7456">
                             <div class="gui_box_titlebar cf_tip">
-                                <div class="spacer_box_title" i18n="osdSetupVideoFormatTitle" />
+                                <div class="spacer_box_title" i18n="osdSetupVideoFormatTitle" ></div>
                             </div>
                             <div class="spacer_box">
                                 <div class="video-types"></div>
@@ -81,7 +81,7 @@
                         </div>
                         <div class="gui_box grey units-container requires-osd-feature" style="display:none;">
                             <div class="gui_box_titlebar cf_tip">
-                                <div class="spacer_box_title" i18n="osdSetupUnitsTitle" />
+                                <div class="spacer_box_title" i18n="osdSetupUnitsTitle" ></div>
                             </div>
                             <div class="spacer_box">
                                 <div class="units"></div>
@@ -89,7 +89,7 @@
                         </div>
                         <div class="gui_box grey timers-container requires-osd-feature" style="display:none;">
                             <div class="gui_box_titlebar cf_tip" style="margin-bottom: 0px;">
-                                <div class="spacer_box_title" i18n="osdSetupTimersTitle" />
+                                <div class="spacer_box_title" i18n="osdSetupTimersTitle" ></div>
                             </div>
                             <div class="spacer_box">
                                 <div id="timer-fields" class="switchable-fields"></div>
@@ -97,7 +97,7 @@
                         </div>
                         <div class="gui_box grey alarms-container requires-osd-feature isexpertmode" style="display:none;">
                             <div class="gui_box_titlebar cf_tip">
-                                <div class="spacer_box_title" i18n="osdSetupAlarmsTitle" />
+                                <div class="spacer_box_title" i18n="osdSetupAlarmsTitle" ></div>
                             </div>
                             <div class="spacer_box">
                                 <div class="alarms"></div>
@@ -106,7 +106,7 @@
                         <div class="gui_box grey warnings-container requires-osd-feature isexpertmode" style="display:none;">
                             <div class="gui_box_titlebar cf_tip" style="margin-bottom: 0px;">
                                 <div class="spacer_box_title">
-                                  <div class="spacer_box_title" i18n="osdSetupWarningsTitle" />
+                                  <div class="spacer_box_title" i18n="osdSetupWarningsTitle" ></div>
                                 </div>
                             </div>
                             <div class="spacer_box">
@@ -116,7 +116,7 @@
                         <div class="gui_box grey stats-container requires-osd-feature isexpertmode" style="display:none;">
                             <div class="gui_box_titlebar"
                                  style="margin-bottom: 0px;">
-                                <div class="spacer_box_title" i18n="osdSetupStatsTitle" />
+                                <div class="spacer_box_title" i18n="osdSetupStatsTitle" ></div>
                             </div>
                             <div class="spacer_box">
                                 <div id="post-flight-stat-fields" class="switchable-fields"></div>
@@ -124,7 +124,7 @@
                         </div>
                         <div class="gui_box grey" style="display:none;">
                             <div class="gui_box_titlebar">
-                                <div class="spacer_box_title" i18n="osdSetupVtxTitle" />
+                                <div class="spacer_box_title" i18n="osdSetupVtxTitle" ></div>
                             </div>
                             <div class="spacer_box">
                                 <div class="vtx-settings"></div>
@@ -132,7 +132,7 @@
                         </div>
                         <div class="gui_box grey" style="display:none;">
                             <div class="gui_box_titlebar">
-                                <div class="spacer_box_title" i18n="osdSetupCraftNameTitle" />
+                                <div class="spacer_box_title" i18n="osdSetupCraftNameTitle" ></div>
                             </div>
                             <div class="spacer_box">
                                 <div class="callsign"></div>
@@ -144,20 +144,20 @@
                 <!-- Font Manager dialog -->
                 <div id="fontmanagercontent" style="display:none; width:720px;">
                     <div class="font-picker" style="margin-bottom: 10px;">
-                        <h1 class="tab_title" i18n="osdSetupFontPresets" />
+                        <h1 class="tab_title" i18n="osdSetupFontPresets" ></h1>
                         <!-- Font preview and list -->
                         <label class="font-manager-version-info"></label>
                         <div class="content_wrapper font-preview"></div>
                         <div class="fontpresets_wrapper">
                             <label id="font-selector-label" i18n="osdSetupFontPresetsSelector"></label>
                             <select class="fontpresets">
-                                <option value="-1" disabled i18n="osdSetupFontPresetsSelectorCustomOption" />
+                                <option value="-1" disabled i18n="osdSetupFontPresetsSelectorCustomOption" ></option>
                                 <!-- Other values populated at runtime -->
                             </select>
                             <span id="font-selector-span" i18n="osdSetupFontPresetsSelectorOr"> Or </span>
                         </div>
                         <!-- Boot logo setup -->
-                        <h1 class="tab_title" i18n="osdSetupCustomLogoTitle" />
+                        <h1 class="tab_title" i18n="osdSetupCustomLogoTitle" ></h1>
                         <div id="font-logo-preview-container" class="content_wrapper">
                             <div id="font-logo-preview">
                                 <!-- this will be resized at runtime -->
@@ -174,7 +174,7 @@
                         <div class="clear-both"></div>
                         <!-- Replace logo button -->
                         <div class="default_btn" style="width:100%; float:left;">
-                            <a class="replace_logo" i18n="osdSetupCustomLogoOpenImageButton" />
+                            <a class="replace_logo" i18n="osdSetupCustomLogoOpenImageButton" ></a>
                         </div>
                         <!-- Upload progress bar -->
                         <div class="info">
@@ -186,16 +186,16 @@
                     <!-- Upload button -->
                     <div class="default_btn green" style="width:100%; float:left;
                         ">
-                        <a class="flash_font active" i18n="osdSetupUploadFont" />
+                        <a class="flash_font active" i18n="osdSetupUploadFont" ></a>
                     </div>
                 </div>
 
                 <div class="content_toolbar supported hide" style="left:0;">
                     <div class="btn save">
-                        <a class="active save" href="#" i18n="osdSetupSave" />
+                        <a class="active save" href="#" i18n="osdSetupSave" ></a>
                     </div>
                     <div class="btn requires-max7456">
-                        <a class="fonts" id="fontmanager" href="#" i18n="osdSetupFontManager" />
+                        <a class="fonts" id="fontmanager" href="#" i18n="osdSetupFontManager" ></a>
                     </div>
                 </div>
             </div>

--- a/src/tabs/ports.html
+++ b/src/tabs/ports.html
@@ -14,7 +14,7 @@
             <table class="ports spacebottom">
                 <thead>
                     <tr>
-                        <td i18n="portsIdentifier"/>
+                        <td i18n="portsIdentifier"></td>
                         <td i18n="portsConfiguration">
                         <td i18n="portsSerialRx">
                         <td i18n="portsTelemetryOut">

--- a/src/tabs/power.html
+++ b/src/tabs/power.html
@@ -93,7 +93,7 @@
 
     <div class="content_toolbar">
         <div class="btn calibration">
-            <a class="calibrationmanager" id="calibrationmanager" href="#" i18n="powerCalibrationManagerButton" />
+            <a class="calibrationmanager" id="calibrationmanager" href="#" i18n="powerCalibrationManagerButton" ></a>
         </div>
         <div class="btn save_btn">
             <a class="save" href="#" i18n="powerButtonSave"></a>
@@ -248,7 +248,7 @@
         </div>
     </div>
     <div class="default_btn margin-top5">
-        <a class="calibrate" id="calibrate" href="#" i18n="powerCalibrationSave" />
+        <a class="calibrate" id="calibrate" href="#" i18n="powerCalibrationSave" ></a>
     </div>
 </div>
 
@@ -276,9 +276,9 @@
     </div>
     
     <div class="default_btn margin-top5">
-        <a class="applycalibration" id="applycalibration" href="#" i18n="powerCalibrationApply" />
+        <a class="applycalibration" id="applycalibration" href="#" i18n="powerCalibrationApply" ></a>
     </div>
     <div class="default_btn">
-        <a class="discardcalibration" id="discardcalibration" href="#" i18n="powerCalibrationDiscard" />
+        <a class="discardcalibration" id="discardcalibration" href="#" i18n="powerCalibrationDiscard" ></a>
     </div>
 </div> 

--- a/src/tabs/power.html
+++ b/src/tabs/power.html
@@ -98,7 +98,7 @@
         <div class="btn save_btn">
             <a class="save" href="#" i18n="powerButtonSave"></a>
         </div>
-        
+
     </div>
 </div>
 
@@ -260,25 +260,25 @@
     </div>
     <div class="vbatcalibration">
         <div class="number tab_title">
-            <label> 
+            <label>
                 <span i18n="powerVoltageCalibratedScale"></span>
-                <output type="number" name="vbatnewscale"></output> 
+                <output type="number" name="vbatnewscale"></output>
             </label>
         </div>
     </div>
     <div class="amperagecalibration">
         <div class="number tab_title">
-            <label> 
+            <label>
                 <span i18n="powerAmperageCalibratedScale"></span>
-                <output type="number" name="amperagenewscale"></output> 
+                <output type="number" name="amperagenewscale"></output>
             </label>
         </div>
     </div>
-    
+
     <div class="default_btn margin-top5">
         <a class="applycalibration" id="applycalibration" href="#" i18n="powerCalibrationApply" ></a>
     </div>
     <div class="default_btn">
         <a class="discardcalibration" id="discardcalibration" href="#" i18n="powerCalibrationDiscard" ></a>
     </div>
-</div> 
+</div>

--- a/src/tabs/receiver.html
+++ b/src/tabs/receiver.html
@@ -42,15 +42,15 @@
                     <tr>
                         <td>
                             <input type="number" name="stick_min" min="1000" max="1200" style="width:80%;"/>
-                            <div class="helpicon cf_tip" i18n_title="receiverHelpStickMin"/>
+                            <div class="helpicon cf_tip" i18n_title="receiverHelpStickMin"></div>
                         </td>
                         <td>
                             <input type="number" name="stick_center" min="1401" max="1599" style="width:70%;"/>
-                            <div class="helpicon cf_tip" i18n_title="receiverHelpStickCenter"/>
+                            <div class="helpicon cf_tip" i18n_title="receiverHelpStickCenter"></div>
                         </td>
                         <td>
                             <input type="number" name="stick_max" min="1800" max="2000" style="width:80%;"/>
-                            <div class="helpicon cf_tip" i18n_title="receiverHelpStickMax"/>
+                            <div class="helpicon cf_tip" i18n_title="receiverHelpStickMax"></div>
                         </td>
                     </tr>
                 </table>
@@ -65,15 +65,15 @@
                     <tr>
                         <td>
                             <input type="number" name="deadband" step="1" min="0" max="32" style="width:70%;"/>
-                            <div class="helpicon cf_tip" i18n_title="receiverHelpDeadband"/>
+                            <div class="helpicon cf_tip" i18n_title="receiverHelpDeadband"></div>
                         </td>
                         <td>
                             <input type="number" name="yaw_deadband" step="1" min="0" max="100" style="width:80%;"/>
-                            <div class="helpicon cf_tip" i18n_title="receiverHelpYawDeadband"/>
+                            <div class="helpicon cf_tip" i18n_title="receiverHelpYawDeadband"></div>
                         </td>
                         <td>
                             <input type="number" name="3ddeadbandthrottle" step="1" min="0" max="100" style="width:80%;"/>
-                            <div class="helpicon cf_tip" i18n_title="receiverHelp3dDeadbandThrottle"/>
+                            <div class="helpicon cf_tip" i18n_title="receiverHelp3dDeadbandThrottle"></div>
                         </td>
                     </tr>
                 </table>
@@ -86,8 +86,8 @@
                     <tr class="rc-smoothing-type">
                         <td>
                             <select name="rcSmoothing-select" style="width: 90%">
-                                <option value="0" i18n="receiverRcSmoothingInterpolation"/>
-                                <option value="1" i18n="receiverRcSmoothingFilter"/>
+                                <option value="0" i18n="receiverRcSmoothingInterpolation"></option>
+                                <option value="1" i18n="receiverRcSmoothingFilter"></option>
                             </select>
                         </td>
                         <td style="border-right: none" colspan="2">
@@ -119,8 +119,8 @@
                     <tr class="rcSmoothing-input-manual">
                         <td>
                             <select name="rcSmoothing-input-manual-select" style="width: 90%">
-                                <option value="0" i18n="receiverRcSmoothingAuto"/>
-                                <option value="1" i18n="receiverRcSmoothingManual"/>
+                                <option value="0" i18n="receiverRcSmoothingAuto"></option>
+                                <option value="1" i18n="receiverRcSmoothingManual"></option>
                             </select>
                         </td>
                         <td style="border-right: none">
@@ -167,8 +167,8 @@
                     <tr class="rcSmoothing-derivative-manual  rc-smooth-deriv-hide">
                         <td>
                             <select name="rcSmoothing-input-derivative-select" style="width: 90%">
-                                <option value="0" i18n="receiverRcSmoothingAuto"/>
-                                <option value="1" i18n="receiverRcSmoothingManual"/>
+                                <option value="0" i18n="receiverRcSmoothingAuto"></option>
+                                <option value="1" i18n="receiverRcSmoothingManual"></option>
                             </select>
                         </td>
                         <td style="border-right: none">
@@ -197,7 +197,7 @@
                     <tr class="rcSmoothing-input-type rc-smooth-deriv-hide">
                         <td style="border-right: none">
                             <select name="rcSmoothingDerivativeType-select" style="width: 90%; margin-left: 5px">
-                                <option value="0" i18n="receiverRcSmoothingDerivativeTypeOff"/>
+                                <option value="0" i18n="receiverRcSmoothingDerivativeTypeOff"></option>
                                 <option value="1">PT1</option>
                                 <option value="2">BIQUAD</option>
                             </select>
@@ -216,10 +216,10 @@
                     <tr class="rcInterpolation">
                         <td>
                             <select name="rcInterpolation-select">
-                                <option value="0" i18n="receiverRcInterpolationOff"/>
-                                <option value="1" i18n="receiverRcInterpolationDefault"/>
-                                <option value="2" i18n="receiverRcInterpolationAuto"/>
-                                <option value="3" i18n="receiverRcInterpolationManual"/>
+                                <option value="0" i18n="receiverRcInterpolationOff"></option>
+                                <option value="1" i18n="receiverRcInterpolationDefault"></option>
+                                <option value="2" i18n="receiverRcInterpolationAuto"></option>
+                                <option value="3" i18n="receiverRcInterpolationManual"></option>
                             </select>
                         </td>
                         <td>

--- a/src/tabs/sensors.html
+++ b/src/tabs/sensors.html
@@ -13,10 +13,10 @@
         <div class="gui_box">
             <div class="info">
                 <div class="checkboxes">
-                    <label><input type="checkbox" name="gyro_on" class="first" /><span i18n="sensorsGyroSelect"/></label> <label><input
-                        type="checkbox" name="accel_on" /><span i18n="sensorsAccelSelect"/></label> <label><input type="checkbox"
-                        name="mag_on" /><span i18n="sensorsMagSelect"/></label> <label><input type="checkbox" name="baro_on" /><span i18n="sensorsBaroSelect"/></label> <label><input
-                        type="checkbox" name="sonar_on" /><span i18n="sensorsSonarSelect"/></label> <label><input type="checkbox" name="debug_on" /><span i18n="sensorsDebugSelect"/></label>
+                    <label><input type="checkbox" name="gyro_on" class="first" /><span i18n="sensorsGyroSelect"></span></label> <label><input
+                        type="checkbox" name="accel_on" /><span i18n="sensorsAccelSelect"></span></label> <label><input type="checkbox"
+                        name="mag_on" /><span i18n="sensorsMagSelect"></span></label> <label><input type="checkbox" name="baro_on" /><span i18n="sensorsBaroSelect"></span></label> <label><input
+                        type="checkbox" name="sonar_on" /><span i18n="sensorsSonarSelect"></span></label> <label><input type="checkbox" name="debug_on" /><span i18n="sensorsDebugSelect"></span></label>
                 </div>
             </div>
         </div>
@@ -226,7 +226,7 @@
         <div class="wrapper debug">
             <div class="gui_box grey">
                 <div class="plot_control">
-                    <div class="title"><span i18n="sensorsDebugTitle"/> 0</div>
+                    <div class="title"><span i18n="sensorsDebugTitle"></span> 0</div>
                     <dl>
                         <dt i18n="sensorsRefresh"></dt>
                         <dd class="rate">
@@ -255,7 +255,7 @@
         </svg>
                 <div class="clear-both"></div>
                 <div class="plot_control">
-                    <div class="title"><span i18n="sensorsDebugTitle"/> 1</div>
+                    <div class="title"><span i18n="sensorsDebugTitle"></span> 1</div>
                     <dl>
                         <dt>X:</dt>
                         <dd class="x">blue</dd>
@@ -270,7 +270,7 @@
         </svg>
                 <div class="clear-both"></div>
                 <div class="plot_control">
-                    <div class="title"><span i18n="sensorsDebugTitle"/> 2</div>
+                    <div class="title"><span i18n="sensorsDebugTitle"></span> 2</div>
                     <dl>
                         <dt>X:</dt>
                         <dd class="x">0</dd>
@@ -285,7 +285,7 @@
         </svg>
                 <div class="clear-both"></div>
                 <div class="plot_control">
-                    <div class="title"><span i18n="sensorsDebugTitle"/> 3</div>
+                    <div class="title"><span i18n="sensorsDebugTitle"></span> 3</div>
                     <dl>
                         <dt>X:</dt>
                         <dd class="x">0</dd>


### PR DESCRIPTION
Fixes malformed HTML across 8 tab files where non-void elements used self-closing syntax (e.g. <span/>) which causes mis-nested DOM structure in the browser's HTML5 parser, including the undefined.mcm OSD error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Updated HTML template markup syntax across multiple configuration tabs for improved standards compliance. No changes to user interface or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->