### PR TITLE
feat: add git pre-commit hook with yarn lint enforcement

### DIFF
--- a/.github/GIT-HOOKS.md
+++ b/.github/GIT-HOOKS.md
@@ -1,0 +1,67 @@
+# Git Pre-Commit Hook Setup
+
+Automatic lint enforcement before commits.
+
+## Setup
+
+**All platforms (Linux, macOS, Windows):**
+
+```bash
+yarn setup:hooks
+```
+
+Or manually for specific platform:
+
+### Linux & macOS
+
+```bash
+bash .github/scripts/setup-hooks.sh
+```
+
+### Windows (PowerShell)
+
+```powershell
+powershell -ExecutionPolicy Bypass -File .github/scripts/setup-hooks.ps1
+```
+
+## How It Works
+
+On every commit:
+1. Checks if `node_modules` exists
+2. If missing, runs `yarn install`
+3. Runs `yarn lint`
+4. Blocks commit if lint errors found
+5. Allows commit if no errors (warnings are OK)
+
+## Usage
+
+```bash
+git commit -m "Your message"
+```
+
+If lint passes: ✅ commit succeeds  
+If lint fails: ❌ commit blocked
+
+### Fixing Lint Errors
+
+```bash
+yarn lint -- --fix     # Auto-fix where possible
+git add <files>
+git commit -m "Fix: resolve lint issues"
+```
+
+### Emergency Bypass
+
+```bash
+git commit --no-verify
+```
+
+⚠️ Only use for urgent fixes — CI/CD will still check lint.
+
+## Files
+
+- `.github/scripts/pre-commit-hook.sh` — The hook script
+- `.github/scripts/setup-hooks.js` — Cross-platform setup (auto-detects OS)
+- `.github/scripts/setup-hooks.sh` — Setup for Linux/macOS (manual)
+- `.github/scripts/setup-hooks.ps1` — Setup for Windows (manual)
+- `.git/hooks/pre-commit` — Installed hook (created by setup script)

--- a/.github/scripts/pre-commit-hook.sh
+++ b/.github/scripts/pre-commit-hook.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Pre-commit hook for EmuConfigurator
+# Enforces yarn lint checks before commits
+# Auto-installs dependencies if needed
+
+set -e
+
+# Ensure node_modules exists, install if missing
+if [ ! -d "node_modules" ]; then
+  echo "[INFO] Installing dependencies..."
+  yarn install
+fi
+
+# Run lint check
+echo "[LINT] Running lint checks..."
+if yarn lint; then
+  echo "[OK] Lint checks passed!"
+  exit 0
+else
+  echo "[ERROR] Lint errors found. Please fix and try again."
+  echo "[TIP] Run 'yarn lint -- --fix' to auto-fix some issues."
+  exit 1
+fi

--- a/.github/scripts/setup-hooks.js
+++ b/.github/scripts/setup-hooks.js
@@ -23,6 +23,14 @@ try {
   const hookSource = path.join(projectRoot, '.github', 'scripts', 'pre-commit-hook.sh');
   const hookDest = path.join(hooksDir, 'pre-commit');
   
+  // Back up existing hook if it exists and is not our source
+  if (fs.existsSync(hookDest)) {
+    const timestamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, -5);
+    const backupPath = `${hookDest}.bak.${timestamp}`;
+    fs.copyFileSync(hookDest, backupPath);
+    console.log(`[INFO] Backed up existing hook to ${path.basename(backupPath)}`);
+  }
+  
   const hookContent = fs.readFileSync(hookSource, 'utf8');
   fs.writeFileSync(hookDest, hookContent);
   

--- a/.github/scripts/setup-hooks.js
+++ b/.github/scripts/setup-hooks.js
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+// Cross-platform git hook setup
+// Detects OS and runs appropriate setup script
+
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+const projectRoot = path.resolve(__dirname, '../../');
+const platform = process.platform;
+
+console.log('[INFO] Setting up git pre-commit hook...');
+  console.log(`[PLATFORM] ${platform === 'win32' ? 'Windows' : platform === 'darwin' ? 'macOS' : 'Linux'}`);
+
+try {
+  // Ensure .git/hooks directory exists
+  const hooksDir = path.join(projectRoot, '.git', 'hooks');
+  if (!fs.existsSync(hooksDir)) {
+    fs.mkdirSync(hooksDir, { recursive: true });
+  }
+
+  // Copy hook script to .git/hooks
+  const hookSource = path.join(projectRoot, '.github', 'scripts', 'pre-commit-hook.sh');
+  const hookDest = path.join(hooksDir, 'pre-commit');
+  
+  const hookContent = fs.readFileSync(hookSource, 'utf8');
+  fs.writeFileSync(hookDest, hookContent);
+  
+  // Make hook executable on Unix-like systems
+  if (platform !== 'win32') {
+    fs.chmodSync(hookDest, 0o755);
+  }
+
+  console.log('[OK] Hook installed at .git/hooks/pre-commit');
+  console.log('[INFO] Testing the hook on your next commit...');
+  process.exit(0);
+} catch (error) {
+  console.error('[ERROR] Setup failed:', error.message);
+  process.exit(1);
+}

