### PR TITLE
Remember last window position and size

### DIFF
--- a/main.js
+++ b/main.js
@@ -204,6 +204,8 @@ const MIN_WINDOW_WIDTH = 1024;
 const MIN_WINDOW_HEIGHT = 550;
 const PREFERRED_WINDOW_WIDTH = 1700;
 const PREFERRED_WINDOW_HEIGHT = 1080;
+const MIN_VISIBLE_HORIZONTAL_OVERLAP = 200; // px required on-screen so the user can grab/move the window
+const MIN_TITLE_BAR_GRAB_HEIGHT = 30;       // px of title bar that must be within the workArea
 
 // Zoom level persistence
 const CONFIG_DIR = path.join(app.getPath('userData'), 'config');
@@ -318,11 +320,13 @@ function isValidWindowBounds(bounds) {
   }
   return screen.getAllDisplays().some(display => {
     const wa = display.workArea;
-    // Title bar must be within the display's work area vertically
-    const titleBarVisible = bounds.y >= wa.y && bounds.y < wa.y + wa.height;
+    // Enough of the title bar must be within the workArea to be grabbable
+    const titleBarVisible =
+      bounds.y >= wa.y &&
+      bounds.y + MIN_TITLE_BAR_GRAB_HEIGHT <= wa.y + wa.height;
     // Window must have meaningful horizontal overlap (not just a sliver)
     const horizontalOverlap =
-      Math.min(bounds.x + bounds.width, wa.x + wa.width) - Math.max(bounds.x, wa.x) > 200;
+      Math.min(bounds.x + bounds.width, wa.x + wa.width) - Math.max(bounds.x, wa.x) > MIN_VISIBLE_HORIZONTAL_OVERLAP;
     return titleBarVisible && horizontalOverlap;
   });
 }
@@ -1099,13 +1103,12 @@ function createWindow() {
     return { action: 'deny' };
   });
 
-  // Save window bounds and maximized state before the window is destroyed.
+  // Save window bounds and maximized state on close.
+  // 'close' fires before the window is destroyed, so getNormalBounds() is always safe here.
   // getNormalBounds() returns the pre-maximize size so restoring normal bounds
   // works correctly even when closing while maximized.
   win.on('close', () => {
-    if (!win.isDestroyed()) {
-      saveConfig({ isMaximized: win.isMaximized(), windowBounds: win.getNormalBounds() });
-    }
+    saveConfig({ isMaximized: win.isMaximized(), windowBounds: win.getNormalBounds() });
   });
 
   // Clear all timers, unregister shortcuts, and release window reference on close

--- a/main.js
+++ b/main.js
@@ -318,10 +318,12 @@ function isValidWindowBounds(bounds) {
   }
   return screen.getAllDisplays().some(display => {
     const wa = display.workArea;
-    const overlapX = Math.max(0, Math.min(bounds.x + bounds.width, wa.x + wa.width) - Math.max(bounds.x, wa.x));
-    const overlapY = Math.max(0, Math.min(bounds.y + bounds.height, wa.y + wa.height) - Math.max(bounds.y, wa.y));
-    // Require enough overlap so the title bar is reachable
-    return overlapX >= 100 && overlapY >= 50;
+    // Title bar must be within the display's work area vertically
+    const titleBarVisible = bounds.y >= wa.y && bounds.y < wa.y + wa.height;
+    // Window must have meaningful horizontal overlap (not just a sliver)
+    const horizontalOverlap =
+      Math.min(bounds.x + bounds.width, wa.x + wa.width) - Math.max(bounds.x, wa.x) > 200;
+    return titleBarVisible && horizontalOverlap;
   });
 }
 

--- a/main.js
+++ b/main.js
@@ -229,21 +229,25 @@ function clampZoom(level) {
   return Math.max(MIN_ZOOM_LEVEL, Math.min(MAX_ZOOM_LEVEL, Number.isNaN(n) ? DEFAULT_ZOOM_LEVEL : n));
 }
 
-// Load unified app config (zoom level, last dialog folder, etc.)
+// Load unified app config (zoom level, last dialog folder, window bounds, etc.)
 function loadConfig() {
   try {
     if (fs.existsSync(APP_CONFIG_FILE)) {
       const data = fs.readFileSync(APP_CONFIG_FILE, 'utf8');
       const config = JSON.parse(data);
+      const wb = config.windowBounds;
       return {
         zoomLevel: typeof config.zoomLevel === 'number' ? config.zoomLevel : DEFAULT_ZOOM_LEVEL,
         lastDialogFolder: typeof config.lastDialogFolder === 'string' ? config.lastDialogFolder : '',
+        windowBounds: (wb && typeof wb.x === 'number' && typeof wb.y === 'number' &&
+                       typeof wb.width === 'number' && typeof wb.height === 'number') ? wb : null,
+        isMaximized: typeof config.isMaximized === 'boolean' ? config.isMaximized : false,
       };
     }
   } catch (e) {
     console.error('Failed to load app config:', e);
   }
-  return { zoomLevel: DEFAULT_ZOOM_LEVEL, lastDialogFolder: '' };
+  return { zoomLevel: DEFAULT_ZOOM_LEVEL, lastDialogFolder: '', windowBounds: null, isMaximized: false };
 }
 
 // Save unified app config (sanitizes known fields, merges with existing config)
