### PR TITLE
feat: Ctrl+mousewheel zoom 

### DIFF
--- a/main.js
+++ b/main.js
@@ -996,6 +996,12 @@ ipcMain.handle('dialog:truncate-file', async (event, filePath, size) => {
   }
 });
 
+ipcMain.handle('zoom-step', (_event, delta) => {
+  if (mainWindow && !mainWindow.isDestroyed()) {
+    applyZoom(mainWindow, _currentZoom + (delta > 0 ? 1 : -1));
+  }
+});
+
 function createWindow() {
   const buildMode = getBuildMode();
   setupMenu(buildMode);
@@ -1135,6 +1141,24 @@ function createWindow() {
     if (_devtoolsZoomTimer) clearTimeout(_devtoolsZoomTimer);
     _devtoolsZoomTimer = setTimeout(() => {
       applyZoom(win, _currentZoom);
+      const dtWC = win.webContents.devToolsWebContents;
+      if (!dtWC || dtWC.isDestroyed()) return;
+      // Ctrl+/-/0 keyboard zoom inside DevTools panel (mirrors app keyboard shortcuts)
+      dtWC.on('before-input-event', (event, input) => {
+        if (input.type !== 'keyDown' || !(input.control || input.meta) || input.alt) return;
+        if (dtWC.isDestroyed()) return;
+        const code = input.code;
+        if (code === 'Equal' || code === 'NumpadAdd') {
+          event.preventDefault();
+          dtWC.setZoomLevel(Math.min(MAX_ZOOM_LEVEL, dtWC.getZoomLevel() + 1));
+        } else if (code === 'Minus' || code === 'NumpadSubtract') {
+          event.preventDefault();
+          dtWC.setZoomLevel(Math.max(MIN_ZOOM_LEVEL, dtWC.getZoomLevel() - 1));
+        } else if (code === 'Digit0' || code === 'Numpad0') {
+          event.preventDefault();
+          dtWC.setZoomLevel(DEFAULT_ZOOM_LEVEL);
+        }
+      });
     }, 150);
   });
 

