### PR TITLE
refactor(build): extract Linux icon path to constant

### DIFF
--- a/forge.config.js
+++ b/forge.config.js
@@ -5,6 +5,9 @@ const { FuseV1Options, FuseVersion } = require('@electron/fuses');
 
 const buildMode = process.env.EMUCFG_BUILD_MODE || 'release';
 
+// Linux icon path constant for makers (deb, rpm)
+const LINUX_ICON = path.resolve(__dirname, 'assets/linux/icon/emu_icon_128.png');
+
 // Handle graceful shutdown in development mode
 // When yarn dev receives Ctrl+C, exit cleanly.
 // The Electron process will be terminated automatically when this parent exits.
@@ -80,7 +83,7 @@ module.exports = {
         options: {
           maintainer: 'EmuFlight',
           homepage: 'https://github.com/EmuFlight/EmuConfigurator',
-          icon: path.resolve(__dirname, 'assets/linux/icon/emu_icon_128.png'),
+          icon: LINUX_ICON,
         },
       },
     },
@@ -90,7 +93,7 @@ module.exports = {
       config: {
         options: {
           homepage: 'https://github.com/EmuFlight/EmuConfigurator',
-          icon: path.resolve(__dirname, 'assets/linux/icon/emu_icon_128.png'),
+          icon: LINUX_ICON,
         },
       },
     },


### PR DESCRIPTION
Extract the duplicate Linux icon path from both @electron-forge/maker-deb and @electron-forge/maker-rpm configs into a single LINUX_ICON constant.

This eliminates duplication and reduces the risk of accidental drift if the icon path ever needs to change.

Resolves #571

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build configuration code organization and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->