### PR TITLE
fix: connect button gating + CLI paste resilience (bugs #10, #13)

### DIFF
--- a/main.js
+++ b/main.js
@@ -370,11 +370,13 @@ ipcMain.handle('serial-list-ports', async () => {
   try {
     const { SerialPort } = require('serialport');
     const ports = await SerialPort.list();
-    return ports.map(p => p.path);
+    return ports
+      .filter(p => !/^\/dev\/ttyS\d+$/.test(p.path || ''))  // exclude bare hardware UARTs
+      .map(p => p.path);
   } catch (e) {
     console.error('main.js: serialport list failed, trying fs fallback:', e.message);
     try {
-      const entries = fs.readdirSync('/dev').filter(f => /^tty(USB|ACM|S)\d+$/.test(f));
+      const entries = fs.readdirSync('/dev').filter(f => /^tty(USB|ACM)\d+$/.test(f));
       return entries.map(f => '/dev/' + f);
     } catch (fsErr) {
       return [];

--- a/src/js/port_handler.js
+++ b/src/js/port_handler.js
@@ -177,8 +177,11 @@ PortHandler.check = function () {
         // the user has manually selected the manual-entry option. While connected
         // or connecting, leave the button state to the connect/disconnect flow.
         if (!GUI.connected_to && !GUI.connecting_to) {
+            // Manual option is always present in the dropdown, so check that the
+            // user has actually typed a port path before treating it as connectable.
             var isManualSelected = $('div#port-picker #port option:selected').data('isManual');
-            if (current_ports.length > 0 || isManualSelected) {
+            var manualPortEntered = isManualSelected && $('#port-override').val().trim().length > 0;
+            if (current_ports.length > 0 || manualPortEntered) {
                 $('.connect_b a.connect').removeClass('disabled');
             } else {
                 $('.connect_b a.connect').addClass('disabled');

--- a/src/js/port_handler.js
+++ b/src/js/port_handler.js
@@ -173,7 +173,17 @@ PortHandler.check = function () {
         GUI.updateManualPortVisibility();
 
         //moved from main.js
-        $('.connect_b a.connect').removeClass('disabled');
+        // Enable connect button only when real serial ports are present, or when
+        // the user has manually selected the manual-entry option. While connected
+        // or connecting, leave the button state to the connect/disconnect flow.
+        if (!GUI.connected_to && !GUI.connecting_to) {
+            var isManualSelected = $('div#port-picker #port option:selected').data('isManual');
+            if (current_ports.length > 0 || isManualSelected) {
+                $('.connect_b a.connect').removeClass('disabled');
+            } else {
+                $('.connect_b a.connect').addClass('disabled');
+            }
+        }
         $('.firmware_b a.flash').removeClass('disabled');
 
         setTimeout(function () {

--- a/src/js/tabs/cli.js
+++ b/src/js/tabs/cli.js
@@ -107,7 +107,15 @@ TABS.cli.initialize = function (callback, nwGui) {
         var outputArray = out_string.split("\n");
         Promise.reduce(outputArray, function(delay, line, index) {
             return new Promise(function (resolve) {
-                GUI.timeout_add('CLI_send_slowly', function () {
+                // Use native setTimeout instead of GUI.timeout_add so this chain
+                // is not killed by GUI.timeout_kill_all() on a transient disconnect
+                // (e.g. FC second-reboot after flash). The cliActive guard below
+                // aborts the chain cleanly if the CLI session actually ends.
+                setTimeout(function () {
+                    if (!CONFIGURATOR.cliActive) {
+                        resolve(0);
+                        return;
+                    }
                     var processingDelay = self.lineDelayMs;
                     line = line.trim();
                     if (line.toLowerCase().startsWith('profile')) {
@@ -120,7 +128,7 @@ TABS.cli.initialize = function (callback, nwGui) {
                     self.sendLine(line, function () {
                         resolve(processingDelay);
                     });
-                }, delay)
+                }, delay);
             })
         }, 0);
 }


### PR DESCRIPTION
## Summary

- **Bug**: Connect button was clickable at app startup before any serial device was present, allowing premature connect attempts against unresolvable ports.
- **Bug**: CLI multi-line paste (diff restore) could silently drop most lines after a firmware flash+reconnect cycle, leaving zero parameters applied despite partial echoes in the CLI window.

## Changes

### `main.js` — filter phantom serial ports from list
`SerialPort.list()` on Linux returns `/dev/ttyS0`, `/dev/ttyS1`, etc. (motherboard UART headers) unconditionally, even with no USB device attached. These ports are never connectable to an FC. Filter them out so the port list only contains `ttyACM*` / `ttyUSB*` entries. The `fs` fallback is tightened to match. Windows (`COM*`) and macOS (`cu.*`) paths are unaffected by the regex.

### `src/js/port_handler.js` — gate connect button on real port presence
Connect button stays in its HTML-default `disabled` state until `current_ports.length > 0`. Re-disables within one 500 ms poll cycle if all ports disappear. Manual-entry mode is treated as connectable only when the user has actually typed something into the port-override field (the `manual` option is always present in the dropdown so an `isManual` check alone was always true). Button state is not touched while connected or connecting.

### `src/js/tabs/cli.js` — native `setTimeout` for paste send chain
`executeCommands()` used `GUI.timeout_add('CLI_send_slowly', …)` which puts timers into `GUI.timeout_array`. `GUI.timeout_kill_all()` is called on every disconnect (including transient FC second-reboots after flash), killing all pending paste timers mid-chain. With `batch start`/`batch end` semantics, any partial paste means zero parameters applied even if dozens of `set` lines were already sent.

Switch to native `setTimeout` so the send chain is not a casualty of an unrelated GUI teardown. Add a `CONFIGURATOR.cliActive` guard in each iteration so the chain aborts cleanly and immediately when the CLI session genuinely ends (tab close, intentional disconnect) rather than leaking sends into a future session.

## Test plan

- [ ] Launch app with no FC plugged in — connect button is gray/disabled and unclickable
- [ ] Plug in FC — button enables within ~500 ms; port appears in dropdown
- [ ] Unplug FC — button grays out again within ~500 ms
- [ ] Type a path in the manual override field with no FC — button enables
- [ ] Clear the manual override field — button grays out
- [ ] Connect → CLI → `diff` → copy → flash hex → reconnect → CLI → paste diff back → verify all parameters are applied (bug #13 scenario)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Connect button now properly enables only when valid serial ports are detected or a valid manual port path is entered, preventing connection attempts with unavailable ports.

* **Improvements**
  * Enhanced serial port detection by filtering out hardware UART devices for improved accuracy.
  * Optimized command scheduling mechanism in CLI operations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/emuflight/EmuConfigurator/pull/588)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->