--- a/.github/scripts/setup-hooks.ps1
+++ b/.github/scripts/setup-hooks.ps1
@@ -1,0 +1,19 @@
+# Setup git pre-commit hook (Windows PowerShell)
+
+$ErrorActionPreference = "Stop"
+
+$ProjectRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSCommandPath))
+Set-Location $ProjectRoot
+
+Write-Host "[INFO] Setting up git pre-commit hook..." -ForegroundColor Green
+
+# Copy hook script to .git/hooks
+$HooksDir = ".git\hooks"
+if (-not (Test-Path $HooksDir)) {
+  New-Item -ItemType Directory -Force -Path $HooksDir | Out-Null
+}
+
+Copy-Item -Path ".github\scripts\pre-commit-hook.sh" -Destination "$HooksDir\pre-commit" -Force
+
+Write-Host "[OK] Hook installed at .git\hooks\pre-commit" -ForegroundColor Green
+Write-Host "[INFO] Testing the hook on your next commit..." -ForegroundColor Yellow

--- a/.github/scripts/setup-hooks.ps1
+++ b/.github/scripts/setup-hooks.ps1
@@ -5,7 +5,7 @@ $ErrorActionPreference = "Stop"
 $ProjectRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSCommandPath))
 Set-Location $ProjectRoot
 
-Write-Host "[INFO] Setting up git pre-commit hook..." -ForegroundColor Green
+Write-Output "[INFO] Setting up git pre-commit hook..."
 
 # Copy hook script to .git/hooks
 $HooksDir = ".git\hooks"
@@ -21,10 +21,10 @@ if (Test-Path $HookDest) {
   $Timestamp = Get-Date -Format "yyyy-MM-dd_HH-mm-ss"
   $BackupPath = "$HookDest.bak.$Timestamp"
   Copy-Item -Path $HookDest -Destination $BackupPath -Force
-  Write-Host "[INFO] Backed up existing hook to $(Split-Path -Leaf $BackupPath)" -ForegroundColor Yellow
+  Write-Output "[INFO] Backed up existing hook to $(Split-Path -Leaf $BackupPath)"
 }
 
 Copy-Item -Path $HookSource -Destination $HookDest -Force
 
-Write-Host "[OK] Hook installed at .git\hooks\pre-commit" -ForegroundColor Green
-Write-Host "[INFO] Testing the hook on your next commit..." -ForegroundColor Yellow
+Write-Output "[OK] Hook installed at .git\hooks\pre-commit"
+Write-Output "[INFO] Testing the hook on your next commit..."

--- a/.github/scripts/setup-hooks.ps1
+++ b/.github/scripts/setup-hooks.ps1
@@ -13,7 +13,18 @@ if (-not (Test-Path $HooksDir)) {
   New-Item -ItemType Directory -Force -Path $HooksDir | Out-Null
 }
 
-Copy-Item -Path ".github\scripts\pre-commit-hook.sh" -Destination "$HooksDir\pre-commit" -Force
+$HookSource = ".github\scripts\pre-commit-hook.sh"
+$HookDest = "$HooksDir\pre-commit"
+
+# Back up existing hook if it exists
+if (Test-Path $HookDest) {
+  $Timestamp = Get-Date -Format "yyyy-MM-dd_HH-mm-ss"
+  $BackupPath = "$HookDest.bak.$Timestamp"
+  Copy-Item -Path $HookDest -Destination $BackupPath -Force
+  Write-Host "[INFO] Backed up existing hook to $(Split-Path -Leaf $BackupPath)" -ForegroundColor Yellow
+}
+
+Copy-Item -Path $HookSource -Destination $HookDest -Force
 
 Write-Host "[OK] Hook installed at .git\hooks\pre-commit" -ForegroundColor Green
 Write-Host "[INFO] Testing the hook on your next commit..." -ForegroundColor Yellow

--- a/.github/scripts/setup-hooks.sh
+++ b/.github/scripts/setup-hooks.sh
@@ -19,7 +19,7 @@ if [ -f "$HOOK_DEST" ]; then
   TIMESTAMP=$(date +%Y-%m-%d_%H-%M-%S)
   BACKUP_PATH="${HOOK_DEST}.bak.${TIMESTAMP}"
   cp "$HOOK_DEST" "$BACKUP_PATH"
