### PR TITLE
fix/bugs and quality of life

### DIFF
--- a/forge.config.js
+++ b/forge.config.js
@@ -80,6 +80,7 @@ module.exports = {
         options: {
           maintainer: 'EmuFlight',
           homepage: 'https://github.com/EmuFlight/EmuConfigurator',
+          icon: path.resolve(__dirname, 'assets/linux/icon/emu_icon_128.png'),
         },
       },
     },
@@ -89,6 +90,7 @@ module.exports = {
       config: {
         options: {
           homepage: 'https://github.com/EmuFlight/EmuConfigurator',
+          icon: path.resolve(__dirname, 'assets/linux/icon/emu_icon_128.png'),
         },
       },
     },

--- a/main.js
+++ b/main.js
@@ -188,6 +188,8 @@ const PREFERRED_WINDOW_HEIGHT = 1080;
 const CONFIG_DIR = path.join(app.getPath('userData'), 'config');
 const APP_CONFIG_FILE = path.join(CONFIG_DIR, 'config.json');
 const DEFAULT_ZOOM_LEVEL = 0; // Ctrl+0 actual size
+const MIN_ZOOM_LEVEL = -9;
+const MAX_ZOOM_LEVEL = 9;
 
 // Ensure config directory exists
 function ensureConfigDir() {
@@ -937,7 +939,7 @@ function createWindow() {
     if (_resizeZoomTimer) clearTimeout(_resizeZoomTimer);
     _resizeZoomTimer = setTimeout(() => {
       if (!win.isDestroyed()) {
-        const savedZoom = loadConfig().zoomLevel;
+        const savedZoom = Math.max(MIN_ZOOM_LEVEL, Math.min(MAX_ZOOM_LEVEL, loadConfig().zoomLevel));
         if (win.webContents.getZoomLevel() !== savedZoom) {
           win.webContents.setZoomLevel(savedZoom);
         }
@@ -964,14 +966,18 @@ function createWindow() {
     }
     
     // Load saved zoom level or use default (Ctrl+0 actual size)
-    const savedZoom = loadConfig().zoomLevel;
+    const savedZoom = Math.max(MIN_ZOOM_LEVEL, Math.min(MAX_ZOOM_LEVEL, loadConfig().zoomLevel));
     win.webContents.setZoomLevel(savedZoom);
   });
   
   // Save zoom level when it changes via mouse wheel
   win.webContents.on('zoom-changed', (event, direction) => {
     const newLevel = win.webContents.getZoomLevel();
-    saveConfig({ zoomLevel: newLevel });
+    const clampedLevel = Math.max(MIN_ZOOM_LEVEL, Math.min(MAX_ZOOM_LEVEL, newLevel));
+    if (newLevel !== clampedLevel) {
+      win.webContents.setZoomLevel(clampedLevel);
+    }
+    saveConfig({ zoomLevel: clampedLevel });
   });
 
   // Intercept new window requests (e.g., target="_blank" links) and open in system browser
@@ -992,14 +998,14 @@ function createWindow() {
   win.webContents.on('devtools-opened', () => {
     setTimeout(() => {
       if (!win.isDestroyed()) {
-        win.webContents.setZoomLevel(loadConfig().zoomLevel);
+        win.webContents.setZoomLevel(Math.max(MIN_ZOOM_LEVEL, Math.min(MAX_ZOOM_LEVEL, loadConfig().zoomLevel)));
       }
     }, 150);
   });
 
   win.webContents.on('devtools-closed', () => {
     if (!win.isDestroyed()) {
-      win.webContents.setZoomLevel(loadConfig().zoomLevel);
+      win.webContents.setZoomLevel(Math.max(MIN_ZOOM_LEVEL, Math.min(MAX_ZOOM_LEVEL, loadConfig().zoomLevel)));
     }
   });
 
@@ -1011,18 +1017,19 @@ function createWindow() {
     const code = input.code;
     if (code === 'Equal' || code === 'NumpadAdd') {
       event.preventDefault();
-      const level = win.webContents.getZoomLevel() + 1;
+      const level = Math.min(MAX_ZOOM_LEVEL, win.webContents.getZoomLevel() + 1);
       win.webContents.setZoomLevel(level);
       saveConfig({ zoomLevel: level });
     } else if (code === 'Minus' || code === 'NumpadSubtract') {
       event.preventDefault();
-      const level = win.webContents.getZoomLevel() - 1;
+      const level = Math.max(MIN_ZOOM_LEVEL, win.webContents.getZoomLevel() - 1);
       win.webContents.setZoomLevel(level);
       saveConfig({ zoomLevel: level });
     } else if (code === 'Digit0' || code === 'Numpad0') {
       event.preventDefault();
-      win.webContents.setZoomLevel(DEFAULT_ZOOM_LEVEL);
-      saveConfig({ zoomLevel: DEFAULT_ZOOM_LEVEL });
+      const level = Math.max(MIN_ZOOM_LEVEL, Math.min(MAX_ZOOM_LEVEL, DEFAULT_ZOOM_LEVEL));
+      win.webContents.setZoomLevel(level);
+      saveConfig({ zoomLevel: level });
     }
   });
 

--- a/main.js
+++ b/main.js
@@ -1011,27 +1011,30 @@ function createWindow() {
     win.webContents.openDevTools();
   }
 
+  function applySavedZoom(win) {
+    const currentZoom = win.webContents.getZoomLevel();
+    const targetZoom = loadConfig().zoomLevel;
+    const clampedZoom = Math.max(MIN_ZOOM_LEVEL, Math.min(MAX_ZOOM_LEVEL, targetZoom));
+    if (currentZoom !== clampedZoom) {
+      win.webContents.setZoomLevel(clampedZoom);
+    }
+  }
+
   // Re-apply saved zoom when DevTools opens/closes (Electron/Chromium can reset zoom on DevTools operations)
   win.webContents.on('devtools-opened', () => {
     setTimeout(() => {
       if (!win.isDestroyed()) {
-        const currentZoom = win.webContents.getZoomLevel();
-        const targetZoom = loadConfig().zoomLevel;
-        if (currentZoom !== targetZoom) {
-          win.webContents.setZoomLevel(Math.max(MIN_ZOOM_LEVEL, Math.min(MAX_ZOOM_LEVEL, targetZoom)));
-        }
+        applySavedZoom(win);
       }
     }, 150);
   });
 
   win.webContents.on('devtools-closed', () => {
-    if (!win.isDestroyed()) {
-      const currentZoom = win.webContents.getZoomLevel();
-      const targetZoom = loadConfig().zoomLevel;
-      if (currentZoom !== targetZoom) {
-        win.webContents.setZoomLevel(Math.max(MIN_ZOOM_LEVEL, Math.min(MAX_ZOOM_LEVEL, targetZoom)));
+    setTimeout(() => {
+      if (!win.isDestroyed()) {
+        applySavedZoom(win);
       }
-    }
+    }, 150);
   });
 
   // Handle zoom keyboard shortcuts via before-input-event so numpad keys and no-shift

--- a/main.js
+++ b/main.js
@@ -191,11 +191,47 @@ const DEFAULT_ZOOM_LEVEL = 0; // Ctrl+0 actual size
 const MIN_ZOOM_LEVEL = -9;
 const MAX_ZOOM_LEVEL = 9;
 
+let cachedConfig = null;
+
 // Ensure config directory exists
 function ensureConfigDir() {
   if (!fs.existsSync(CONFIG_DIR)) {
     fs.mkdirSync(CONFIG_DIR, { recursive: true });
   }
+}
+
+// Load app config from cachedConfig (initialized once at startup).
+function loadConfig() {
+  if (cachedConfig === null) {
+    try {
+      if (fs.existsSync(APP_CONFIG_FILE)) {
+        const data = fs.readFileSync(APP_CONFIG_FILE, 'utf8');
+        const config = JSON.parse(data);
+        cachedConfig = {
+          zoomLevel: typeof config.zoomLevel === 'number' ? config.zoomLevel : DEFAULT_ZOOM_LEVEL,
+          lastDialogFolder: typeof config.lastDialogFolder === 'string' ? config.lastDialogFolder : '',
+        };
+      } else {
+        cachedConfig = { zoomLevel: DEFAULT_ZOOM_LEVEL, lastDialogFolder: '' };
+      }
+    } catch (e) {
+      console.error('Failed to load app config:', e);
+      cachedConfig = { zoomLevel: DEFAULT_ZOOM_LEVEL, lastDialogFolder: '' };
+    }
+  }
+  return cachedConfig;
+}
+
+// Save a partial patch into app config (merges with existing config).
+function saveConfig(patch) {
+  try {
+    ensureConfigDir();
+    cachedConfig = { ...loadConfig(), ...patch };
+    fs.writeFileSync(APP_CONFIG_FILE, JSON.stringify(cachedConfig, null, 2));
+  } catch (e) {
+    console.error('Failed to save app config:', e);
+  }
+}
 }
 
 // Load app config from config.json.
@@ -928,8 +964,9 @@ function createWindow() {
     // zoom restoration is handled by the devtools-opened / devtools-closed events
   });
 
-  // Active enforcement: if window size falls below minimum after any resize, restore it
   let _resizeZoomTimer = null;
+
+  // Active enforcement: if window size falls below minimum after any resize, restore it
   win.on('resize', () => {
     const [width, height] = win.getSize();
     if (width < MIN_WINDOW_WIDTH || height < MIN_WINDOW_HEIGHT) {
@@ -945,6 +982,14 @@ function createWindow() {
         }
       }
     }, 150);
+  });
+
+  // Clear resize timer on window close to prevent lingering references
+  win.on('closed', () => {
+    if (_resizeZoomTimer) {
+      clearTimeout(_resizeZoomTimer);
+      _resizeZoomTimer = null;
+    }
   });
 
   // Also prevent moves that would resize
