### PR TITLE
fix(sensors): add 300ms post-reconnect settling delay before MSP polling

### DIFF
--- a/src/js/tabs/sensors.js
+++ b/src/js/tabs/sensors.js
@@ -445,19 +445,24 @@ TABS.sensors.initialize = function (callback) {
 
                     $('.tab-sensors select[name="debug_refresh_rate"]').val(result.sensor_settings.rates.debug);
 
-                    // start polling data by triggering refresh rate change event
-                    $('.tab-sensors .rate select:first').change();
-                } else {
-                    // start polling immediatly (as there is no configuration saved in the storage)
-                    $('.tab-sensors .rate select:first').change();
                 }
+                // Delay polling start to allow the FC to settle after reconnect.
+                // Immediate high-frequency MSP polling on a fresh VCP connection
+                // can overflow the firmware TX ring buffer, causing watchdog timeout
+                // and unexpected disconnect. This 300ms delay mitigates the issue.
+                setTimeout(function () {
+                    $('.tab-sensors .rate select:first').change();
+                }, 300);
             });
         });
 
-        // status data pulled via separate timer with static speed
-        GUI.interval_add('status_pull', function status_pull() {
-            MSP.send_message(MSPCodes.MSP_STATUS);
-        }, 250, true);
+        // status data pulled via separate timer with static speed.
+        // Delayed 300ms for the same FC settling reason as the sensor polling above.
+        setTimeout(function () {
+            GUI.interval_add('status_pull', function status_pull() {
+                MSP.send_message(MSPCodes.MSP_STATUS);
+            }, 250, true);
+        }, 300);
 
         GUI.content_ready(callback);
     });


### PR DESCRIPTION
## Summary

Mitigation for firmware CDC_Send_DATA TX-buffer overflow bug (EmuFlight#1107).

After exiting CLI and reconnecting, immediate high-frequency MSP polling (especially from the sensors tab) floods the FC USB ring buffer, causing the firmware's blocking CDC_Send_DATA() to starve the scheduler and trigger WWDG reset — resulting in a second unexpected disconnect and flatline sensor data.

## Changes

- Added 300ms setTimeout delay before starting sensor polling (IMU/baro/sonar/debug intervals)
- Added 300ms setTimeout delay before starting status polling
- Combined with existing 200ms settle in finishOpen(), provides 500ms total window for FC USB stabilization

## Resolves

**Configurator-side fixes from issue #546:**
- Task 1 was already resolved in master (CLI exit/reconnect lifecycle via GUI.pendingAfterReconnect ✓)
  - MSP.callbacks_cleanup() called on CLI exit ✓
  - callback() deferred until finishOpen() handshake completes ✓
- Task 2 is resolved by this PR (sensors polling delay)

**Not resolved (deferred to firmware):**
- Task 3 (rebase/squash) — rethink-WM already merged
- Root firmware cause remains (EmuFlight#1107 — CDC_Send_DATA needs timeout + watchdog feed)

Fixes #546 (configurator portion)