--- a/main.js
+++ b/main.js
@@ -1050,8 +1050,6 @@ function createWindow() {
   // Active enforcement: if window size falls below minimum after any resize, restore it
   let _resizeZoomTimer = null;
   let _devtoolsZoomTimer = null; // shared between devtools-opened/closed to prevent timer leaks
-  let _dtInputHandler = null;   // stored so devtools-closed can removeListener and prevent stacking
-  let _dtWCRef = null;
   const debouncedZoomReapply = () => {
     if (_resizeZoomTimer) clearTimeout(_resizeZoomTimer);
     _resizeZoomTimer = setTimeout(() => {
@@ -1143,35 +1141,10 @@ function createWindow() {
     if (_devtoolsZoomTimer) clearTimeout(_devtoolsZoomTimer);
     _devtoolsZoomTimer = setTimeout(() => {
       applyZoom(win, _currentZoom);
-      const dtWC = win.webContents.devToolsWebContents;
-      if (!dtWC || dtWC.isDestroyed()) return;
-      if (_dtInputHandler) return; // already registered; avoid stacking on reopen
-      _dtWCRef = dtWC;
-      _dtInputHandler = (event, input) => {
-        if (input.type !== 'keyDown' || !(input.control || input.meta) || input.alt) return;
-        if (dtWC.isDestroyed()) return;
-        const code = input.code;
-        if (code === 'Equal' || code === 'NumpadAdd') {
-          event.preventDefault();
-          dtWC.setZoomLevel(Math.min(MAX_ZOOM_LEVEL, dtWC.getZoomLevel() + 1));
-        } else if (code === 'Minus' || code === 'NumpadSubtract') {
-          event.preventDefault();
-          dtWC.setZoomLevel(Math.max(MIN_ZOOM_LEVEL, dtWC.getZoomLevel() - 1));
-        } else if (code === 'Digit0' || code === 'Numpad0') {
-          event.preventDefault();
-          dtWC.setZoomLevel(DEFAULT_ZOOM_LEVEL);
-        }
-      };
-      dtWC.on('before-input-event', _dtInputHandler);
     }, 150);
   });
 
   win.webContents.on('devtools-closed', () => {
-    if (_dtWCRef && _dtInputHandler) {
-      _dtWCRef.removeListener('before-input-event', _dtInputHandler);
-      _dtInputHandler = null;
-      _dtWCRef = null;
-    }
     if (_devtoolsZoomTimer) clearTimeout(_devtoolsZoomTimer);
     _devtoolsZoomTimer = setTimeout(() => {
       applyZoom(win, _currentZoom);

--- a/main.js
+++ b/main.js
@@ -1050,6 +1050,8 @@ function createWindow() {
   // Active enforcement: if window size falls below minimum after any resize, restore it
   let _resizeZoomTimer = null;
   let _devtoolsZoomTimer = null; // shared between devtools-opened/closed to prevent timer leaks
+  let _dtInputHandler = null;   // stored so devtools-closed can removeListener and prevent stacking
+  let _dtWCRef = null;
   const debouncedZoomReapply = () => {
     if (_resizeZoomTimer) clearTimeout(_resizeZoomTimer);
     _resizeZoomTimer = setTimeout(() => {
@@ -1143,8 +1145,9 @@ function createWindow() {
       applyZoom(win, _currentZoom);
       const dtWC = win.webContents.devToolsWebContents;
       if (!dtWC || dtWC.isDestroyed()) return;
-      // Ctrl+/-/0 keyboard zoom inside DevTools panel (mirrors app keyboard shortcuts)
-      dtWC.on('before-input-event', (event, input) => {
+      if (_dtInputHandler) return; // already registered; avoid stacking on reopen
+      _dtWCRef = dtWC;
+      _dtInputHandler = (event, input) => {
         if (input.type !== 'keyDown' || !(input.control || input.meta) || input.alt) return;
         if (dtWC.isDestroyed()) return;
         const code = input.code;
@@ -1158,11 +1161,17 @@ function createWindow() {
           event.preventDefault();
           dtWC.setZoomLevel(DEFAULT_ZOOM_LEVEL);
         }
-      });
+      };
+      dtWC.on('before-input-event', _dtInputHandler);
     }, 150);
   });
 
   win.webContents.on('devtools-closed', () => {
+    if (_dtWCRef && _dtInputHandler) {
+      _dtWCRef.removeListener('before-input-event', _dtInputHandler);
+      _dtInputHandler = null;
+      _dtWCRef = null;
+    }
     if (_devtoolsZoomTimer) clearTimeout(_devtoolsZoomTimer);
     _devtoolsZoomTimer = setTimeout(() => {
       applyZoom(win, _currentZoom);

--- a/src/support/preload.js
+++ b/src/support/preload.js
@@ -602,7 +602,7 @@ if (typeof window.chrome === 'undefined' || !window.chrome.fileSystem) {
 
 // Ctrl+mousewheel zoom: intercept before Chromium's own fractional zoom kicks in
 window.addEventListener('wheel', function (event) {
-    if (!(event.ctrlKey || event.metaKey)) return;
+    if (!(event.ctrlKey || event.metaKey) || event.deltaY === 0) return;
     event.preventDefault();
     ipcRenderer.invoke('zoom-step', event.deltaY < 0 ? 1 : -1);
 }, { passive: false, capture: true });

--- a/src/support/preload.js
+++ b/src/support/preload.js
@@ -599,3 +599,10 @@ if (typeof window.chrome === 'undefined' || !window.chrome.fileSystem) {
         fileSystem: chromeFileSystem,
     });
 }
+
+// Ctrl+mousewheel zoom: intercept before Chromium's own fractional zoom kicks in
+window.addEventListener('wheel', function (event) {
+    if (!(event.ctrlKey || event.metaKey)) return;
+    event.preventDefault();
+    ipcRenderer.invoke('zoom-step', event.deltaY < 0 ? 1 : -1);
+}, { passive: false, capture: true });


### PR DESCRIPTION
## Summary
- Adds Ctrl+mousewheel zoom support
- `preload.js`: capture-phase `wheel` listener intercepts Ctrl+wheel, calls `event.preventDefault()` to block Chromium's own fractional zoom, then sends `ipcRenderer.invoke('zoom-step', ±1)` to main
- `main.js`: new `ipcMain.handle('zoom-step', ...)` handler calls `applyZoom()` — same path as keyboard Ctrl+/- shortcuts, so zoom uses consistent integer steps and respects the -9..+9 clamp

## Test plan
- [ ] `yarn dev` — hold Ctrl and scroll wheel up: zoom increases one step per notch
- [ ] Hold Ctrl and scroll wheel down: zoom decreases one step per notch
- [ ] Zoom stays clamped at -9 and +9 (no further change at limits)
- [ ] Ctrl+0 resets to default after wheeling
- [ ] Zoom persists across restart (same as keyboard zoom)
- [ ] Regular scroll (no Ctrl) still works normally (no zoom)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added keyboard shortcut zoom controls (Ctrl/Cmd + Plus/Minus/Zero).
  * Added mouse wheel zoom support with Ctrl/Cmd modifier.
  * Zoom levels are now constrained within defined limits for consistency.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/emuflight/EmuConfigurator/pull/589)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->