@@ -998,14 +1043,22 @@ function createWindow() {
   win.webContents.on('devtools-opened', () => {
     setTimeout(() => {
       if (!win.isDestroyed()) {
-        win.webContents.setZoomLevel(Math.max(MIN_ZOOM_LEVEL, Math.min(MAX_ZOOM_LEVEL, loadConfig().zoomLevel)));
+        const currentZoom = win.webContents.getZoomLevel();
+        const targetZoom = loadConfig().zoomLevel;
+        if (currentZoom !== targetZoom) {
+          win.webContents.setZoomLevel(Math.max(MIN_ZOOM_LEVEL, Math.min(MAX_ZOOM_LEVEL, targetZoom)));
+        }
       }
     }, 150);
   });
 
   win.webContents.on('devtools-closed', () => {
     if (!win.isDestroyed()) {
-      win.webContents.setZoomLevel(Math.max(MIN_ZOOM_LEVEL, Math.min(MAX_ZOOM_LEVEL, loadConfig().zoomLevel)));
+      const currentZoom = win.webContents.getZoomLevel();
+      const targetZoom = loadConfig().zoomLevel;
+      if (currentZoom !== targetZoom) {
+        win.webContents.setZoomLevel(Math.max(MIN_ZOOM_LEVEL, Math.min(MAX_ZOOM_LEVEL, targetZoom)));
+      }
     }
   });
 

--- a/main.js
+++ b/main.js
@@ -184,9 +184,9 @@ const MIN_WINDOW_HEIGHT = 550;
 const PREFERRED_WINDOW_WIDTH = 1700;
 const PREFERRED_WINDOW_HEIGHT = 1080;
 
-// Zoom level persistence
+// App config persistence (zoom level, last dialog folder, etc.)
 const CONFIG_DIR = path.join(app.getPath('userData'), 'config');
-const ZOOM_CONFIG_FILE = path.join(CONFIG_DIR, 'zoom.json');
+const APP_CONFIG_FILE = path.join(CONFIG_DIR, 'config.json');
 const DEFAULT_ZOOM_LEVEL = 0; // Ctrl+0 actual size
 
 // Ensure config directory exists
@@ -196,27 +196,31 @@ function ensureConfigDir() {
   }
 }
 
