### PR TITLE
fix: set linux application icon in forge config

### DIFF
--- a/forge.config.js
+++ b/forge.config.js
@@ -80,6 +80,7 @@ module.exports = {
         options: {
           maintainer: 'EmuFlight',
           homepage: 'https://github.com/EmuFlight/EmuConfigurator',
+          icon: path.resolve(__dirname, 'assets/linux/icon/emu_icon_128.png'),
         },
       },
     },
@@ -89,6 +90,7 @@ module.exports = {
       config: {
         options: {
           homepage: 'https://github.com/EmuFlight/EmuConfigurator',
+          icon: path.resolve(__dirname, 'assets/linux/icon/emu_icon_128.png'),
         },
       },
     },


### PR DESCRIPTION
Explicitly define the icon path for Linux package makers (deb and rpm)
in forge.config.js to ensure the application icon is correctly
displayed in the installed environment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added Linux packaging icon support for Debian and RPM installations, improving application appearance on Linux systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->