-  echo "[INFO] Backed up existing hook to $(basename $BACKUP_PATH)"
+  echo "[INFO] Backed up existing hook to $(basename "$BACKUP_PATH")"
 fi
 
 cp "$HOOK_SOURCE" "$HOOK_DEST"

--- a/.github/scripts/setup-hooks.sh
+++ b/.github/scripts/setup-hooks.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Setup git pre-commit hook (Linux & macOS)
+
+set -e
+
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$PROJECT_ROOT"
+
+echo "[INFO] Setting up git pre-commit hook..."
+
+# Copy hook script to .git/hooks
+mkdir -p .git/hooks
+cp .github/scripts/pre-commit-hook.sh .git/hooks/pre-commit
+chmod +x .git/hooks/pre-commit
+
+echo "[OK] Hook installed at .git/hooks/pre-commit"
+echo "[INFO] Testing the hook on your next commit..."

--- a/.github/scripts/setup-hooks.sh
+++ b/.github/scripts/setup-hooks.sh
@@ -10,8 +10,20 @@ echo "[INFO] Setting up git pre-commit hook..."
 
 # Copy hook script to .git/hooks
 mkdir -p .git/hooks
-cp .github/scripts/pre-commit-hook.sh .git/hooks/pre-commit
-chmod +x .git/hooks/pre-commit
+
+HOOK_DEST=".git/hooks/pre-commit"
+HOOK_SOURCE=".github/scripts/pre-commit-hook.sh"
+
+# Back up existing hook if it exists
+if [ -f "$HOOK_DEST" ]; then
+  TIMESTAMP=$(date +%Y-%m-%d_%H-%M-%S)
+  BACKUP_PATH="${HOOK_DEST}.bak.${TIMESTAMP}"
+  cp "$HOOK_DEST" "$BACKUP_PATH"
+  echo "[INFO] Backed up existing hook to $(basename $BACKUP_PATH)"
+fi
+
+cp "$HOOK_SOURCE" "$HOOK_DEST"
+chmod +x "$HOOK_DEST"
 
 echo "[OK] Hook installed at .git/hooks/pre-commit"
 echo "[INFO] Testing the hook on your next commit..."

--- a/README.md
+++ b/README.md
@@ -46,6 +46,27 @@ Download the installer for your platform from the [Releases](https://github.com/
 | `yarn package:debug` | Build an unpacked debug package |
 | `yarn commands` | Show the available project commands |
 | `yarn lint` | Run ESLint |
+| `yarn setup:hooks` | Install git pre-commit hook (enforces lint checks) |
+
+### Git Hooks
+
+EmuConfigurator enforces code quality with automatic git commit hooks. Before each commit, `yarn lint` runs automatically — commits with lint **errors** are blocked (warnings OK).
+
+**Setup (first time):**
+
+```bash
+yarn setup:hooks
+```
+
+This works on **all platforms** (Windows, macOS, Linux).
+
+**After setup:**
+- Commits are checked automatically
+- Lint errors block commits
+- Run `yarn lint -- --fix` to auto-fix issues
+- Use `git commit --no-verify` to bypass (emergency only)
+
+See [`.github/GIT-HOOKS.md`](.github/GIT-HOOKS.md) for detailed docs.
 
 ### Build Output
 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "main": "main.js",
   "default_locale": "en",
   "scripts": {
+    "setup:hooks": "node .github/scripts/setup-hooks.js",
     "dev": "node scripts/build.js && cross-env NODE_ENV=development NODE_NO_WARNINGS=1 electron-forge start",
     "debug": "yarn dev",
     "dev:verbose": "node scripts/build.js && cross-env NODE_ENV=development electron-forge start",


### PR DESCRIPTION
- Simple shell-based pre-commit hook for all platforms
- Auto-installs dependencies if node_modules missing
- Blocks commits on lint errors (warnings OK)
- Cross-platform setup via 'yarn setup:hooks'
- Works on Windows, macOS, and Linux
- Includes platform-specific setup scripts for manual setup
- Updated README with setup and usage docs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated Git pre-commit hook that runs linting before each commit
  * Commits with lint errors are blocked (warnings allowed)
  * Emergency bypass available via `git commit --no-verify`

* **Documentation**
  * Added setup guide for Git pre-commit hooks with cross-platform support
  * New `yarn setup:hooks` command to initialize hooks

<!-- end of auto-generated comment: release notes by coderabbit.ai -->