### PR TITLE
fix: zoom peristence

### DIFF
--- a/main.js
+++ b/main.js
@@ -191,10 +191,9 @@ const DEFAULT_ZOOM_LEVEL = 0; // Ctrl+0 actual size
 const MIN_ZOOM_LEVEL = -9;
 const MAX_ZOOM_LEVEL = 9;
 
-// Zoom cache coordination: prevents race between F12 handler and devtools-opened/closed handlers
-let _zoomRecentlySaved = false;     // Flag indicating F12 handler just saved zoom
-let _cachedZoom = DEFAULT_ZOOM_LEVEL; // Cached zoom from F12 handler
-let _zoomCacheTimer = null;         // Timer to clear the cache flag after debounce
+// In-memory zoom level — single source of truth; avoids disk reads on resize
+// and eliminates races between the F12 handler and devtools-opened/closed handlers.
+let _currentZoom = DEFAULT_ZOOM_LEVEL;
 
 // Ensure config directory exists
 function ensureConfigDir() {
@@ -914,11 +913,6 @@ function createWindow() {
     // Store current zoom before toggling DevTools (DevTools toggle can reset zoom)
     const currentZoom = win.webContents.getZoomLevel();
     
-    // Signal to devtools handlers that we're managing zoom to avoid race condition
-    _zoomRecentlySaved = true;
-    _cachedZoom = currentZoom;
-    if (_zoomCacheTimer) clearTimeout(_zoomCacheTimer);
-    
     if (win.webContents.isDevToolsOpened()) {
       win.webContents.closeDevTools();
     } else {
@@ -929,14 +923,10 @@ function createWindow() {
     setTimeout(() => {
       if (win.isDestroyed()) return;
       const safeZoom = clampZoom(currentZoom);
+      _currentZoom = safeZoom;
       win.webContents.setZoomLevel(safeZoom);
       saveZoomLevel(safeZoom); // Persist the zoom level
     }, 150);
-    
-    // Clear the zoom cache flag after debounce so normal devtools handlers resume
-    _zoomCacheTimer = setTimeout(() => {
-      _zoomRecentlySaved = false;
-    }, 250);
   });
 
   // Active enforcement: if window size falls below minimum after any resize, restore it
@@ -946,13 +936,12 @@ function createWindow() {
     if (width < MIN_WINDOW_WIDTH || height < MIN_WINDOW_HEIGHT) {
       win.setSize(Math.max(width, MIN_WINDOW_WIDTH), Math.max(height, MIN_WINDOW_HEIGHT));
     }
-    // Re-apply saved zoom: Chromium can silently reset zoom level when window resizes
+    // Re-apply current zoom: Chromium can silently reset zoom level when window resizes
     if (_resizeZoomTimer) clearTimeout(_resizeZoomTimer);
     _resizeZoomTimer = setTimeout(() => {
       if (!win.isDestroyed()) {
-        const savedZoom = clampZoom(loadZoomLevel());
-        if (win.webContents.getZoomLevel() !== savedZoom) {
-          win.webContents.setZoomLevel(savedZoom);
+        if (win.webContents.getZoomLevel() !== _currentZoom) {
+          win.webContents.setZoomLevel(_currentZoom);
         }
       }
     }, 150);
@@ -978,6 +967,7 @@ function createWindow() {
     
     // Load saved zoom level or use default (Ctrl+0 actual size)
     const savedZoom = clampZoom(loadZoomLevel());
+    _currentZoom = savedZoom;
     win.webContents.setZoomLevel(savedZoom);
   });
   
@@ -988,6 +978,7 @@ function createWindow() {
     if (newLevel !== clampedLevel) {
       win.webContents.setZoomLevel(clampedLevel);
     }
+    _currentZoom = clampedLevel;
     saveZoomLevel(clampedLevel);
   });
 
@@ -1002,44 +993,27 @@ function createWindow() {
     return { action: 'deny' };
   });
 
-  // Clear all timers and flags on window close to prevent lingering references
+  // Clear resize timer on window close to prevent lingering references
   win.on('closed', () => {
     if (_resizeZoomTimer) {
       clearTimeout(_resizeZoomTimer);
       _resizeZoomTimer = null;
     }
-    if (_zoomCacheTimer) {
-      clearTimeout(_zoomCacheTimer);
-      _zoomCacheTimer = null;
-    }
-    _zoomRecentlySaved = false;
   });
 
-  // Re-apply saved zoom when DevTools opens/closes (Electron/Chromium can reset zoom on DevTools operations)
+  // Re-apply current zoom when DevTools opens/closes (Electron/Chromium can reset zoom on DevTools operations)
   win.webContents.on('devtools-opened', () => {
     setTimeout(() => {
-      if (!win.isDestroyed()) {
-        // If F12 handler recently saved zoom, use cached value instead of loading from disk
-        const currentZoom = win.webContents.getZoomLevel();
-        const targetZoom = _zoomRecentlySaved ? _cachedZoom : loadZoomLevel();
-        const clampedZoom = clampZoom(targetZoom);
-        if (currentZoom !== clampedZoom) {
-          win.webContents.setZoomLevel(clampedZoom);
-        }
+      if (!win.isDestroyed() && win.webContents.getZoomLevel() !== _currentZoom) {
+        win.webContents.setZoomLevel(_currentZoom);
       }
     }, 150);
   });
 
   win.webContents.on('devtools-closed', () => {
     setTimeout(() => {
-      if (!win.isDestroyed()) {
-        // If F12 handler recently saved zoom, use cached value instead of loading from disk
-        const currentZoom = win.webContents.getZoomLevel();
-        const targetZoom = _zoomRecentlySaved ? _cachedZoom : loadZoomLevel();
-        const clampedZoom = clampZoom(targetZoom);
-        if (currentZoom !== clampedZoom) {
-          win.webContents.setZoomLevel(clampedZoom);
-        }
+      if (!win.isDestroyed() && win.webContents.getZoomLevel() !== _currentZoom) {
+        win.webContents.setZoomLevel(_currentZoom);
       }
     }, 150);
   });
@@ -1050,18 +1024,26 @@ function createWindow() {
   win.webContents.on('before-input-event', (event, input) => {
     if (input.type !== 'keyDown' || !(input.control || input.meta) || input.shift || input.alt) return;
     const code = input.code;
+    // Note: setZoomLevel() does NOT emit 'zoom-changed', so we must update _currentZoom
+    // and call saveZoomLevel() here directly for persistence and resize-recovery to work.
     if (code === 'Equal' || code === 'NumpadAdd') {
       event.preventDefault();
       const level = clampZoom(win.webContents.getZoomLevel() + 1);
       win.webContents.setZoomLevel(level);
+      _currentZoom = level;
+      saveZoomLevel(level);
     } else if (code === 'Minus' || code === 'NumpadSubtract') {
       event.preventDefault();
       const level = clampZoom(win.webContents.getZoomLevel() - 1);
       win.webContents.setZoomLevel(level);
+      _currentZoom = level;
+      saveZoomLevel(level);
     } else if (code === 'Digit0' || code === 'Numpad0') {
       event.preventDefault();
       const level = clampZoom(DEFAULT_ZOOM_LEVEL);
       win.webContents.setZoomLevel(level);
+      _currentZoom = level;
+      saveZoomLevel(level);
     }
   });
 

--- a/main.js
+++ b/main.js
@@ -253,7 +253,7 @@ function saveZoomLevel(level) {
 
 // Apply and persist a zoom change: clamps, updates in-memory state, sets webContents level, saves to disk.
 function applyZoom(win, level) {
-  if (!win || win.isDestroyed()) return;
+  if (!win || win.isDestroyed() || !win.webContents) return;
   const previous = _currentZoom;
   const clamped = clampZoom(level);
   _currentZoom = clamped;

--- a/main.js
+++ b/main.js
@@ -117,14 +117,14 @@ function setupMenu(buildMode) {
           label: 'Actual Size',
           click: () => {
             const w = BrowserWindow.getFocusedWindow();
-            applyZoom(w, DEFAULT_ZOOM_LEVEL);
+            if (w) applyZoom(w, DEFAULT_ZOOM_LEVEL);
           }
         },
         {
           label: 'Zoom In',
           click: () => {
             const w = BrowserWindow.getFocusedWindow();
-            applyZoom(w, _currentZoom + 1);
+            if (w) applyZoom(w, _currentZoom + 1);
           }
         },
         {
@@ -237,7 +237,7 @@ function loadZoomLevel() {
 
 // Clamp zoom level to valid range [MIN_ZOOM_LEVEL, MAX_ZOOM_LEVEL]
 function clampZoom(level) {
-  return Math.max(MIN_ZOOM_LEVEL, Math.min(MAX_ZOOM_LEVEL, level));
+  return Math.max(MIN_ZOOM_LEVEL, Math.min(MAX_ZOOM_LEVEL, Number(level) || DEFAULT_ZOOM_LEVEL));
 }
 
 // Save zoom level to config file
@@ -251,13 +251,25 @@ function saveZoomLevel(level) {
   }
 }
 
+// Update in-memory zoom state.
+function updateZoomState(level) {
+  _currentZoom = level;
+}
+
+// Apply zoom to webContents.
+function setWebContentsZoom(win, level) {
+  if (!win || win.isDestroyed() || !win.webContents) return false;
+  win.webContents.setZoomLevel(level);
+  return true;
+}
+
 // Apply and persist a zoom change: clamps, updates in-memory state, sets webContents level, saves to disk.
 function applyZoom(win, level) {
   if (!win || win.isDestroyed() || !win.webContents) return;
   const previous = _currentZoom;
   const clamped = clampZoom(level);
-  _currentZoom = clamped;
-  win.webContents.setZoomLevel(clamped);
+  updateZoomState(clamped);
+  setWebContentsZoom(win, clamped);
   if (clamped !== previous) {
     saveZoomLevel(clamped);
   }
@@ -952,20 +964,23 @@ function createWindow() {
 
   // Active enforcement: if window size falls below minimum after any resize, restore it
   let _resizeZoomTimer = null;
+  const debouncedZoomReapply = () => {
+    if (_resizeZoomTimer) clearTimeout(_resizeZoomTimer);
+    _resizeZoomTimer = setTimeout(() => {
+      if (!win.isDestroyed() && win.webContents.getZoomLevel() !== _currentZoom) {
+        win.webContents.setZoomLevel(_currentZoom);
+      }
+      _resizeZoomTimer = null;
+    }, 150);
+  };
+  
   win.on('resize', () => {
     const [width, height] = win.getSize();
     if (width < MIN_WINDOW_WIDTH || height < MIN_WINDOW_HEIGHT) {
       win.setSize(Math.max(width, MIN_WINDOW_WIDTH), Math.max(height, MIN_WINDOW_HEIGHT));
     }
     // Re-apply current zoom: Chromium can silently reset zoom level when window resizes
-    if (_resizeZoomTimer) clearTimeout(_resizeZoomTimer);
-    _resizeZoomTimer = setTimeout(() => {
-      if (!win.isDestroyed()) {
-        if (win.webContents.getZoomLevel() !== _currentZoom) {
-          win.webContents.setZoomLevel(_currentZoom);
-        }
-      }
-    }, 150);
+    debouncedZoomReapply();
   });
 
   // Also prevent moves that would resize

--- a/main.js
+++ b/main.js
@@ -212,11 +212,16 @@ function loadZoomLevel() {
   return DEFAULT_ZOOM_LEVEL;
 }
 
+// Clamp zoom level to valid range [MIN_ZOOM_LEVEL, MAX_ZOOM_LEVEL]
+function clampZoom(level) {
+  return Math.max(MIN_ZOOM_LEVEL, Math.min(MAX_ZOOM_LEVEL, level));
+}
+
 // Save zoom level to config file
 function saveZoomLevel(level) {
   try {
     ensureConfigDir();
-    const clampedLevel = Math.max(MIN_ZOOM_LEVEL, Math.min(MAX_ZOOM_LEVEL, level));
+    const clampedLevel = clampZoom(level);
     fs.writeFileSync(ZOOM_CONFIG_FILE, JSON.stringify({ zoomLevel: clampedLevel }, null, 2));
   } catch (e) {
     console.error('Failed to save zoom config:', e);
@@ -928,7 +933,7 @@ function createWindow() {
     if (_resizeZoomTimer) clearTimeout(_resizeZoomTimer);
       _resizeZoomTimer = setTimeout(() => {
         if (!win.isDestroyed()) {
-        const savedZoom = Math.max(MIN_ZOOM_LEVEL, Math.min(MAX_ZOOM_LEVEL, loadZoomLevel()));
+        const savedZoom = clampZoom(loadZoomLevel());
         if (win.webContents.getZoomLevel() !== savedZoom) {
           win.webContents.setZoomLevel(savedZoom);
         }
@@ -955,14 +960,14 @@ function createWindow() {
     }
     
     // Load saved zoom level or use default (Ctrl+0 actual size)
-    const savedZoom = Math.max(MIN_ZOOM_LEVEL, Math.min(MAX_ZOOM_LEVEL, loadZoomLevel()));
+    const savedZoom = clampZoom(loadZoomLevel());
     win.webContents.setZoomLevel(savedZoom);
   });
   
   // Save zoom level when it changes (e.g., Ctrl+Plus, Ctrl+Minus, Ctrl+0)
   win.webContents.on('zoom-changed', (_event, direction) => {
     const newLevel = win.webContents.getZoomLevel();
-    const clampedLevel = Math.max(MIN_ZOOM_LEVEL, Math.min(MAX_ZOOM_LEVEL, newLevel));
+    const clampedLevel = clampZoom(newLevel);
     if (newLevel !== clampedLevel) {
       win.webContents.setZoomLevel(clampedLevel);
     }
@@ -976,6 +981,8 @@ function createWindow() {
       shell.openExternal(url);
       return { action: 'deny' }; // Prevent Electron from opening its own window
     }
+    // Deny all other URLs (file://, app://, etc.) to avoid Electron's "response must be an object" console error
+    return { action: 'deny' };
   });
 
   // Clear resize timer on window close to prevent lingering references
@@ -992,7 +999,7 @@ function createWindow() {
       if (!win.isDestroyed()) {
         const currentZoom = win.webContents.getZoomLevel();
         const targetZoom = loadZoomLevel();
-        const clampedZoom = Math.max(MIN_ZOOM_LEVEL, Math.min(MAX_ZOOM_LEVEL, targetZoom));
+        const clampedZoom = clampZoom(targetZoom);
         if (currentZoom !== clampedZoom) {
           win.webContents.setZoomLevel(clampedZoom);
         }
@@ -1005,7 +1012,7 @@ function createWindow() {
       if (!win.isDestroyed()) {
         const currentZoom = win.webContents.getZoomLevel();
         const targetZoom = loadZoomLevel();
-        const clampedZoom = Math.max(MIN_ZOOM_LEVEL, Math.min(MAX_ZOOM_LEVEL, targetZoom));
+        const clampedZoom = clampZoom(targetZoom);
         if (currentZoom !== clampedZoom) {
           win.webContents.setZoomLevel(clampedZoom);
         }
@@ -1021,17 +1028,17 @@ function createWindow() {
     const code = input.code;
     if (code === 'Equal' || code === 'NumpadAdd') {
       event.preventDefault();
-      const level = Math.min(MAX_ZOOM_LEVEL, win.webContents.getZoomLevel() + 1);
+      const level = clampZoom(win.webContents.getZoomLevel() + 1);
       win.webContents.setZoomLevel(level);
       saveZoomLevel(level);
     } else if (code === 'Minus' || code === 'NumpadSubtract') {
       event.preventDefault();
-      const level = Math.max(MIN_ZOOM_LEVEL, win.webContents.getZoomLevel() - 1);
+      const level = clampZoom(win.webContents.getZoomLevel() - 1);
       win.webContents.setZoomLevel(level);
       saveZoomLevel(level);
     } else if (code === 'Digit0' || code === 'Numpad0') {
       event.preventDefault();
-      const level = Math.max(MIN_ZOOM_LEVEL, Math.min(MAX_ZOOM_LEVEL, DEFAULT_ZOOM_LEVEL));
+      const level = clampZoom(DEFAULT_ZOOM_LEVEL);
       win.webContents.setZoomLevel(level);
       saveZoomLevel(level);
     }

--- a/main.js
+++ b/main.js
@@ -237,7 +237,8 @@ function loadZoomLevel() {
 
 // Clamp zoom level to valid range [MIN_ZOOM_LEVEL, MAX_ZOOM_LEVEL]
 function clampZoom(level) {
-  return Math.max(MIN_ZOOM_LEVEL, Math.min(MAX_ZOOM_LEVEL, Number(level) || DEFAULT_ZOOM_LEVEL));
+  const n = Number(level);
+  return Math.max(MIN_ZOOM_LEVEL, Math.min(MAX_ZOOM_LEVEL, Number.isNaN(n) ? DEFAULT_ZOOM_LEVEL : n));
 }
 
 // Save zoom level to config file

--- a/main.js
+++ b/main.js
@@ -251,11 +251,6 @@ function saveZoomLevel(level) {
   }
 }
 
-// Update in-memory zoom state.
-function updateZoomState(level) {
-  _currentZoom = level;
-}
-
 // Apply zoom to webContents.
 function setWebContentsZoom(win, level) {
   if (!win || win.isDestroyed() || !win.webContents) return false;
@@ -264,11 +259,12 @@ function setWebContentsZoom(win, level) {
 }
 
 // Apply and persist a zoom change: clamps, updates in-memory state, sets webContents level, saves to disk.
+// All zoom mutations must go through this function to keep _currentZoom consistent.
 function applyZoom(win, level) {
   if (!win || win.isDestroyed() || !win.webContents) return;
   const previous = _currentZoom;
   const clamped = clampZoom(level);
-  updateZoomState(clamped);
+  _currentZoom = clamped;
   setWebContentsZoom(win, clamped);
   if (clamped !== previous) {
     saveZoomLevel(clamped);
@@ -967,7 +963,11 @@ function createWindow() {
   const debouncedZoomReapply = () => {
     if (_resizeZoomTimer) clearTimeout(_resizeZoomTimer);
     _resizeZoomTimer = setTimeout(() => {
-      if (!win.isDestroyed() && win.webContents.getZoomLevel() !== _currentZoom) {
+      if (!win || win.isDestroyed() || !win.webContents) {
+        _resizeZoomTimer = null;
+        return;
+      }
+      if (win.webContents.getZoomLevel() !== _currentZoom) {
         win.webContents.setZoomLevel(_currentZoom);
       }
       _resizeZoomTimer = null;
@@ -1002,9 +1002,7 @@ function createWindow() {
     }
     
     // Load saved zoom level or use default (Ctrl+0 actual size)
-    const savedZoom = clampZoom(loadZoomLevel());
-    _currentZoom = savedZoom;
-    win.webContents.setZoomLevel(savedZoom);
+    applyZoom(win, loadZoomLevel());
   });
   
   // Save zoom level when it changes (e.g., mouse-wheel / pinch zoom)

--- a/main.js
+++ b/main.js
@@ -254,10 +254,13 @@ function saveZoomLevel(level) {
 // Apply and persist a zoom change: clamps, updates in-memory state, sets webContents level, saves to disk.
 function applyZoom(win, level) {
   if (!win || win.isDestroyed()) return;
+  const previous = _currentZoom;
   const clamped = clampZoom(level);
   _currentZoom = clamped;
   win.webContents.setZoomLevel(clamped);
-  saveZoomLevel(clamped);
+  if (clamped !== previous) {
+    saveZoomLevel(clamped);
+  }
 }
 
 function getInitialWindowBounds() {
@@ -939,6 +942,7 @@ function createWindow() {
   // Register F12 as global shortcut to toggle DevTools.
   // Zoom is preserved by the devtools-opened/devtools-closed handlers via _currentZoom.
   globalShortcut.register('F12', () => {
+    if (!win || win.isDestroyed() || !win.webContents) return;
     if (win.webContents.isDevToolsOpened()) {
       win.webContents.closeDevTools();
     } else {

--- a/main.js
+++ b/main.js
@@ -960,7 +960,7 @@ function createWindow() {
   });
   
   // Save zoom level when it changes (e.g., Ctrl+Plus, Ctrl+Minus, Ctrl+0)
-  win.webContents.on('zoom-changed', (event, direction) => {
+  win.webContents.on('zoom-changed', (_event, direction) => {
     const newLevel = win.webContents.getZoomLevel();
     const clampedLevel = Math.max(MIN_ZOOM_LEVEL, Math.min(MAX_ZOOM_LEVEL, newLevel));
     if (newLevel !== clampedLevel) {

--- a/main.js
+++ b/main.js
@@ -191,6 +191,11 @@ const DEFAULT_ZOOM_LEVEL = 0; // Ctrl+0 actual size
 const MIN_ZOOM_LEVEL = -9;
 const MAX_ZOOM_LEVEL = 9;
 
+// Zoom cache coordination: prevents race between F12 handler and devtools-opened/closed handlers
+let _zoomRecentlySaved = false;     // Flag indicating F12 handler just saved zoom
+let _cachedZoom = DEFAULT_ZOOM_LEVEL; // Cached zoom from F12 handler
+let _zoomCacheTimer = null;         // Timer to clear the cache flag after debounce
+
 // Ensure config directory exists
 function ensureConfigDir() {
   if (!fs.existsSync(CONFIG_DIR)) {
@@ -909,6 +914,11 @@ function createWindow() {
     // Store current zoom before toggling DevTools (DevTools toggle can reset zoom)
     const currentZoom = win.webContents.getZoomLevel();
     
+    // Signal to devtools handlers that we're managing zoom to avoid race condition
+    _zoomRecentlySaved = true;
+    _cachedZoom = currentZoom;
+    if (_zoomCacheTimer) clearTimeout(_zoomCacheTimer);
+    
     if (win.webContents.isDevToolsOpened()) {
       win.webContents.closeDevTools();
     } else {
@@ -920,6 +930,11 @@ function createWindow() {
       win.webContents.setZoomLevel(currentZoom);
       saveZoomLevel(currentZoom); // Persist the zoom level
     }, 150);
+    
+    // Clear the zoom cache flag after debounce so normal devtools handlers resume
+    _zoomCacheTimer = setTimeout(() => {
+      _zoomRecentlySaved = false;
+    }, 250);
   });
 
   // Active enforcement: if window size falls below minimum after any resize, restore it
@@ -997,8 +1012,9 @@ function createWindow() {
   win.webContents.on('devtools-opened', () => {
     setTimeout(() => {
       if (!win.isDestroyed()) {
+        // If F12 handler recently saved zoom, use cached value instead of loading from disk
         const currentZoom = win.webContents.getZoomLevel();
-        const targetZoom = loadZoomLevel();
+        const targetZoom = _zoomRecentlySaved ? _cachedZoom : loadZoomLevel();
         const clampedZoom = clampZoom(targetZoom);
         if (currentZoom !== clampedZoom) {
           win.webContents.setZoomLevel(clampedZoom);
@@ -1010,8 +1026,9 @@ function createWindow() {
   win.webContents.on('devtools-closed', () => {
     setTimeout(() => {
       if (!win.isDestroyed()) {
+        // If F12 handler recently saved zoom, use cached value instead of loading from disk
         const currentZoom = win.webContents.getZoomLevel();
-        const targetZoom = loadZoomLevel();
+        const targetZoom = _zoomRecentlySaved ? _cachedZoom : loadZoomLevel();
         const clampedZoom = clampZoom(targetZoom);
         if (currentZoom !== clampedZoom) {
           win.webContents.setZoomLevel(clampedZoom);

--- a/main.js
+++ b/main.js
@@ -958,6 +958,15 @@ function createWindow() {
     saveZoomLevel(clampedLevel);
   });
 
+  // Intercept new window requests (e.g., target="_blank" links) and open in system browser
+  win.webContents.setWindowOpenHandler(({ url }) => {
+    // Open external links in the system default browser
+    if (url.startsWith('http://') || url.startsWith('https://')) {
+      shell.openExternal(url);
+      return { action: 'deny' }; // Prevent Electron from opening its own window
+    }
+  });
+
   // Window resize zoom restoration timer
   let _resizeZoomTimer = null;
   win.on('resize', () => {

--- a/main.js
+++ b/main.js
@@ -188,6 +188,8 @@ const PREFERRED_WINDOW_HEIGHT = 1080;
 const CONFIG_DIR = path.join(app.getPath('userData'), 'config');
 const ZOOM_CONFIG_FILE = path.join(CONFIG_DIR, 'zoom.json');
 const DEFAULT_ZOOM_LEVEL = 0; // Ctrl+0 actual size
+const MIN_ZOOM_LEVEL = -9;
+const MAX_ZOOM_LEVEL = 9;
 
 // Ensure config directory exists
 function ensureConfigDir() {
@@ -214,7 +216,8 @@ function loadZoomLevel() {
 function saveZoomLevel(level) {
   try {
     ensureConfigDir();
-    fs.writeFileSync(ZOOM_CONFIG_FILE, JSON.stringify({ zoomLevel: level }, null, 2));
+    const clampedLevel = Math.max(MIN_ZOOM_LEVEL, Math.min(MAX_ZOOM_LEVEL, level));
+    fs.writeFileSync(ZOOM_CONFIG_FILE, JSON.stringify({ zoomLevel: clampedLevel }, null, 2));
   } catch (e) {
     console.error('Failed to save zoom config:', e);
   }
@@ -941,39 +944,95 @@ function createWindow() {
     }
     
     // Load saved zoom level or use default (Ctrl+0 actual size)
-    const savedZoom = loadZoomLevel();
+    const savedZoom = Math.max(MIN_ZOOM_LEVEL, Math.min(MAX_ZOOM_LEVEL, loadZoomLevel()));
     win.webContents.setZoomLevel(savedZoom);
   });
   
   // Save zoom level when it changes (e.g., Ctrl+Plus, Ctrl+Minus, Ctrl+0)
   win.webContents.on('zoom-changed', (event, direction) => {
     const newLevel = win.webContents.getZoomLevel();
-    saveZoomLevel(newLevel);
-  });
-
-  // Intercept new window requests (e.g., target="_blank" links) and open in system browser
-  win.webContents.setWindowOpenHandler(({ url }) => {
-    // Open external links in the system default browser
-    if (url.startsWith('http://') || url.startsWith('https://')) {
-      shell.openExternal(url);
-      return { action: 'deny' }; // Prevent Electron from opening its own window
+    const clampedLevel = Math.max(MIN_ZOOM_LEVEL, Math.min(MAX_ZOOM_LEVEL, newLevel));
+    if (newLevel !== clampedLevel) {
+      win.webContents.setZoomLevel(clampedLevel);
     }
-    return { action: 'allow' };
+    saveZoomLevel(clampedLevel);
   });
 
-  if (buildMode === 'dev') {
-    win.webContents.openDevTools();
-  }
+  // Window resize zoom restoration timer
+  let _resizeZoomTimer = null;
+  win.on('resize', () => {
+    const [width, height] = win.getSize();
+    if (width < MIN_WINDOW_WIDTH || height < MIN_WINDOW_HEIGHT) {
+      win.setSize(Math.max(width, MIN_WINDOW_WIDTH), Math.max(height, MIN_WINDOW_HEIGHT));
+    }
+    // Re-apply saved zoom: Chromium can silently reset zoom level when window resizes
+    if (_resizeZoomTimer) clearTimeout(_resizeZoomTimer);
+    _resizeZoomTimer = setTimeout(() => {
+      if (!win.isDestroyed()) {
+        const savedZoom = Math.max(MIN_ZOOM_LEVEL, Math.min(MAX_ZOOM_LEVEL, loadZoomLevel()));
+        if (win.webContents.getZoomLevel() !== savedZoom) {
+          win.webContents.setZoomLevel(savedZoom);
+        }
+      }
+    }, 150);
+  });
 
-  // Re-apply zoom level when DevTools closes (Electron resets zoom on DevTools open/close)
+  // Clear resize timer on window close to prevent lingering references
+  win.on('closed', () => {
+    if (_resizeZoomTimer) {
+      clearTimeout(_resizeZoomTimer);
+      _resizeZoomTimer = null;
+    }
+  });
+
+  // Re-apply saved zoom when DevTools opens/closes (Electron/Chromium can reset zoom on DevTools operations)
+  win.webContents.on('devtools-opened', () => {
+    setTimeout(() => {
+      if (!win.isDestroyed()) {
+        const currentZoom = win.webContents.getZoomLevel();
+        const targetZoom = loadZoomLevel();
+        const clampedZoom = Math.max(MIN_ZOOM_LEVEL, Math.min(MAX_ZOOM_LEVEL, targetZoom));
+        if (currentZoom !== clampedZoom) {
+          win.webContents.setZoomLevel(clampedZoom);
+        }
+      }
+    }, 150);
+  });
+
+  win.webContents.on('devtools-closed', () => {
+    setTimeout(() => {
+      if (!win.isDestroyed()) {
+        const currentZoom = win.webContents.getZoomLevel();
+        const targetZoom = loadZoomLevel();
+        const clampedZoom = Math.max(MIN_ZOOM_LEVEL, Math.min(MAX_ZOOM_LEVEL, targetZoom));
+        if (currentZoom !== clampedZoom) {
+          win.webContents.setZoomLevel(clampedZoom);
+        }
+      }
+    }, 150);
+  });
+
+  // Handle zoom keyboard shortcuts via before-input-event so numpad keys and no-shift
+  // variants work reliably. event.preventDefault() suppresses the menu role accelerator
+  // so only this handler fires for keyboard-triggered zoom changes.
   win.webContents.on('before-input-event', (event, input) => {
-    // F12 or Ctrl+Shift+I opens/closes DevTools; re-apply zoom persistently
-    if ((input.key === 'F12') || 
-        (input.control && input.shift && input.key.toLowerCase() === 'i')) {
-      setTimeout(() => {
-        const savedZoom = loadZoomLevel();
-        win.webContents.setZoomLevel(savedZoom); // Reapply zoom after DevTools toggle
-      }, 100);
+    if (input.type !== 'keyDown' || !input.control || input.shift || input.alt) return;
+    const code = input.code;
+    if (code === 'Equal' || code === 'NumpadAdd') {
+      event.preventDefault();
+      const level = Math.min(MAX_ZOOM_LEVEL, win.webContents.getZoomLevel() + 1);
+      win.webContents.setZoomLevel(level);
+      saveZoomLevel(level);
+    } else if (code === 'Minus' || code === 'NumpadSubtract') {
+      event.preventDefault();
+      const level = Math.max(MIN_ZOOM_LEVEL, win.webContents.getZoomLevel() - 1);
+      win.webContents.setZoomLevel(level);
+      saveZoomLevel(level);
+    } else if (code === 'Digit0' || code === 'Numpad0') {
+      event.preventDefault();
+      const level = Math.max(MIN_ZOOM_LEVEL, Math.min(MAX_ZOOM_LEVEL, DEFAULT_ZOOM_LEVEL));
+      win.webContents.setZoomLevel(level);
+      saveZoomLevel(level);
     }
   });
 

--- a/main.js
+++ b/main.js
@@ -948,8 +948,8 @@ function createWindow() {
     }
     // Re-apply saved zoom: Chromium can silently reset zoom level when window resizes
     if (_resizeZoomTimer) clearTimeout(_resizeZoomTimer);
-      _resizeZoomTimer = setTimeout(() => {
-        if (!win.isDestroyed()) {
+    _resizeZoomTimer = setTimeout(() => {
+      if (!win.isDestroyed()) {
         const savedZoom = clampZoom(loadZoomLevel());
         if (win.webContents.getZoomLevel() !== savedZoom) {
           win.webContents.setZoomLevel(savedZoom);

--- a/main.js
+++ b/main.js
@@ -131,7 +131,7 @@ function setupMenu(buildMode) {
           label: 'Zoom Out',
           click: () => {
             const w = BrowserWindow.getFocusedWindow();
-            applyZoom(w, _currentZoom - 1);
+            if (w) applyZoom(w, _currentZoom - 1);
           }
         },
         ...(showDevTools ? [
@@ -212,7 +212,6 @@ const MAX_ZOOM_LEVEL = 9;
 // In-memory zoom level — single source of truth; avoids disk reads on resize
 // and eliminates races between the F12 handler and devtools-opened/closed handlers.
 let _currentZoom = DEFAULT_ZOOM_LEVEL;
-let _devtoolsZoomTimer = null; // shared timer for devtools-opened/closed zoom restore (prevents timer leaks)
 
 // Ensure config directory exists
 function ensureConfigDir() {
@@ -961,6 +960,7 @@ function createWindow() {
 
   // Active enforcement: if window size falls below minimum after any resize, restore it
   let _resizeZoomTimer = null;
+  let _devtoolsZoomTimer = null; // shared between devtools-opened/closed to prevent timer leaks
   const debouncedZoomReapply = () => {
     if (_resizeZoomTimer) clearTimeout(_resizeZoomTimer);
     _resizeZoomTimer = setTimeout(() => {

--- a/main.js
+++ b/main.js
@@ -927,8 +927,10 @@ function createWindow() {
     
     // Restore zoom level after toggling DevTools
     setTimeout(() => {
-      win.webContents.setZoomLevel(currentZoom);
-      saveZoomLevel(currentZoom); // Persist the zoom level
+      if (win.isDestroyed()) return;
+      const safeZoom = clampZoom(currentZoom);
+      win.webContents.setZoomLevel(safeZoom);
+      saveZoomLevel(safeZoom); // Persist the zoom level
     }, 150);
     
     // Clear the zoom cache flag after debounce so normal devtools handlers resume
@@ -980,7 +982,7 @@ function createWindow() {
   });
   
   // Save zoom level when it changes (e.g., Ctrl+Plus, Ctrl+Minus, Ctrl+0)
-  win.webContents.on('zoom-changed', (_event, direction) => {
+  win.webContents.on('zoom-changed', (_event, _direction) => {
     const newLevel = win.webContents.getZoomLevel();
     const clampedLevel = clampZoom(newLevel);
     if (newLevel !== clampedLevel) {
@@ -1000,12 +1002,17 @@ function createWindow() {
     return { action: 'deny' };
   });
 
-  // Clear resize timer on window close to prevent lingering references
+  // Clear all timers and flags on window close to prevent lingering references
   win.on('closed', () => {
     if (_resizeZoomTimer) {
       clearTimeout(_resizeZoomTimer);
       _resizeZoomTimer = null;
     }
+    if (_zoomCacheTimer) {
+      clearTimeout(_zoomCacheTimer);
+      _zoomCacheTimer = null;
+    }
+    _zoomRecentlySaved = false;
   });
 
   // Re-apply saved zoom when DevTools opens/closes (Electron/Chromium can reset zoom on DevTools operations)

--- a/main.js
+++ b/main.js
@@ -992,15 +992,9 @@ function createWindow() {
     win.webContents.setZoomLevel(savedZoom);
   });
   
-  // Save zoom level when it changes (e.g., Ctrl+Plus, Ctrl+Minus, Ctrl+0)
+  // Save zoom level when it changes (e.g., mouse-wheel / pinch zoom)
   win.webContents.on('zoom-changed', (_event, _direction) => {
-    const newLevel = win.webContents.getZoomLevel();
-    const clampedLevel = clampZoom(newLevel);
-    if (newLevel !== clampedLevel) {
-      win.webContents.setZoomLevel(clampedLevel);
-    }
-    _currentZoom = clampedLevel;
-    saveZoomLevel(clampedLevel);
+    applyZoom(win, win.webContents.getZoomLevel());
   });
 
   // Intercept new window requests (e.g., target="_blank" links) and open in system browser
@@ -1014,7 +1008,7 @@ function createWindow() {
     return { action: 'deny' };
   });
 
-  // Clear all timers on window close to prevent lingering references
+  // Clear all timers and release window reference on close
   win.on('closed', () => {
     if (_resizeZoomTimer) {
       clearTimeout(_resizeZoomTimer);
@@ -1023,6 +1017,9 @@ function createWindow() {
     if (_devtoolsZoomTimer) {
       clearTimeout(_devtoolsZoomTimer);
       _devtoolsZoomTimer = null;
+    }
+    if (mainWindow === win) {
+      mainWindow = null;
     }
   });
 
@@ -1117,12 +1114,6 @@ function createWindow() {
   });
 
   mainWindow = win;
-
-  win.on('closed', () => {
-    if (mainWindow === win) {
-      mainWindow = null;
-    }
-  });
 }
 
 // Attempt to acquire single-instance lock with retry logic for dev mode.

--- a/main.js
+++ b/main.js
@@ -76,7 +76,7 @@ function getWindowIconPath() {
 }
 
 // Build modes (set by npm scripts in package.json):
-//   'dev'           - `yarn dev` sets NODE_ENV=development → devtools auto-open + menu item
+//   'dev'           - `yarn dev` sets NODE_ENV=development → devtools menu item (no auto-open)
 //   'dev-release'   - `yarn make:debug` sets EMUCFG_BUILD_MODE=dev-release → all menu items including toggle devtools
 //   'release'       - `yarn make` (default) → all menu items except toggle devtools (inspect only)
 function getBuildMode() {
@@ -948,7 +948,10 @@ function createWindow() {
   win.setMinimumSize(MIN_WINDOW_WIDTH, MIN_WINDOW_HEIGHT);
 
   // Register F12 as global shortcut to toggle DevTools.
+  // Unregister first: if createWindow() is called again (e.g. macOS activate after last window closed),
+  // re-registration would fail silently and the old handler would reference a destroyed window.
   // Zoom is preserved by the devtools-opened/devtools-closed handlers via _currentZoom.
+  globalShortcut.unregister('F12');
   globalShortcut.register('F12', () => {
     if (!win || win.isDestroyed() || !win.webContents) return;
     if (win.webContents.isDevToolsOpened()) {
@@ -1022,8 +1025,9 @@ function createWindow() {
     return { action: 'deny' };
   });
 
-  // Clear all timers and release window reference on close
+  // Clear all timers, unregister shortcuts, and release window reference on close
   win.on('closed', () => {
+    globalShortcut.unregister('F12');
     if (_resizeZoomTimer) {
       clearTimeout(_resizeZoomTimer);
       _resizeZoomTimer = null;

--- a/main.js
+++ b/main.js
@@ -1048,23 +1048,20 @@ function createWindow() {
   // variants work reliably. event.preventDefault() suppresses the menu role accelerator
   // so only this handler fires for keyboard-triggered zoom changes.
   win.webContents.on('before-input-event', (event, input) => {
-    if (input.type !== 'keyDown' || !input.control || input.shift || input.alt) return;
+    if (input.type !== 'keyDown' || !(input.control || input.meta) || input.shift || input.alt) return;
     const code = input.code;
     if (code === 'Equal' || code === 'NumpadAdd') {
       event.preventDefault();
       const level = clampZoom(win.webContents.getZoomLevel() + 1);
       win.webContents.setZoomLevel(level);
-      saveZoomLevel(level);
     } else if (code === 'Minus' || code === 'NumpadSubtract') {
       event.preventDefault();
       const level = clampZoom(win.webContents.getZoomLevel() - 1);
       win.webContents.setZoomLevel(level);
-      saveZoomLevel(level);
     } else if (code === 'Digit0' || code === 'Numpad0') {
       event.preventDefault();
       const level = clampZoom(DEFAULT_ZOOM_LEVEL);
       win.webContents.setZoomLevel(level);
-      saveZoomLevel(level);
     }
   });
 

--- a/main.js
+++ b/main.js
@@ -918,11 +918,22 @@ function createWindow() {
   });
 
   // Active enforcement: if window size falls below minimum after any resize, restore it
+  let _resizeZoomTimer = null;
   win.on('resize', () => {
     const [width, height] = win.getSize();
     if (width < MIN_WINDOW_WIDTH || height < MIN_WINDOW_HEIGHT) {
       win.setSize(Math.max(width, MIN_WINDOW_WIDTH), Math.max(height, MIN_WINDOW_HEIGHT));
     }
+    // Re-apply saved zoom: Chromium can silently reset zoom level when window resizes
+    if (_resizeZoomTimer) clearTimeout(_resizeZoomTimer);
+      _resizeZoomTimer = setTimeout(() => {
+        if (!win.isDestroyed()) {
+        const savedZoom = Math.max(MIN_ZOOM_LEVEL, Math.min(MAX_ZOOM_LEVEL, loadZoomLevel()));
+        if (win.webContents.getZoomLevel() !== savedZoom) {
+          win.webContents.setZoomLevel(savedZoom);
+        }
+      }
+    }, 150);
   });
 
   // Also prevent moves that would resize
@@ -965,25 +976,6 @@ function createWindow() {
       shell.openExternal(url);
       return { action: 'deny' }; // Prevent Electron from opening its own window
     }
-  });
-
-  // Window resize zoom restoration timer
-  let _resizeZoomTimer = null;
-  win.on('resize', () => {
-    const [width, height] = win.getSize();
-    if (width < MIN_WINDOW_WIDTH || height < MIN_WINDOW_HEIGHT) {
-      win.setSize(Math.max(width, MIN_WINDOW_WIDTH), Math.max(height, MIN_WINDOW_HEIGHT));
-    }
-    // Re-apply saved zoom: Chromium can silently reset zoom level when window resizes
-    if (_resizeZoomTimer) clearTimeout(_resizeZoomTimer);
-    _resizeZoomTimer = setTimeout(() => {
-      if (!win.isDestroyed()) {
-        const savedZoom = Math.max(MIN_ZOOM_LEVEL, Math.min(MAX_ZOOM_LEVEL, loadZoomLevel()));
-        if (win.webContents.getZoomLevel() !== savedZoom) {
-          win.webContents.setZoomLevel(savedZoom);
-        }
-      }
-    }, 150);
   });
 
   // Clear resize timer on window close to prevent lingering references

--- a/main.js
+++ b/main.js
@@ -115,6 +115,7 @@ function setupMenu(buildMode) {
         { role: 'togglefullscreen' },
         {
           label: 'Actual Size',
+          accelerator: 'CmdOrCtrl+0',
           click: () => {
             const w = BrowserWindow.getFocusedWindow();
             if (w) applyZoom(w, DEFAULT_ZOOM_LEVEL);
@@ -122,6 +123,7 @@ function setupMenu(buildMode) {
         },
         {
           label: 'Zoom In',
+          accelerator: 'CmdOrCtrl+Plus',
           click: () => {
             const w = BrowserWindow.getFocusedWindow();
             if (w) applyZoom(w, _currentZoom + 1);
@@ -129,6 +131,7 @@ function setupMenu(buildMode) {
         },
         {
           label: 'Zoom Out',
+          accelerator: 'CmdOrCtrl+-',
           click: () => {
             const w = BrowserWindow.getFocusedWindow();
             if (w) applyZoom(w, _currentZoom - 1);

--- a/main.js
+++ b/main.js
@@ -113,9 +113,27 @@ function setupMenu(buildMode) {
         { role: 'forceReload' },
         { type: 'separator' },
         { role: 'togglefullscreen' },
-        { role: 'resetZoom' },
-        { role: 'zoomIn' },
-        { role: 'zoomOut' },
+        {
+          label: 'Actual Size',
+          click: () => {
+            const w = BrowserWindow.getFocusedWindow();
+            applyZoom(w, DEFAULT_ZOOM_LEVEL);
+          }
+        },
+        {
+          label: 'Zoom In',
+          click: () => {
+            const w = BrowserWindow.getFocusedWindow();
+            applyZoom(w, _currentZoom + 1);
+          }
+        },
+        {
+          label: 'Zoom Out',
+          click: () => {
+            const w = BrowserWindow.getFocusedWindow();
+            applyZoom(w, _currentZoom - 1);
+          }
+        },
         ...(showDevTools ? [
           { type: 'separator' },
           { role: 'toggleDevTools', label: 'Toggle Developer Tools' }
@@ -194,6 +212,7 @@ const MAX_ZOOM_LEVEL = 9;
 // In-memory zoom level — single source of truth; avoids disk reads on resize
 // and eliminates races between the F12 handler and devtools-opened/closed handlers.
 let _currentZoom = DEFAULT_ZOOM_LEVEL;
+let _devtoolsZoomTimer = null; // shared timer for devtools-opened/closed zoom restore (prevents timer leaks)
 
 // Ensure config directory exists
 function ensureConfigDir() {
@@ -230,6 +249,15 @@ function saveZoomLevel(level) {
   } catch (e) {
     console.error('Failed to save zoom config:', e);
   }
+}
+
+// Apply and persist a zoom change: clamps, updates in-memory state, sets webContents level, saves to disk.
+function applyZoom(win, level) {
+  if (!win || win.isDestroyed()) return;
+  const clamped = clampZoom(level);
+  _currentZoom = clamped;
+  win.webContents.setZoomLevel(clamped);
+  saveZoomLevel(clamped);
 }
 
 function getInitialWindowBounds() {
@@ -908,25 +936,14 @@ function createWindow() {
   // Enforce minimum window size multiple ways for cross-platform compatibility
   win.setMinimumSize(MIN_WINDOW_WIDTH, MIN_WINDOW_HEIGHT);
 
-  // Register F12 as global shortcut to toggle DevTools while preserving zoom
+  // Register F12 as global shortcut to toggle DevTools.
+  // Zoom is preserved by the devtools-opened/devtools-closed handlers via _currentZoom.
   globalShortcut.register('F12', () => {
-    // Store current zoom before toggling DevTools (DevTools toggle can reset zoom)
-    const currentZoom = win.webContents.getZoomLevel();
-    
     if (win.webContents.isDevToolsOpened()) {
       win.webContents.closeDevTools();
     } else {
       win.webContents.openDevTools();
     }
-    
-    // Restore zoom level after toggling DevTools
-    setTimeout(() => {
-      if (win.isDestroyed()) return;
-      const safeZoom = clampZoom(currentZoom);
-      _currentZoom = safeZoom;
-      win.webContents.setZoomLevel(safeZoom);
-      saveZoomLevel(safeZoom); // Persist the zoom level
-    }, 150);
   });
 
   // Active enforcement: if window size falls below minimum after any resize, restore it
@@ -993,57 +1010,52 @@ function createWindow() {
     return { action: 'deny' };
   });
 
-  // Clear resize timer on window close to prevent lingering references
+  // Clear all timers on window close to prevent lingering references
   win.on('closed', () => {
     if (_resizeZoomTimer) {
       clearTimeout(_resizeZoomTimer);
       _resizeZoomTimer = null;
     }
+    if (_devtoolsZoomTimer) {
+      clearTimeout(_devtoolsZoomTimer);
+      _devtoolsZoomTimer = null;
+    }
   });
 
   // Re-apply current zoom when DevTools opens/closes (Electron/Chromium can reset zoom on DevTools operations)
+  // Both events share _devtoolsZoomTimer so rapid open/close doesn't leak multiple timers.
   win.webContents.on('devtools-opened', () => {
-    setTimeout(() => {
-      if (!win.isDestroyed() && win.webContents.getZoomLevel() !== _currentZoom) {
-        win.webContents.setZoomLevel(_currentZoom);
-      }
+    if (_devtoolsZoomTimer) clearTimeout(_devtoolsZoomTimer);
+    _devtoolsZoomTimer = setTimeout(() => {
+      applyZoom(win, _currentZoom);
     }, 150);
   });
 
   win.webContents.on('devtools-closed', () => {
-    setTimeout(() => {
-      if (!win.isDestroyed() && win.webContents.getZoomLevel() !== _currentZoom) {
-        win.webContents.setZoomLevel(_currentZoom);
-      }
+    if (_devtoolsZoomTimer) clearTimeout(_devtoolsZoomTimer);
+    _devtoolsZoomTimer = setTimeout(() => {
+      applyZoom(win, _currentZoom);
     }, 150);
   });
 
-  // Handle zoom keyboard shortcuts via before-input-event so numpad keys and no-shift
-  // variants work reliably. event.preventDefault() suppresses the menu role accelerator
-  // so only this handler fires for keyboard-triggered zoom changes.
+  // Handle zoom keyboard shortcuts via before-input-event so numpad keys and Shift+Equal
+  // (Ctrl++ on US keyboards) work reliably. event.preventDefault() suppresses the menu
+  // accelerator so only this handler fires for keyboard-triggered zoom changes.
+  // Note: setZoomLevel() does NOT emit 'zoom-changed'; applyZoom() handles _currentZoom
+  // update and saveZoomLevel() directly so persistence and resize-recovery work correctly.
   win.webContents.on('before-input-event', (event, input) => {
-    if (input.type !== 'keyDown' || !(input.control || input.meta) || input.shift || input.alt) return;
+    if (input.type !== 'keyDown' || !(input.control || input.meta) || input.alt) return;
     const code = input.code;
-    // Note: setZoomLevel() does NOT emit 'zoom-changed', so we must update _currentZoom
-    // and call saveZoomLevel() here directly for persistence and resize-recovery to work.
     if (code === 'Equal' || code === 'NumpadAdd') {
+      // Accepts Ctrl+= and Ctrl++ (Shift+Equal) for zoom in
       event.preventDefault();
-      const level = clampZoom(win.webContents.getZoomLevel() + 1);
-      win.webContents.setZoomLevel(level);
-      _currentZoom = level;
-      saveZoomLevel(level);
+      applyZoom(win, _currentZoom + 1);
     } else if (code === 'Minus' || code === 'NumpadSubtract') {
       event.preventDefault();
-      const level = clampZoom(win.webContents.getZoomLevel() - 1);
-      win.webContents.setZoomLevel(level);
-      _currentZoom = level;
-      saveZoomLevel(level);
+      applyZoom(win, _currentZoom - 1);
     } else if (code === 'Digit0' || code === 'Numpad0') {
       event.preventDefault();
-      const level = clampZoom(DEFAULT_ZOOM_LEVEL);
-      win.webContents.setZoomLevel(level);
-      _currentZoom = level;
-      saveZoomLevel(level);
+      applyZoom(win, DEFAULT_ZOOM_LEVEL);
     }
   });
 


### PR DESCRIPTION
- **fix: zoom persistence, clamping, keyboard shortcuts, and devtools integration**
- **fix: revert accidental removal of URL intercept**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized, bounded zoom with a single source of truth and consistent re-application across DevTools toggles and window resizes.
  * Keyboard zoom shortcuts handled at input level (Ctrl/⌘ + +/−/0) to apply clamped zoom immediately and prevent default accelerators.

* **Bug Fixes**
  * Zoom persistence only writes clamped changes to avoid spurious disk writes.
  * Debounced re-application prevents zoom drift after resizes and DevTools toggles.
  * Non-HTTP(S) URLs are blocked from opening and timers/handlers are cleaned up on window close.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->