-// Load zoom level from config file
-function loadZoomLevel() {
+// Load app config from config.json.
+function loadConfig() {
   try {
-    if (fs.existsSync(ZOOM_CONFIG_FILE)) {
-      const data = fs.readFileSync(ZOOM_CONFIG_FILE, 'utf8');
+    if (fs.existsSync(APP_CONFIG_FILE)) {
+      const data = fs.readFileSync(APP_CONFIG_FILE, 'utf8');
       const config = JSON.parse(data);
-      return typeof config.zoomLevel === 'number' ? config.zoomLevel : DEFAULT_ZOOM_LEVEL;
+      return {
+        zoomLevel: typeof config.zoomLevel === 'number' ? config.zoomLevel : DEFAULT_ZOOM_LEVEL,
+        lastDialogFolder: typeof config.lastDialogFolder === 'string' ? config.lastDialogFolder : '',
+      };
     }
   } catch (e) {
-    console.error('Failed to load zoom config:', e);
+    console.error('Failed to load app config:', e);
   }
-  return DEFAULT_ZOOM_LEVEL;
+  return { zoomLevel: DEFAULT_ZOOM_LEVEL, lastDialogFolder: '' };
 }
 
-// Save zoom level to config file
-function saveZoomLevel(level) {
+// Save a partial patch into app config (merges with existing config).
+function saveConfig(patch) {
   try {
     ensureConfigDir();
-    fs.writeFileSync(ZOOM_CONFIG_FILE, JSON.stringify({ zoomLevel: level }, null, 2));
+    const existing = loadConfig();
+    fs.writeFileSync(APP_CONFIG_FILE, JSON.stringify({ ...existing, ...patch }, null, 2));
   } catch (e) {
-    console.error('Failed to save zoom config:', e);
+    console.error('Failed to save app config:', e);
   }
 }
 
@@ -782,23 +786,39 @@ const { dialog } = require('electron');
 // IPC: show save file dialog
 ipcMain.handle('dialog:choose-entry', async (event, options) => {
   const { type, suggestedName, accepts } = options;
+  const name = typeof suggestedName === 'string' && suggestedName ? suggestedName : undefined;
+
+  const cfg = loadConfig();
+  const lastFolder = cfg.lastDialogFolder;
+  const defaultPath = lastFolder && name ? path.join(lastFolder, name)
+                    : lastFolder            ? lastFolder
+                    : name                  ? name
+                    : undefined;
 
   if (type === 'saveFile') {
     const filters = accepts ? accepts.map(a => ({ name: a.description, extensions: a.extensions })) : [];
-    return await dialog.showSaveDialog({
-      defaultPath: suggestedName,
+    const result = await dialog.showSaveDialog({
+      defaultPath,
       filters: filters.length > 0 ? filters : undefined,
     });
+    if (!result.canceled && result.filePath) {
+      saveConfig({ lastDialogFolder: path.dirname(result.filePath) });
+    }
+    return result;
   } else if (type === 'openFile') {
     const openFilters = accepts
       ? accepts.filter(a => Array.isArray(a.extensions) && a.extensions.length > 0)
                .map(a => ({ name: a.description, extensions: a.extensions }))
       : [];
-    return await dialog.showOpenDialog({
-      defaultPath: suggestedName,
+    const result = await dialog.showOpenDialog({
+      defaultPath,
       filters: openFilters,
       properties: ['openFile'],
     });
+    if (!result.canceled && result.filePaths && result.filePaths.length > 0) {
+      saveConfig({ lastDialogFolder: path.dirname(result.filePaths[0]) });
+    }
+    return result;
   }
   return { canceled: true };
 });
@@ -898,28 +918,31 @@ function createWindow() {
 
   // Register F12 as global shortcut to toggle DevTools while preserving zoom
   globalShortcut.register('F12', () => {
-    // Store current zoom before toggling DevTools (DevTools toggle can reset zoom)
-    const currentZoom = win.webContents.getZoomLevel();
-    
     if (win.webContents.isDevToolsOpened()) {
       win.webContents.closeDevTools();
     } else {
       win.webContents.openDevTools();
     }
-    
-    // Restore zoom level after toggling DevTools
-    setTimeout(() => {
-      win.webContents.setZoomLevel(currentZoom);
-      saveZoomLevel(currentZoom); // Persist the zoom level
-    }, 150);
+    // zoom restoration is handled by the devtools-opened / devtools-closed events
   });
 
   // Active enforcement: if window size falls below minimum after any resize, restore it
+  let _resizeZoomTimer = null;
   win.on('resize', () => {
     const [width, height] = win.getSize();
     if (width < MIN_WINDOW_WIDTH || height < MIN_WINDOW_HEIGHT) {
       win.setSize(Math.max(width, MIN_WINDOW_WIDTH), Math.max(height, MIN_WINDOW_HEIGHT));
     }
+    // Re-apply saved zoom: Chromium can silently reset zoom level when window resizes
+    if (_resizeZoomTimer) clearTimeout(_resizeZoomTimer);
+    _resizeZoomTimer = setTimeout(() => {
+      if (!win.isDestroyed()) {
+        const savedZoom = loadConfig().zoomLevel;
+        if (win.webContents.getZoomLevel() !== savedZoom) {
+          win.webContents.setZoomLevel(savedZoom);
+        }
+      }
+    }, 150);
   });
 
   // Also prevent moves that would resize
@@ -941,14 +964,14 @@ function createWindow() {
     }
     
     // Load saved zoom level or use default (Ctrl+0 actual size)
-    const savedZoom = loadZoomLevel();
+    const savedZoom = loadConfig().zoomLevel;
     win.webContents.setZoomLevel(savedZoom);
   });
   
-  // Save zoom level when it changes (e.g., Ctrl+Plus, Ctrl+Minus, Ctrl+0)
+  // Save zoom level when it changes via mouse wheel
   win.webContents.on('zoom-changed', (event, direction) => {
     const newLevel = win.webContents.getZoomLevel();
-    saveZoomLevel(newLevel);
+    saveConfig({ zoomLevel: newLevel });
   });
 
   // Intercept new window requests (e.g., target="_blank" links) and open in system browser
@@ -965,15 +988,41 @@ function createWindow() {
     win.webContents.openDevTools();
   }
 
-  // Re-apply zoom level when DevTools closes (Electron resets zoom on DevTools open/close)
+  // Re-apply saved zoom when DevTools opens/closes (Electron/Chromium can reset zoom on DevTools operations)
+  win.webContents.on('devtools-opened', () => {
+    setTimeout(() => {
+      if (!win.isDestroyed()) {
+        win.webContents.setZoomLevel(loadConfig().zoomLevel);
+      }
+    }, 150);
+  });
+
+  win.webContents.on('devtools-closed', () => {
+    if (!win.isDestroyed()) {
+      win.webContents.setZoomLevel(loadConfig().zoomLevel);
+    }
+  });
+
+  // Handle zoom keyboard shortcuts via before-input-event so numpad keys and no-shift
+  // variants work reliably. event.preventDefault() suppresses the menu role accelerator
+  // so only this handler fires for keyboard-triggered zoom changes.
   win.webContents.on('before-input-event', (event, input) => {
-    // F12 or Ctrl+Shift+I opens/closes DevTools; re-apply zoom persistently
-    if ((input.key === 'F12') || 
-        (input.control && input.shift && input.key.toLowerCase() === 'i')) {
-      setTimeout(() => {
-        const savedZoom = loadZoomLevel();
-        win.webContents.setZoomLevel(savedZoom); // Reapply zoom after DevTools toggle
-      }, 100);
+    if (input.type !== 'keyDown' || !input.control || input.shift || input.alt) return;
+    const code = input.code;
+    if (code === 'Equal' || code === 'NumpadAdd') {
+      event.preventDefault();
+      const level = win.webContents.getZoomLevel() + 1;
+      win.webContents.setZoomLevel(level);
+      saveConfig({ zoomLevel: level });
+    } else if (code === 'Minus' || code === 'NumpadSubtract') {
+      event.preventDefault();
+      const level = win.webContents.getZoomLevel() - 1;
+      win.webContents.setZoomLevel(level);
+      saveConfig({ zoomLevel: level });
+    } else if (code === 'Digit0' || code === 'Numpad0') {
+      event.preventDefault();
+      win.webContents.setZoomLevel(DEFAULT_ZOOM_LEVEL);
+      saveConfig({ zoomLevel: DEFAULT_ZOOM_LEVEL });
     }
   });
 

--- a/main.js
+++ b/main.js
@@ -232,35 +232,7 @@ function saveConfig(patch) {
     console.error('Failed to save app config:', e);
   }
 }
-}
 
-// Load app config from config.json.
-function loadConfig() {
-  try {
-    if (fs.existsSync(APP_CONFIG_FILE)) {
-      const data = fs.readFileSync(APP_CONFIG_FILE, 'utf8');
-      const config = JSON.parse(data);
-      return {
-        zoomLevel: typeof config.zoomLevel === 'number' ? config.zoomLevel : DEFAULT_ZOOM_LEVEL,
-        lastDialogFolder: typeof config.lastDialogFolder === 'string' ? config.lastDialogFolder : '',
-      };
-    }
-  } catch (e) {
-    console.error('Failed to load app config:', e);
-  }
-  return { zoomLevel: DEFAULT_ZOOM_LEVEL, lastDialogFolder: '' };
-}
-
-// Save a partial patch into app config (merges with existing config).
-function saveConfig(patch) {
-  try {
-    ensureConfigDir();
-    const existing = loadConfig();
-    fs.writeFileSync(APP_CONFIG_FILE, JSON.stringify({ ...existing, ...patch }, null, 2));
-  } catch (e) {
-    console.error('Failed to save app config:', e);
-  }
-}
 
 function getInitialWindowBounds() {
   const display = screen.getDisplayNearestPoint(screen.getCursorScreenPoint());

--- a/src/js/tabs/firmware_flasher.js
+++ b/src/js/tabs/firmware_flasher.js
@@ -425,6 +425,8 @@ TABS.firmware_flasher.initialize = function (callback) {
                                         $('select[name="board"]').val('0');
                                         $('select[name="firmware_version"]').empty()
                                             .append($('<option value="0">' + i18n.getMessage('firmwareFlasherOptionLabelSelectFirmwareVersion') + '</option>'));
+                                        // Hide release info since we're now using local firmware
+                                        $('div.release_info').slideUp();
                                     } else {
                                         self.flashingMessage('firmwareFlasherHexCorrupted', self.FLASH_MESSAGE_TYPES.INVALID);
                                     }

--- a/src/js/tabs/firmware_flasher.js
+++ b/src/js/tabs/firmware_flasher.js
@@ -8,14 +8,7 @@ TABS.firmware_flasher = {
 
 TABS.firmware_flasher.initialize = function (callback) {
 
-    function extractTarget(filename) {
-        var targetFromFilenameExpression = /EmuFlight_([\d.]+)?_?(\w+)(\-.*)?\.(.*)/;
-        var match = targetFromFilenameExpression.exec(filename);
-        if (match) {
-            return match[2];
-        }
-        return filename.split('.')[0];
-    }
+
     var self = this;
 
     if (GUI.active_tab != 'firmware_flasher') {
@@ -66,7 +59,8 @@ TABS.firmware_flasher.initialize = function (callback) {
                         FirmwareCache.put(summary, intel_hex);
                     }
 
-                    self.flashingMessage('<a class="save_firmware" href="#" title="Save Firmware">' + summary.target + ' (' + parsed_hex.bytes_total + ' bytes)' + '</a>',
+                    var displayFilename = summary.file.length > 20 ? '...' + summary.file.slice(-17) : summary.file;
+                    self.flashingMessage('<a class="save_firmware" href="#" title="Save Firmware">' + displayFilename + ' (' + parsed_hex.bytes_total + ' bytes)' + '</a>',
                                          self.FLASH_MESSAGE_TYPES.NEUTRAL);
 
                     self.enableFlashing(true);
@@ -418,8 +412,8 @@ TABS.firmware_flasher.initialize = function (callback) {
                                         self.enableFlashing(true);
 
                                         var filename = path.split(/[/\\]/).pop();
-                                        var target = extractTarget(filename);
-                                        self.flashingMessage(target + ' (' + parsed_hex.bytes_total + ' bytes)', self.FLASH_MESSAGE_TYPES.NEUTRAL);
+                                        var displayFilename = filename.length > 20 ? '...' + filename.slice(-17) : filename;
+                                        self.flashingMessage(displayFilename + ' (' + parsed_hex.bytes_total + ' bytes)', self.FLASH_MESSAGE_TYPES.NEUTRAL);
                                         // Reset online selects to placeholder; no trigger to preserve loaded firmware state
                                         $('select[name="board"]').val('0');
                                         $('select[name="firmware_version"]').empty()

--- a/src/js/tabs/firmware_flasher.js
+++ b/src/js/tabs/firmware_flasher.js
@@ -57,7 +57,8 @@ TABS.firmware_flasher.initialize = function (callback) {
                         FirmwareCache.put(summary, intel_hex);
                     }
 
-                    self.flashingMessage('<a class="save_firmware" href="#" title="Save Firmware">' + i18n.getMessage('firmwareFlasherFirmwareOnlineLoaded', parsed_hex.bytes_total) + '</a>',
+                    var displayFilename = summary.file.length > 20 ? '...' + summary.file.slice(-17) : summary.file;
+                    self.flashingMessage('<a class="save_firmware" href="#" title="Save Firmware">' + displayFilename + ' (' + parsed_hex.bytes_total + ' bytes)' + '</a>',
                                          self.FLASH_MESSAGE_TYPES.NEUTRAL);
 
                     self.enableFlashing(true);
@@ -409,7 +410,8 @@ TABS.firmware_flasher.initialize = function (callback) {
                                         self.enableFlashing(true);
 
                                         var filename = path.split(/[/\\]/).pop();
-                                        self.flashingMessage(filename + ' (' + parsed_hex.bytes_total + ' bytes)', self.FLASH_MESSAGE_TYPES.NEUTRAL);
+                                        var displayFilename = filename.length > 20 ? '...' + filename.slice(-17) : filename;
+                                        self.flashingMessage(displayFilename + ' (' + parsed_hex.bytes_total + ' bytes)', self.FLASH_MESSAGE_TYPES.NEUTRAL);
                                         // Reset online selects to placeholder; no trigger to preserve loaded firmware state
                                         $('select[name="board"]').val('0');
                                         $('select[name="firmware_version"]').empty()

--- a/src/js/tabs/firmware_flasher.js
+++ b/src/js/tabs/firmware_flasher.js
@@ -124,8 +124,11 @@ TABS.firmware_flasher.initialize = function (callback) {
 
             chrome.storage.local.get('selected_board', function (result) {
                 if (result.selected_board) {
-                    var boardBuilds = builds[result.selected_board]
+                    var boardBuilds = builds[result.selected_board];
                     $('select[name="board"]').val(boardBuilds ? result.selected_board : 0).trigger('change');
+                } else {
+                    $('select[name="firmware_version"]').empty()
+                        .append($('<option value="0">{0}</option>'.format(i18n.getMessage('firmwareFlasherOptionLabelSelectFirmwareVersion'))));
                 }
             });
         }
@@ -224,8 +227,11 @@ TABS.firmware_flasher.initialize = function (callback) {
 
                 chrome.storage.local.get('selected_board', function (result) {
                     if (result.selected_board) {
-                        var boardReleases = releases[result.selected_board]
+                        var boardReleases = releases[result.selected_board];
                         $('select[name="board"]').val(boardReleases ? result.selected_board : 0).trigger('change');
+                    } else {
+                        $('select[name="firmware_version"]').empty()
+                            .append($('<option value="0">{0}</option>'.format(i18n.getMessage('firmwareFlasherOptionLabelSelectFirmwareVersion'))));
                     }
                 });
             }
@@ -328,21 +334,23 @@ TABS.firmware_flasher.initialize = function (callback) {
                 } else {
                     versions_e.append($("<option value='0'>{0} {1}</option>".format(i18n.getMessage('firmwareFlasherOptionLabelSelectFirmwareVersionFor'), target)));
 
-                    TABS.firmware_flasher.releases[target].forEach(function(descriptor) {
-                        var select_e =
-                                $("<option value='{0}'>{0} - {1} - {2}</option>".format(
-                                        descriptor.version,
-                                        descriptor.target,
-                                        descriptor.date
-                                ))
-                                .css("font-weight", FirmwareCache.has(descriptor)
-                                        ? "bold"
-                                        : "normal"
-                                )
-                                .data('summary', descriptor);
+                    if (TABS.firmware_flasher.releases && TABS.firmware_flasher.releases[target]) {
+                        TABS.firmware_flasher.releases[target].forEach(function(descriptor) {
+                            var select_e =
+                                    $('<option value="{0}">{0} - {1} - {2}</option>'.format(
+                                            descriptor.version,
+                                            descriptor.target,
+                                            descriptor.date
+                                    ))
+                                    .css('font-weight', FirmwareCache.has(descriptor)
+                                            ? 'bold'
+                                            : 'normal'
+                                    )
+                                    .data('summary', descriptor);
 
-                        versions_e.append(select_e);
-                    });
+                            versions_e.append(select_e);
+                        });
+                    }
                 }
 
                 // Assume flashing latest, so default to it.
@@ -397,7 +405,12 @@ TABS.firmware_flasher.initialize = function (callback) {
                                     if (parsed_hex) {
                                         self.enableFlashing(true);
 
-                                        self.flashingMessage(i18n.getMessage('firmwareFlasherFirmwareLocalLoaded', parsed_hex.bytes_total), self.FLASH_MESSAGE_TYPES.NEUTRAL);
+                                        var filename = path.split(/[/\\]/).pop();
+                                        self.flashingMessage(filename + ' (' + parsed_hex.bytes_total + ' bytes)', self.FLASH_MESSAGE_TYPES.NEUTRAL);
+                                        // Reset online selects to placeholder; no trigger to preserve loaded firmware state
+                                        $('select[name="board"]').val('0');
+                                        $('select[name="firmware_version"]').empty()
+                                            .append($('<option value="0">' + i18n.getMessage('firmwareFlasherOptionLabelSelectFirmwareVersion') + '</option>'));
                                     } else {
                                         self.flashingMessage('firmwareFlasherHexCorrupted', self.FLASH_MESSAGE_TYPES.INVALID);
                                     }
@@ -423,8 +436,8 @@ TABS.firmware_flasher.initialize = function (callback) {
 
             let release = $("option:selected", evt.target).data("summary");
             let isCached = FirmwareCache.has(release);
-            if (evt.target.value == "0") {
-                $("a.load_remote_file").addClass('disabled');
+            if (evt.target.value == '0' || $('select[name="board"]').val() == '0') {
+                $('a.load_remote_file').addClass('disabled');
             } else if (isCached) {
                 FirmwareCache.get(release, cached => {
                     console.info("Release found in cache: " + release.file);

--- a/src/js/tabs/firmware_flasher.js
+++ b/src/js/tabs/firmware_flasher.js
@@ -354,7 +354,10 @@ TABS.firmware_flasher.initialize = function (callback) {
                 }
 
                 // Assume flashing latest, so default to it.
-                versions_e.prop("selectedIndex", 1).change();
+                var firstOption = versions_e.find('option[value!="0"]').first();
+                if (firstOption.length > 0) {
+                    versions_e.val(firstOption.val()).change();
+                }
             }
             chrome.storage.local.set({'selected_board': target});
         });

--- a/src/js/tabs/firmware_flasher.js
+++ b/src/js/tabs/firmware_flasher.js
@@ -9,13 +9,12 @@ TABS.firmware_flasher = {
 TABS.firmware_flasher.initialize = function (callback) {
 
     function extractTarget(filename) {
-        var parts = filename.split('_');
-        if (parts.length >= 3) {
-            var targetPart = parts[2];
-            // Remove extension if present
-            return targetPart.split('.')[0];
+        var targetFromFilenameExpression = /EmuFlight_([\d.]+)?_?(\w+)(\-.*)?\.(.*)/;
+        var match = targetFromFilenameExpression.exec(filename);
+        if (match) {
+            return match[2];
         }
-        return 'unknown';
+        return filename.split('.')[0];
     }
     var self = this;
 

--- a/src/js/tabs/firmware_flasher.js
+++ b/src/js/tabs/firmware_flasher.js
@@ -7,6 +7,16 @@ TABS.firmware_flasher = {
 };
 
 TABS.firmware_flasher.initialize = function (callback) {
+
+    function extractTarget(filename) {
+        var parts = filename.split('_');
+        if (parts.length >= 3) {
+            var targetPart = parts[2];
+            // Remove extension if present
+            return targetPart.split('.')[0];
+        }
+        return 'unknown';
+    }
     var self = this;
 
     if (GUI.active_tab != 'firmware_flasher') {
@@ -57,8 +67,7 @@ TABS.firmware_flasher.initialize = function (callback) {
                         FirmwareCache.put(summary, intel_hex);
                     }
 
-                    var displayFilename = summary.file.length > 20 ? '...' + summary.file.slice(-17) : summary.file;
-                    self.flashingMessage('<a class="save_firmware" href="#" title="Save Firmware">' + displayFilename + ' (' + parsed_hex.bytes_total + ' bytes)' + '</a>',
+                    self.flashingMessage('<a class="save_firmware" href="#" title="Save Firmware">' + summary.target + ' (' + parsed_hex.bytes_total + ' bytes)' + '</a>',
                                          self.FLASH_MESSAGE_TYPES.NEUTRAL);
 
                     self.enableFlashing(true);
@@ -410,8 +419,8 @@ TABS.firmware_flasher.initialize = function (callback) {
                                         self.enableFlashing(true);
 
                                         var filename = path.split(/[/\\]/).pop();
-                                        var displayFilename = filename.length > 20 ? '...' + filename.slice(-17) : filename;
-                                        self.flashingMessage(displayFilename + ' (' + parsed_hex.bytes_total + ' bytes)', self.FLASH_MESSAGE_TYPES.NEUTRAL);
+                                        var target = extractTarget(filename);
+                                        self.flashingMessage(target + ' (' + parsed_hex.bytes_total + ' bytes)', self.FLASH_MESSAGE_TYPES.NEUTRAL);
                                         // Reset online selects to placeholder; no trigger to preserve loaded firmware state
                                         $('select[name="board"]').val('0');
                                         $('select[name="firmware_version"]').empty()


### PR DESCRIPTION
needs further testing

- **Implement fixes for zoom persistence, last folder memory, and flasher improvements**
- **Fix flasher tab target version default selection** [works]
- **Improve firmware loading progress bar display**
- **Display target name in firmware loading progress bar**
- **Hide release info when loading local hex**
- **Clamp zoom levels to valid range (-9 to 9)**
- **Performance and cleanup fixes for main.js**
- installation icon / os-level icon (Linux) [works]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Zoom level persistence now reliably restores and is clamped; survives restarts, resize events and devtools toggles.
  * File dialogs now remember and restore the last-used folder.
  * Firmware flasher dropdown and remote-load controls initialize and update correctly, avoiding invalid selections.

* **New Features**
  * App-wide persistent configuration for zoom and dialog preferences.
  * Local firmware display shows filename and size; default version selection improved.
  * Linux installers include the application icon.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->