@@ -256,6 +260,17 @@ function saveConfig(patch) {
     }
     if ('lastDialogFolder' in patch) {
       sanitizedPatch.lastDialogFolder = typeof patch.lastDialogFolder === 'string' ? patch.lastDialogFolder : '';
+    }
+    if ('windowBounds' in patch) {
+      const b = patch.windowBounds;
+      if (b && typeof b.x === 'number' && typeof b.y === 'number' &&
+          typeof b.width === 'number' && typeof b.height === 'number' &&
+          b.width >= MIN_WINDOW_WIDTH && b.height >= MIN_WINDOW_HEIGHT) {
+        sanitizedPatch.windowBounds = { x: b.x, y: b.y, width: b.width, height: b.height };
+      }
+    }
+    if ('isMaximized' in patch) {
+      sanitizedPatch.isMaximized = Boolean(patch.isMaximized);
     }
     const existing = loadConfig();
     fs.writeFileSync(APP_CONFIG_FILE, JSON.stringify({ ...existing, ...sanitizedPatch }, null, 2));
@@ -289,6 +304,36 @@ function getInitialWindowBounds() {
     x: workArea.x + Math.max(0, Math.floor((workArea.width - width) / 2)),
     y: workArea.y + Math.max(0, Math.floor((workArea.height - height) / 2)),
   };
+}
+
+// Returns true if the given bounds have sufficient overlap with at least one display
+// to ensure the window is visible and grabbable after a monitor configuration change.
+function isValidWindowBounds(bounds) {
+  if (!bounds || typeof bounds.x !== 'number' || typeof bounds.y !== 'number' ||
+      typeof bounds.width !== 'number' || typeof bounds.height !== 'number') {
+    return false;
+  }
+  if (bounds.width < MIN_WINDOW_WIDTH || bounds.height < MIN_WINDOW_HEIGHT) {
+    return false;
+  }
+  return screen.getAllDisplays().some(display => {
+    const wa = display.workArea;
+    const overlapX = Math.max(0, Math.min(bounds.x + bounds.width, wa.x + wa.width) - Math.max(bounds.x, wa.x));
+    const overlapY = Math.max(0, Math.min(bounds.y + bounds.height, wa.y + wa.height) - Math.max(bounds.y, wa.y));
+    // Require enough overlap so the title bar is reachable
+    return overlapX >= 100 && overlapY >= 50;
+  });
+}
+
+// Returns startup bounds: saved position/size if valid, otherwise full work area (first launch).
+function getStartupWindowBounds(config) {
+  if (config.windowBounds && isValidWindowBounds(config.windowBounds)) {
+    return config.windowBounds;
+  }
+  // First launch or invalid saved bounds: fill the available work area
+  const display = screen.getDisplayNearestPoint(screen.getCursorScreenPoint());
+  const workArea = display.workArea;
+  return { x: workArea.x, y: workArea.y, width: workArea.width, height: workArea.height };
 }
 
 function resetWindowToPreferredBounds(win) {
@@ -946,7 +991,8 @@ ipcMain.handle('dialog:truncate-file', async (event, filePath, size) => {
 function createWindow() {
   const buildMode = getBuildMode();
   setupMenu(buildMode);
-  const initialBounds = getInitialWindowBounds();
+  const startupConfig = loadConfig();
+  const initialBounds = getStartupWindowBounds(startupConfig);
 
   const windowIconPath = getWindowIconPath();
 
@@ -964,6 +1010,11 @@ function createWindow() {
     },
     icon: windowIconPath,
   });
+
+  // Restore maximized state from last session
+  if (startupConfig.isMaximized) {
+    win.maximize();
+  }
 
   // Enforce minimum window size multiple ways for cross-platform compatibility
   win.setMinimumSize(MIN_WINDOW_WIDTH, MIN_WINDOW_HEIGHT);
@@ -1044,6 +1095,15 @@ function createWindow() {
     }
     // Deny all other URLs (file://, app://, etc.) to avoid Electron's "response must be an object" console error
     return { action: 'deny' };
+  });
+
+  // Save window bounds and maximized state before the window is destroyed.
+  // getNormalBounds() returns the pre-maximize size so restoring normal bounds
+  // works correctly even when closing while maximized.
+  win.on('close', () => {
+    if (!win.isDestroyed()) {
+      saveConfig({ isMaximized: win.isMaximized(), windowBounds: win.getNormalBounds() });
+    }
   });
 
   // Clear all timers, unregister shortcuts, and release window reference on close


### PR DESCRIPTION
Persist window bounds and maximized state in app config so relaunch restores user window layout while keeping first-launch full work area support.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The app now remembers and restores window position, size, and maximized state across launches.
  * Restored window positions are validated to ensure they appear correctly on your current display(s); if invalid, the window opens on the nearest visible work area.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->