### PR TITLE
Fix #342: RSSI channel not saved when RSSI_ADC is enabled

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -1751,6 +1751,12 @@
     "receiverRssiChannelDisabledOption": {
         "message": "Disabled"
     },
+    "receiverRssiAdcDisabled": {
+        "message": "RSSI_ADC feature <span class=\"message-positive\">disabled</span> automatically — RSSI channel requires it to be off"
+    },
+    "configurationRssiAdcDisablesChannel": {
+        "message": "RSSI_ADC enabled — RSSI Channel selection in the Receiver tab will be <span class=\"message-negative\">disabled</span> on save"
+    },
     "receiverRefreshRateTitle": {
         "message": "Graph refresh rate"
     },

--- a/src/js/tabs/configuration.js
+++ b/src/js/tabs/configuration.js
@@ -1007,6 +1007,12 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
                     checkUpdate3dControls();
                     break;
 
+                case 'RSSI_ADC':
+                    if (FEATURE_CONFIG.features.isEnabled('RSSI_ADC')) {
+                        GUI.log(i18n.getMessage('configurationRssiAdcDisablesChannel'));
+                    }
+                    break;
+
                 default:
                     break;
             }

--- a/src/js/tabs/receiver.js
+++ b/src/js/tabs/receiver.js
@@ -257,10 +257,24 @@ TABS.receiver.initialize = function (callback) {
             // catch rssi aux
             RSSI_CONFIG.channel = parseInt($('select[name="rssi_channel"]').val());
 
+            // If a channel is selected and RSSI_ADC feature is enabled, the firmware's
+            // validateAndFixConfig() will force rssi_channel back to 0 on boot.
+            // Automatically disable RSSI_ADC so the channel value is preserved.
+            var rssiAdcCleared = false;
+            if (RSSI_CONFIG.channel > 0 && FEATURE_CONFIG.features.isEnabled('RSSI_ADC')) {
+                var RSSI_ADC_FEATURE_BIT = 15;
+                FEATURE_CONFIG.features.setMask(bit_clear(FEATURE_CONFIG.features.getMask(), RSSI_ADC_FEATURE_BIT));
+                rssiAdcCleared = true;
+                GUI.log(i18n.getMessage('receiverRssiAdcDisabled'));
+            }
 
             if (semver.gte(CONFIG.apiVersion, "1.20.0")) {
                 RX_CONFIG.rcInterpolation = parseInt($('select[name="rcInterpolation-select"]').val());
                 RX_CONFIG.rcInterpolationInterval = parseInt($('input[name="rcInterpolationInterval-number"]').val());
+            }
+
+            function save_feature_config() {
+                MSP.send_message(MSPCodes.MSP_SET_FEATURE_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_FEATURE_CONFIG), false, save_rssi_config);
             }
 
             function save_rssi_config() {
@@ -291,7 +305,8 @@ TABS.receiver.initialize = function (callback) {
                 });
             }
 
-            MSP.send_message(MSPCodes.MSP_SET_RX_MAP, mspHelper.crunch(MSPCodes.MSP_SET_RX_MAP), false, save_rssi_config);
+            var first_save_callback = rssiAdcCleared ? save_feature_config : save_rssi_config;
+            MSP.send_message(MSPCodes.MSP_SET_RX_MAP, mspHelper.crunch(MSPCodes.MSP_SET_RX_MAP), false, first_save_callback);
         });
 
         $("a.sticks").click(function() {


### PR DESCRIPTION
## Root Cause

EmuFlight firmware's validateAndFixConfig() silently zeroes rssi_channel whenever FEATURE_RSSI_ADC is enabled, destroying any persisted value on every boot. This makes it impossible to save an RSSI channel assignment from the Configurator.

## Solution

The Configurator now detects the conflict and automatically disables RSSI_ADC when the user selects a non-zero RSSI channel in the Receiver tab. On save, MSP_SET_FEATURE_CONFIG is sent before MSP_SET_RSSI_CONFIG, ensuring the channel value is persisted correctly.

## Changes

- **Receiver tab**: Auto-disable RSSI_ADC on channel select + user log message
- **Configuration tab**: Inform user when RSSI_ADC is enabled (informational log)
- **i18n**: Added two new messages for user feedback

## Test Steps

1. Connect a flight controller
2. Go to **Configuration** → confirm `RSSI_ADC` is enabled
3. Go to **Receiver** → select an **AUX channel** for RSSI Channel
4. Click **Save** → observe log: *"RSSI_ADC feature disabled automatically..."*
5. Power-cycle the FC
6. Verify RSSI Channel still shows the selected channel (not reverted to Disabled)

## Related

- Closes #342
- Related firmware issue: emuflight/EmuFlight#1135 (optional cleanup)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added RSSI_ADC feature handling with informational notifications about channel selection impact
  * Implemented safety checks for proper RSSI channel configuration when RSSI_ADC is active

<!-- end of auto-generated comment: release notes by coderabbit.ai -->