### PR TITLE
fix: robust DFU detection after reboot

### DIFF
--- a/src/js/protocols/stm32.js
+++ b/src/js/protocols/stm32.js
@@ -100,14 +100,24 @@ STM32_protocol.prototype.connect = function (port, baud, hex, options, callback)
                 serial.send(bufferOut, function () {
                     serial.disconnect(function (result) {
                         if (result) {
-                            // delay to allow board to boot in bootloader mode
-                            // required to detect if a DFU device appears
-                            setTimeout(function() {
-                                // refresh device list
+                            // Poll for DFU device after reboot. A single fixed delay is
+                            // insufficient on slow systems (Windows VMs, installed packages)
+                            // where USB re-enumeration takes longer than 1 second.
+                            // Poll every 250ms for up to 5 seconds before falling back.
+                            var dfuPollAttempt = 0;
+                            var DFU_POLL_INTERVAL = 250;
+                            var DFU_POLL_MAX = 20;
+
+                            function pollForDFU() {
+                                dfuPollAttempt++;
                                 PortHandler.check_usb_devices(function(dfu_available) {
-                                    if(dfu_available) {
+                                    if (dfu_available) {
+                                        console.log('STM32 - DFU detected after ' + (dfuPollAttempt * DFU_POLL_INTERVAL) + 'ms');
                                         STM32DFU.connect(usbDevices, hex, options, self.callback);
+                                    } else if (dfuPollAttempt < DFU_POLL_MAX) {
+                                        setTimeout(pollForDFU, DFU_POLL_INTERVAL);
                                     } else {
+                                        console.log('STM32 - DFU not detected after ' + (DFU_POLL_MAX * DFU_POLL_INTERVAL) + 'ms, trying serial...');
                                         serial.connect(port, {bitrate: self.baud, parityBit: 'even', stopBits: 'one'}, function (openInfo) {
                                             if (openInfo) {
                                                 self.initialize();
@@ -118,7 +128,10 @@ STM32_protocol.prototype.connect = function (port, baud, hex, options, callback)
                                         });
                                     }
                                 });
-                            }, 1000);
+                            }
+
+                            // Initial 500ms delay for the board to begin re-enumeration
+                            setTimeout(pollForDFU, 500);
                         } else {
                             GUI.connect_lock = false;
                         }


### PR DESCRIPTION
Poll for DFU device up to 5s after reboot to handle slow USB re-enumeration (fixes first-try flash failures on Windows VM and .deb installs).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved STM32 device reboot detection reliability through adaptive polling instead of fixed delays, providing more consistent firmware update operations. Enhanced error recovery and fallback handling ensure stable connections when device detection is delayed or unsuccessful.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->