### PR TITLE
feat: add Stable PIDs sub-tab (Angle / Horizon / NFE / RTH)

### DIFF
--- a/locales/ca/messages.json
+++ b/locales/ca/messages.json
@@ -841,12 +841,6 @@
     "pidTuningUpgradeFirmwareToChangePidController": {
         "message": "<span class=\"message-negative\">Canviant el controlador PID a deshabilitat - ho pots canviar pel CLI.</span> Tens un firmware amb versió API <span class=\"message-negative\">$1</span>, però aquesta funcionalitat requereix <span class=\"message-positive\">$2</span>."
     },
-    "pidTuningSubTabPid": {
-        "message": "Configuració de PIDs"
-    },
-    "pidTuningSubTabFilter": {
-        "message": "Configuració de Filtres"
-    },
     "pidTuningShowAllPids": {
         "message": "Mostra tots els PIDs"
     },

--- a/locales/ca/messages.json
+++ b/locales/ca/messages.json
@@ -841,9 +841,6 @@
     "pidTuningUpgradeFirmwareToChangePidController": {
         "message": "<span class=\"message-negative\">Canviant el controlador PID a deshabilitat - ho pots canviar pel CLI.</span> Tens un firmware amb versió API <span class=\"message-negative\">$1</span>, però aquesta funcionalitat requereix <span class=\"message-positive\">$2</span>."
     },
-    "pidTuningShowAllPids": {
-        "message": "Mostra tots els PIDs"
-    },
     "pidTuningHideUnusedPids": {
         "message": "Amaga els PIDs no utilitzats"
     },

--- a/locales/de/messages.json
+++ b/locales/de/messages.json
@@ -1002,15 +1002,6 @@
     "pidTuningUpgradeFirmwareToChangePidController": {
         "message": "<span class=\"message-negative\">Changing PID controller disabled - you can change it via the CLI.</span> You have firmware with API version <span class=\"message-negative\">$1</span>, but this functionality requires requires <span class=\"message-positive\">$2</span>."
     },
-    "pidTuningSubTabPid": {
-        "message": "PID Einstellungen"
-    },
-    "pidTuningSubTabRates": {
-        "message": "Drehratenprofil Einstellungen"
-    },
-    "pidTuningSubTabFilter": {
-        "message": "Filter Einstellungen"
-    },
     "pidTuningShowAllPids": {
         "message": "Zeige alle PIDs"
     },

--- a/locales/de/messages.json
+++ b/locales/de/messages.json
@@ -1002,9 +1002,6 @@
     "pidTuningUpgradeFirmwareToChangePidController": {
         "message": "<span class=\"message-negative\">Changing PID controller disabled - you can change it via the CLI.</span> You have firmware with API version <span class=\"message-negative\">$1</span>, but this functionality requires requires <span class=\"message-positive\">$2</span>."
     },
-    "pidTuningShowAllPids": {
-        "message": "Zeige alle PIDs"
-    },
     "pidTuningHideUnusedPids": {
         "message": "Verstecke ungenutzt PIDs"
     },

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -1337,9 +1337,6 @@
     "pidTuningSubTabFeel": {
         "message": "Feel Settings"
     },
-    "pidTuningShowAllPids": {
-        "message": "Show all PIDs"
-    },
     "pidTuningHideUnusedPids": {
         "message": "Hide unused PIDs"
     },

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -1329,7 +1329,7 @@
         "message": "Stable PIDs"
     },
     "pidTuningSubTabRates": {
-        "message": "Rateprofile Settings"
+        "message": "Rate Settings"
     },
     "pidTuningSubTabFilter": {
         "message": "Filter Settings"

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -2975,16 +2975,16 @@
         "message": "Maximum angle allowed in Angle Mode."
     },
     "pidTuningAngleHigh": {
-        "message": "High Angle Error"
+        "message": "Roll/Pitch High"
     },
     "pidTuningAngleHighHelp": {
-        "message": "High Angle Error settings deal with crash recovery and quick stick movement.  This will be the P used as high PID-error occurs for example at the moment of crashing."
+        "message": "High angle-error PIDs — active during crash recovery and fast stick movement when angle error is large."
     },
     "pidTuningAngleLow": {
-        "message": "Low Angle Error"
+        "message": "Roll/Pitch Low"
     },
     "pidTuningAngleLowHelp": {
-        "message": "Low Angle Error settings are used when PID-error is minimal during normal flight."
+        "message": "Low angle-error PIDs — active during normal stable flight when angle error is small."
     },
     "pidTuningAngleFeedForward": {
         "message": "Angle Feed-Forward"

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -2951,7 +2951,7 @@
         "message": "Keeps the craft from jumping up at the end of yaws. Higher number gives more damping at the end of yaw moves (works like old yaw D, which was not a real D like on other axis)"
     },
     "pidTuningLevel": {
-        "message": "Angle/Horizon/NFE"
+        "message": "Angle / Horizon / NFE / RTH"
     },
     "pidTuningStrength": {
         "message": "Strength"

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -1323,7 +1323,10 @@
         "message": "<span class=\"message-negative\">Changing PID controller disabled - you can change it via the CLI.</span>  You have firmware with API version <span class=\"message-negative\">$1</span>, but this functionality requires <span class=\"message-positive\">$2</span>."
     },
     "pidTuningSubTabPid": {
-        "message": "PID Settings"
+        "message": "Acro PIDs"
+    },
+    "pidTuningSubTabStable": {
+        "message": "Stable PIDs"
     },
     "pidTuningSubTabRates": {
         "message": "Rateprofile Settings"
@@ -2982,6 +2985,9 @@
     },
     "pidTuningAngleLowHelp": {
         "message": "Low Angle Error settings are used when PID-error is minimal during normal flight."
+    },
+    "pidTuningAngleITermNAHelp": {
+        "message": "I-term for stable mode is not yet exposed via MSP. This field will become active in a future firmware update."
     },
     "pidTuningAngleFeedForward": {
         "message": "Angle Feed-Forward"

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -2986,9 +2986,6 @@
     "pidTuningAngleLowHelp": {
         "message": "Low Angle Error settings are used when PID-error is minimal during normal flight."
     },
-    "pidTuningAngleITermNAHelp": {
-        "message": "I-term for stable mode is not yet exposed via MSP. This field will become active in a future firmware update."
-    },
     "pidTuningAngleFeedForward": {
         "message": "Angle Feed-Forward"
     },

--- a/locales/es/messages.json
+++ b/locales/es/messages.json
@@ -1040,15 +1040,6 @@
     "pidTuningUpgradeFirmwareToChangePidController": {
         "message": "<span class=\"message-negative\">Cambio de controlador PID desactivado - puedes cambiarlo a través de CLI.</span>  Tienes firmware con versión de API <span class=\"message-negative\">$1</span>, pero esta funcionalidad requiere <span class=\"message-positive\">$2</span>."
     },
-    "pidTuningSubTabPid": {
-        "message": "Ajustes PID"
-    },
-    "pidTuningSubTabRates": {
-        "message": "Tasas"
-    },
-    "pidTuningSubTabFilter": {
-        "message": "Ajustes de Filtros"
-    },
     "pidTuningShowAllPids": {
         "message": "Ver todos los PIDs"
     },

--- a/locales/es/messages.json
+++ b/locales/es/messages.json
@@ -1040,9 +1040,6 @@
     "pidTuningUpgradeFirmwareToChangePidController": {
         "message": "<span class=\"message-negative\">Cambio de controlador PID desactivado - puedes cambiarlo a través de CLI.</span>  Tienes firmware con versión de API <span class=\"message-negative\">$1</span>, pero esta funcionalidad requiere <span class=\"message-positive\">$2</span>."
     },
-    "pidTuningShowAllPids": {
-        "message": "Ver todos los PIDs"
-    },
     "pidTuningHideUnusedPids": {
         "message": "Ocultar PIDs no usados"
     },

--- a/locales/fr/messages.json
+++ b/locales/fr/messages.json
@@ -1004,9 +1004,6 @@
     "pidTuningUpgradeFirmwareToChangePidController": {
         "message": "<span class=\"message-negative\">Changement de contrôleur PID désactivé - mais possible en CLI.</span> Votre microprogramme dispose de l'API version <span class=\"message-negative\">$1</span>, cette fonctionnalité nécessite la version <span class=\"message-positive\">$2</span>."
     },
-    "pidTuningShowAllPids": {
-        "message": "Montrer tous les PIDs"
-    },
     "pidTuningHideUnusedPids": {
         "message": "Cacher les PIDs non utilisés"
     },

--- a/locales/fr/messages.json
+++ b/locales/fr/messages.json
@@ -1004,15 +1004,6 @@
     "pidTuningUpgradeFirmwareToChangePidController": {
         "message": "<span class=\"message-negative\">Changement de contrôleur PID désactivé - mais possible en CLI.</span> Votre microprogramme dispose de l'API version <span class=\"message-negative\">$1</span>, cette fonctionnalité nécessite la version <span class=\"message-positive\">$2</span>."
     },
-    "pidTuningSubTabPid": {
-        "message": "Réglages PID"
-    },
-    "pidTuningSubTabRates": {
-        "message": "Paramètres Rates du profil"
-    },
-    "pidTuningSubTabFilter": {
-        "message": "Réglages filtres"
-    },
     "pidTuningShowAllPids": {
         "message": "Montrer tous les PIDs"
     },

--- a/locales/gl/messages.json
+++ b/locales/gl/messages.json
@@ -1043,15 +1043,6 @@
     "pidTuningUpgradeFirmwareToChangePidController": {
         "message": "<span class=\"message-negative\"> Cambio do controlador PID desactivado - pode cambialo a través da CLI. </span> Ten firmware coa versión API <span class=\"message-negative\">$1</span>, pero esta funcionalidade require <span class=\"message-positive\">$2</span>."
     },
-    "pidTuningSubTabPid": {
-        "message": "Opcións de PID"
-    },
-    "pidTuningSubTabRates": {
-        "message": "Configuración do perfil de taxa"
-    },
-    "pidTuningSubTabFilter": {
-        "message": "Opcións de filtros"
-    },
     "pidTuningShowAllPids": {
         "message": "Mostrar tódolos PID's"
     },

--- a/locales/gl/messages.json
+++ b/locales/gl/messages.json
@@ -1043,9 +1043,6 @@
     "pidTuningUpgradeFirmwareToChangePidController": {
         "message": "<span class=\"message-negative\"> Cambio do controlador PID desactivado - pode cambialo a través da CLI. </span> Ten firmware coa versión API <span class=\"message-negative\">$1</span>, pero esta funcionalidade require <span class=\"message-positive\">$2</span>."
     },
-    "pidTuningShowAllPids": {
-        "message": "Mostrar tódolos PID's"
-    },
     "pidTuningHideUnusedPids": {
         "message": "Oculta PID's no usados"
     },

--- a/locales/hr/messages.json
+++ b/locales/hr/messages.json
@@ -1040,9 +1040,6 @@
     "pidTuningUpgradeFirmwareToChangePidController": {
         "message": "<span class=\"message-negative\">Mijenjanje postavki PID kontrolera onemogućeno - možete ih mijenjati kroz CLI.</span> Firmware koji koristite ima API verziju<span class=\"message-negative\">$1</span>, ali ova mogućnost zahtijeva verziju <span class=\"message-positive\">$2</span>."
     },
-    "pidTuningShowAllPids": {
-        "message": "Prikaži sve PIDove"
-    },
     "pidTuningHideUnusedPids": {
         "message": "Sakrij nekorištene PIDove"
     },

--- a/locales/hr/messages.json
+++ b/locales/hr/messages.json
@@ -1040,12 +1040,6 @@
     "pidTuningUpgradeFirmwareToChangePidController": {
         "message": "<span class=\"message-negative\">Mijenjanje postavki PID kontrolera onemogućeno - možete ih mijenjati kroz CLI.</span> Firmware koji koristite ima API verziju<span class=\"message-negative\">$1</span>, ali ova mogućnost zahtijeva verziju <span class=\"message-positive\">$2</span>."
     },
-    "pidTuningSubTabPid": {
-        "message": "PID Postavke"
-    },
-    "pidTuningSubTabFilter": {
-        "message": "Postavke filtera"
-    },
     "pidTuningShowAllPids": {
         "message": "Prikaži sve PIDove"
     },

--- a/locales/id/messages.json
+++ b/locales/id/messages.json
@@ -887,12 +887,6 @@
     "pidTuningUpgradeFirmwareToChangePidController": {
         "message": "<span class=\"message-negative\">Perubahan PID dinonaktifkan - anda bisa mengubahnya melalui CLI.</span> Anda mempunyai firmware dengan versi API <span class = \"message-negative\">$1</span>, namun Fungsi ini memerlukan <span class=\"message-positive\">$2</span>."
     },
-    "pidTuningSubTabPid": {
-        "message": "Pengaturan PID"
-    },
-    "pidTuningSubTabFilter": {
-        "message": "Pengaturan Filter"
-    },
     "pidTuningShowAllPids": {
         "message": "Tampilkan semua PID"
     },
@@ -2230,7 +2224,6 @@
     "powerVoltageHead": {
         "message": "Meteran Tegangan"
     },
-
     "powerVoltageId10": {
         "message": "Baterai"
     },

--- a/locales/id/messages.json
+++ b/locales/id/messages.json
@@ -887,9 +887,6 @@
     "pidTuningUpgradeFirmwareToChangePidController": {
         "message": "<span class=\"message-negative\">Perubahan PID dinonaktifkan - anda bisa mengubahnya melalui CLI.</span> Anda mempunyai firmware dengan versi API <span class = \"message-negative\">$1</span>, namun Fungsi ini memerlukan <span class=\"message-positive\">$2</span>."
     },
-    "pidTuningShowAllPids": {
-        "message": "Tampilkan semua PID"
-    },
     "pidTuningHideUnusedPids": {
         "message": "Sembunyikan PID yang tidak dipakai"
     },

--- a/locales/it/messages.json
+++ b/locales/it/messages.json
@@ -935,9 +935,6 @@
     "pidTuningUpgradeFirmwareToChangePidController": {
         "message": "<span class=\"message-negative\">la modifica del controllore dei PID è disabilitata - puoi modificarli tramite CLI.</span> hai un Firmware con versione delle API <span class=\"message-negative\">$1</span>, ma questa funzionalità richiede <span class=\"message-positive\">$2</span>."
     },
-    "pidTuningShowAllPids": {
-        "message": "mostra tutti i PID"
-    },
     "pidTuningHideUnusedPids": {
         "message": "nascondi PID non utilizzati"
     },

--- a/locales/it/messages.json
+++ b/locales/it/messages.json
@@ -935,12 +935,6 @@
     "pidTuningUpgradeFirmwareToChangePidController": {
         "message": "<span class=\"message-negative\">la modifica del controllore dei PID è disabilitata - puoi modificarli tramite CLI.</span> hai un Firmware con versione delle API <span class=\"message-negative\">$1</span>, ma questa funzionalità richiede <span class=\"message-positive\">$2</span>."
     },
-    "pidTuningSubTabPid": {
-        "message": "Impostazioni PID"
-    },
-    "pidTuningSubTabFilter": {
-        "message": "Impostazioni Filtri"
-    },
     "pidTuningShowAllPids": {
         "message": "mostra tutti i PID"
     },

--- a/locales/ja/messages.json
+++ b/locales/ja/messages.json
@@ -1043,12 +1043,6 @@
     "pidTuningUpgradeFirmwareToChangePidController": {
         "message": "<span class=\"message-negative\">PID制御の変更が無効 - CLIにより変更できます。</span> このファームウェアはAPIバージョン<span class=\"message-negative\">$1</span>ですが、この機能には<span class=\"message-positive\">$2</span>が必要です。"
     },
-    "pidTuningSubTabPid": {
-        "message": "PID設定"
-    },
-    "pidTuningSubTabFilter": {
-        "message": "フィルター設定"
-    },
     "pidTuningShowAllPids": {
         "message": "全PID値の表示"
     },

--- a/locales/ja/messages.json
+++ b/locales/ja/messages.json
@@ -1043,9 +1043,6 @@
     "pidTuningUpgradeFirmwareToChangePidController": {
         "message": "<span class=\"message-negative\">PID制御の変更が無効 - CLIにより変更できます。</span> このファームウェアはAPIバージョン<span class=\"message-negative\">$1</span>ですが、この機能には<span class=\"message-positive\">$2</span>が必要です。"
     },
-    "pidTuningShowAllPids": {
-        "message": "全PID値の表示"
-    },
     "pidTuningHideUnusedPids": {
         "message": "未使用なPID値 非表示"
     },

--- a/locales/ko/messages.json
+++ b/locales/ko/messages.json
@@ -1055,9 +1055,6 @@
     "pidTuningUpgradeFirmwareToChangePidController": {
         "message": "<span class=\"message-negative\">PID 변경 컨트롤러가 비활성화됨 - 당신은 CLI를 통하여 변경할 수 있습니다.</span> 당신은 API 버전  <span class=\"message-negative\">$1</span>의 펌웨어를 가지고 있으나, 이 기능은  <span class=\"message-positive\">$2</span>를 필요로 합니다."
     },
-    "pidTuningShowAllPids": {
-        "message": "모든 PID 보기"
-    },
     "pidTuningHideUnusedPids": {
         "message": "사용하지 않는 PID 숨기기"
     },

--- a/locales/ko/messages.json
+++ b/locales/ko/messages.json
@@ -1055,12 +1055,6 @@
     "pidTuningUpgradeFirmwareToChangePidController": {
         "message": "<span class=\"message-negative\">PID 변경 컨트롤러가 비활성화됨 - 당신은 CLI를 통하여 변경할 수 있습니다.</span> 당신은 API 버전  <span class=\"message-negative\">$1</span>의 펌웨어를 가지고 있으나, 이 기능은  <span class=\"message-positive\">$2</span>를 필요로 합니다."
     },
-    "pidTuningSubTabPid": {
-        "message": "PID 설정"
-    },
-    "pidTuningSubTabFilter": {
-        "message": "필터 설정"
-    },
     "pidTuningShowAllPids": {
         "message": "모든 PID 보기"
     },

--- a/locales/lv/messages.json
+++ b/locales/lv/messages.json
@@ -1061,12 +1061,6 @@
     "pidTuningUpgradeFirmwareToChangePidController": {
         "message": "<span class=\"message-negative\">PID kontroliera maiņa ir atslēgta  - jūs to varat nomainīt iekš CLI.</span>  Jums ir programmatūra ar API versiju <span class=\"message-negative\">$1</span>, bet šai funkcionalitātei nepieciešama <span class=\"message-positive\">$2</span>."
     },
-    "pidTuningSubTabPid": {
-        "message": "PID Iestatījumi"
-    },
-    "pidTuningSubTabFilter": {
-        "message": "Filtra Iestatījumi"
-    },
     "pidTuningShowAllPids": {
         "message": "Parādīt visus PIDus"
     },

--- a/locales/lv/messages.json
+++ b/locales/lv/messages.json
@@ -1061,9 +1061,6 @@
     "pidTuningUpgradeFirmwareToChangePidController": {
         "message": "<span class=\"message-negative\">PID kontroliera maiņa ir atslēgta  - jūs to varat nomainīt iekš CLI.</span>  Jums ir programmatūra ar API versiju <span class=\"message-negative\">$1</span>, bet šai funkcionalitātei nepieciešama <span class=\"message-positive\">$2</span>."
     },
-    "pidTuningShowAllPids": {
-        "message": "Parādīt visus PIDus"
-    },
     "pidTuningHideUnusedPids": {
         "message": "Paslēpt neizmantotos PID"
     },

--- a/locales/pt/messages.json
+++ b/locales/pt/messages.json
@@ -1031,12 +1031,6 @@
     "pidTuningUpgradeFirmwareToChangePidController": {
         "message": "<span class=\"message-negative\">Alterações no controlador PID desabilitado - você pode mudar isso na Linha de comandos (CLI).</span>  Seu firmware está com a API versão <span class=\"message-negative\">$1</span>, mas esta funcionalidade requer a versão <span class=\"message-positive\">$2</span>."
     },
-    "pidTuningSubTabPid": {
-        "message": "Configurar PID"
-    },
-    "pidTuningSubTabFilter": {
-        "message": "Configurar Filtro"
-    },
     "pidTuningShowAllPids": {
         "message": "Exibir todos PIDs"
     },

--- a/locales/pt/messages.json
+++ b/locales/pt/messages.json
@@ -1031,9 +1031,6 @@
     "pidTuningUpgradeFirmwareToChangePidController": {
         "message": "<span class=\"message-negative\">Alterações no controlador PID desabilitado - você pode mudar isso na Linha de comandos (CLI).</span>  Seu firmware está com a API versão <span class=\"message-negative\">$1</span>, mas esta funcionalidade requer a versão <span class=\"message-positive\">$2</span>."
     },
-    "pidTuningShowAllPids": {
-        "message": "Exibir todos PIDs"
-    },
     "pidTuningHideUnusedPids": {
         "message": "Esconder PIDs não utilizados"
     },

--- a/locales/ru/messages.json
+++ b/locales/ru/messages.json
@@ -163,7 +163,6 @@
     "tabServos": {
         "message": "Сервоприводы"
     },
-
     "tabTransponder": {
         "message": "Транспондер гонки"
     },
@@ -1031,12 +1030,6 @@
     },
     "pidTuningUpgradeFirmwareToChangePidController": {
         "message": "<span class=\"message-negative\">Менять PID-контроллер запрещено, но его можно поменять в командной строке.</span>  Ваша прошивка поддерживает конфигуратор версии <span class=\"message-negative\">$1</span>, а этот функционал требует версию прошивки <span class=\"message-positive\">$2</span>."
-    },
-    "pidTuningSubTabPid": {
-        "message": "PID-настройки"
-    },
-    "pidTuningSubTabFilter": {
-        "message": "Настройки фильтров"
     },
     "pidTuningShowAllPids": {
         "message": "Показать все PID-ы"
@@ -3184,7 +3177,6 @@
     "osdWarningRcSmoothingFailure": {
         "message": "Предупреждает когда инициализация RC не работает (нарушена)"
     },
-
     "osdWarningFailsafe": {
         "message": "Предупреждает когда происходит failsafe"
     },

--- a/locales/ru/messages.json
+++ b/locales/ru/messages.json
@@ -1031,9 +1031,6 @@
     "pidTuningUpgradeFirmwareToChangePidController": {
         "message": "<span class=\"message-negative\">Менять PID-контроллер запрещено, но его можно поменять в командной строке.</span>  Ваша прошивка поддерживает конфигуратор версии <span class=\"message-negative\">$1</span>, а этот функционал требует версию прошивки <span class=\"message-positive\">$2</span>."
     },
-    "pidTuningShowAllPids": {
-        "message": "Показать все PID-ы"
-    },
     "pidTuningHideUnusedPids": {
         "message": "Скрыть ненужные PID-ы"
     },

--- a/locales/sv/messages.json
+++ b/locales/sv/messages.json
@@ -1037,9 +1037,6 @@
     "pidTuningUpgradeFirmwareToChangePidController": {
         "message": "<span class=\"message-negative\">Inte möjligt att ändra PID-kontroller - du kan ändra den via CLI.</span>  Din firmware har API-version <span class=\"message-negative\">$1</span>, men denna funktion kräver <span class=\"message-positive\">$2</span>."
     },
-    "pidTuningShowAllPids": {
-        "message": "Visa alla PIDs"
-    },
     "pidTuningHideUnusedPids": {
         "message": "Dölj PIDs som inte används"
     },

--- a/locales/sv/messages.json
+++ b/locales/sv/messages.json
@@ -1037,12 +1037,6 @@
     "pidTuningUpgradeFirmwareToChangePidController": {
         "message": "<span class=\"message-negative\">Inte möjligt att ändra PID-kontroller - du kan ändra den via CLI.</span>  Din firmware har API-version <span class=\"message-negative\">$1</span>, men denna funktion kräver <span class=\"message-positive\">$2</span>."
     },
-    "pidTuningSubTabPid": {
-        "message": "PID-inställningar"
-    },
-    "pidTuningSubTabFilter": {
-        "message": "Filter-inställningar"
-    },
     "pidTuningShowAllPids": {
         "message": "Visa alla PIDs"
     },

--- a/locales/zh_CN/messages.json
+++ b/locales/zh_CN/messages.json
@@ -1055,9 +1055,6 @@
     "pidTuningUpgradeFirmwareToChangePidController": {
         "message": "<span class=\"message-negative\">禁止切换 PID 控制器 -  你可以通过CLI 来调整。</span> 当前固件 API 版本为 <span class=\"message-negative\">$1</span>，而此功能需要版本 <span class=\"message-positive\">$2</span>。"
     },
-    "pidTuningShowAllPids": {
-        "message": "显示所有PID"
-    },
     "pidTuningHideUnusedPids": {
         "message": "隐藏未使用的PID"
     },

--- a/locales/zh_CN/messages.json
+++ b/locales/zh_CN/messages.json
@@ -1055,12 +1055,6 @@
     "pidTuningUpgradeFirmwareToChangePidController": {
         "message": "<span class=\"message-negative\">禁止切换 PID 控制器 -  你可以通过CLI 来调整。</span> 当前固件 API 版本为 <span class=\"message-negative\">$1</span>，而此功能需要版本 <span class=\"message-positive\">$2</span>。"
     },
-    "pidTuningSubTabPid": {
-        "message": "PID 设置"
-    },
-    "pidTuningSubTabFilter": {
-        "message": "滤波器设置"
-    },
     "pidTuningShowAllPids": {
         "message": "显示所有PID"
     },

--- a/src/css/tabs/pid_tuning.css
+++ b/src/css/tabs/pid_tuning.css
@@ -166,12 +166,6 @@
     width: 33%;
 }
 
-/* Visual separator between PID rows and mode-setting rows in the same table */
-.tab-pid_tuning .subtab-stable tr.pid_section_sep td {
-    padding-top: 8px;
-    border-top: 1px solid var(--subtleAccent);
-}
-
 .tab-pid_tuning table.compensation tr {
     height: 30px;
     border-bottom: 1px solid var(--subtleAccent);

--- a/src/css/tabs/pid_tuning.css
+++ b/src/css/tabs/pid_tuning.css
@@ -139,18 +139,37 @@
     width: 25%;
 }
 
-.tab-pid_tuning #pid_accel table th {
+.tab-pid_tuning .subtab-stable {
+    display: flex;
+    flex-flow: row wrap;
+    align-items: flex-start;
+    justify-content: center;
+    gap: 10px;
+}
+
+.tab-pid_tuning .subtab-stable .cf_column {
+    min-width: 250px;
+    flex: 1;
+}
+
+.tab-pid_tuning .subtab-stable table th {
     width: auto;
 }
 
-.tab-pid_tuning #pid_accel table td {
+.tab-pid_tuning .subtab-stable table td {
     width: auto;
 }
 
-/* Equal-width columns for the 3-column OLDANGLEUI and angleLimit tables */
-.tab-pid_tuning #pid_accel table td.third,
-.tab-pid_tuning #pid_accel table th.third {
+/* Equal-width columns for 3-column tables in the stable subtab */
+.tab-pid_tuning .subtab-stable table td.third,
+.tab-pid_tuning .subtab-stable table th.third {
     width: 33%;
+}
+
+/* Visual separator between PID rows and mode-setting rows in the same table */
+.tab-pid_tuning .subtab-stable tr.pid_section_sep td {
+    padding-top: 8px;
+    border-top: 1px solid var(--subtleAccent);
 }
 
 .tab-pid_tuning table.compensation tr {

--- a/src/css/tabs/pid_tuning.css
+++ b/src/css/tabs/pid_tuning.css
@@ -140,10 +140,16 @@
 }
 
 .tab-pid_tuning #pid_accel table th {
-    width: 33%;
+    width: auto;
 }
 
 .tab-pid_tuning #pid_accel table td {
+    width: auto;
+}
+
+/* Equal-width columns for the 3-column OLDANGLEUI and angleLimit tables */
+.tab-pid_tuning #pid_accel table td.third,
+.tab-pid_tuning #pid_accel table th.third {
     width: 33%;
 }
 

--- a/src/css/tabs/pid_tuning.css
+++ b/src/css/tabs/pid_tuning.css
@@ -1006,10 +1006,11 @@
 
 .tab-pid_tuning .pid_titlebar .name-helpicon-flex {
     display: flex;
-    flex-flow: row wrap;
+    flex-flow: row nowrap;
     justify-content: space-around;
 }
 
 .tab-pid_tuning .pid_titlebar .name-helpicon-flex .helpicon {
     margin-right: 0;
+    flex-shrink: 0;
 }

--- a/src/js/tabs/pid_tuning.js
+++ b/src/js/tabs/pid_tuning.js
@@ -7,7 +7,6 @@
 
 TABS.pid_tuning = {
     RATE_PROFILE_MASK: 128,
-    showAllPids: false,
     updating: true,
     dirty: false,
     currentProfile: null,
@@ -290,7 +289,6 @@ TABS.pid_tuning.initialize = function(callback) {
 
         $('.NEWANGLEUI').hide();
         $('.OLDANGLEUI').hide();
-        //$('#showAllPids').hide(); //remove the useless button
         if ( semver.gte(CONFIG.apiVersion, "1.24.0") ) {
             $('.pid_tuning input[name="angleLimit"]').val(ADVANCED_TUNING.levelAngleLimit);
             $('.angleLimit').show();
@@ -1510,39 +1508,6 @@ TABS.pid_tuning.initialize = function(callback) {
         });
     }
 
-    function hideUnusedPids() {
-        // Hide all optional elements
-        //$('.pid_optional tr').hide(); // Hide all rows
-        //$('.pid_optional table').hide(); // Hide tables
-        $('.pid_optional').hide(); // Hide general div
-
-        if (!have_sensor(CONFIG.activeSensors, 'acc')) {
-            $('#pid_accel').hide();
-        }
-
-        var hideSensorPid = function(element, sensorReady) {
-            var isVisible = element.is(":visible");
-            if (!isVisible || !sensorReady) {
-                element.hide();
-                isVisible = false;
-            }
-
-            return isVisible;
-        }
-
-        var isVisibleBaroMagGps = false;
-
-        isVisibleBaroMagGps |= hideSensorPid($('#pid_baro'), have_sensor(CONFIG.activeSensors, 'baro') || have_sensor(CONFIG.activeSensors, 'sonar'));
-
-        isVisibleBaroMagGps |= hideSensorPid($('#pid_mag'), have_sensor(CONFIG.activeSensors, 'mag'));
-
-        isVisibleBaroMagGps |= hideSensorPid($('#pid_gps'), have_sensor(CONFIG.activeSensors, 'GPS'));
-
-        if (!isVisibleBaroMagGps) {
-            $('#pid_baro_mag_gps').hide();
-        }
-    }
-
     function drawAxes(curveContext, width, height) {
         curveContext.strokeStyle = '#000000';
         curveContext.lineWidth = 4;
@@ -1787,25 +1752,7 @@ TABS.pid_tuning.initialize = function(callback) {
 
         populatePresetsSelector(selectPresetValues);
 
-        var showAllButton = $('#showAllPids');
-
-        function updatePidDisplay() {
-            if (!self.showAllPids) {
-                hideUnusedPids();
-                showAllButton.text(i18n.getMessage("pidTuningShowAllPids"));
-            } else {
-                showAllPids();
-                showAllButton.text(i18n.getMessage("pidTuningHideUnusedPids"));
-            }
-        }
-
         showAllPids();
-        updatePidDisplay();
-
-        showAllButton.on('click', function() {
-            self.showAllPids = !self.showAllPids;
-            updatePidDisplay();
-        });
 
         $('#resetProfile').on('click', function() {
             resetProfile();

--- a/src/js/tabs/pid_tuning.js
+++ b/src/js/tabs/pid_tuning.js
@@ -1679,7 +1679,7 @@ TABS.pid_tuning.initialize = function(callback) {
         //end MSP 1.51
 
         function activateSubtab(subtabName) {
-            const names = ['pid', 'rates', 'filter','feel'];
+            const names = ['pid', 'stable', 'rates', 'filter', 'feel'];
             if (!names.includes(subtabName)) {
                 console.debug('Invalid subtab name: "' + subtabName + '"');
                 return;
@@ -1698,6 +1698,8 @@ TABS.pid_tuning.initialize = function(callback) {
         activateSubtab(self.activeSubtab);
 
         $('.tab-pid_tuning .tab_container .pid').on('click', () => activateSubtab('pid'));
+
+        $('.tab-pid_tuning .tab_container .stable').on('click', () => activateSubtab('stable'));
 
         $('.tab-pid_tuning .tab_container .rates').on('click', () => activateSubtab('rates'));
 

--- a/src/js/tabs/pid_tuning.js
+++ b/src/js/tabs/pid_tuning.js
@@ -1649,7 +1649,7 @@ TABS.pid_tuning.initialize = function(callback) {
                 console.debug('Invalid subtab name: "' + subtabName + '"');
                 return;
             }
-            for (name of names) {
+            for (const name of names) {
                 const el = $('.tab-pid_tuning .subtab-' + name);
                 el[name == subtabName ? 'show' : 'hide']();
             }

--- a/src/tabs/pid_tuning.html
+++ b/src/tabs/pid_tuning.html
@@ -562,12 +562,6 @@
                                                 <div></div>
                                             </div>
                                         </th>
-                                        <th class="integral">
-                                            <div class="name-helpicon-flex">
-                                                <div i18n="pidTuningIntegral"></div>
-                                                <div class="helpicon cf_tip" i18n_title="pidTuningAngleITermNAHelp"></div>
-                                            </div>
-                                        </th>
                                         <th class="derivative">
                                             <div class="name-helpicon-flex">
                                                 <div i18n="pidTuningDerivative"></div>
@@ -585,7 +579,6 @@
                                             </div>
                                         </td>
                                         <td class="pid_data"><input type="number" name="p_angle_high" step="1" min="0" max="200"></td>
-                                        <td class="pid_data"><input type="number" name="i_angle_high" step="1" min="0" max="255" disabled></td>
                                         <td class="pid_data"><input type="number" name="d_angle_high" step="1" min="0" max="200"></td>
                                     </tr>
                                     <tr class="LOW pid_tuning needed_by_LEVEL">
@@ -596,7 +589,6 @@
                                             </div>
                                         </td>
                                         <td class="pid_data"><input type="number" name="p_angle_low" step="1" min="0" max="200"></td>
-                                        <td class="pid_data"><input type="number" name="i_angle_low" step="1" min="0" max="255" disabled></td>
                                         <td class="pid_data"><input type="number" name="d_angle_low" step="1" min="0" max="200"></td>
                                     </tr>
                                 </table>

--- a/src/tabs/pid_tuning.html
+++ b/src/tabs/pid_tuning.html
@@ -62,6 +62,9 @@
                     <td class="pid active">
                         <a href="#" i18n="pidTuningSubTabPid"></a>
                     </td>
+                    <td class="stable">
+                        <a href="#" i18n="pidTuningSubTabStable"></a>
+                    </td>
                     <td class="rates">
                         <a href="#" i18n="pidTuningSubTabRates"></a>
                     </td>
@@ -168,160 +171,6 @@
                                 </tr>
                             </table>
                         </div>
-                        <!-- BARO, MAG, GPS - Non-existent/Broken/Purged -->
-                        <!-- ENTIRE ANGLE UI -->
-                        <div id="pid_accel" class="pid_optional needed_by_LEVEL gui_box grey topspacer pid_tuning isexpertmode">
-                            <!-- show Angle/NFE/Horizon both old and new UI-->
-                            <table id="pid_level" class="pid_tuning needed_by_LEVEL">
-                                <tr class="needed_by_LEVEL">
-                                    <th colspan="3">
-                                        <div class="pid_mode">
-                                            <div i18n="pidTuningLevel" style="float:left;"></div>
-                                            <div class="helpicon cf_tip" i18n_title="pidTuningLevelHelp"></div>
-                                        </div>
-                                    </th>
-                                </tr>
-                            </table> <!-- END show Angle/NFE/Horizon both old and new UI-->
-                            <div class="OLDANGLEUI">
-                                <table class="pid_titlebar needed_by_LEVEL">
-                                    <tr class="needed_by_LEVEL">
-                                        <th class="third"></th>
-                                        <th class="third" i18n="pidTuningStrength" style="width: 33%;"></th>
-                                        <th class="third" i18n="pidTuningTransition" style="width: 33%;"></th>
-                                    </tr>
-                                </table>
-                                <table class="needed_by_LEVEL">
-                                    <tr class="LEVEL">
-                                        <!-- 7 -->
-                                        <td class="third" i18n="pidTuningAngle"></td>
-                                        <td class="third"><input type="number" name="p" step="1" min="0" max="255"></td>
-                                        <td class="third"></td>
-                                    </tr>
-                                    <tr class="LEVEL">
-                                        <!-- 7 -->
-                                        <td class="third" i18n="pidTuningHorizon"></td>
-                                        <td class="third"><input type="number" name="i" step="1" min="0" max="255"></td>
-                                        <td class="third"><input type="number" name="d" step="1" min="0" max="255"></td>
-                                    </tr>
-                                </table>
-                            </div> <!-- class OLDANGLEUI -->
-                            <!-- new angle code features-->
-                            <div class="NEWANGLEUI">
-                                <table class="pid_titlebar needed_by_LEVEL">
-                                    <tr class="needed_by_LEVEL">
-                                        <th class="name"></th>
-                                        <th class="proportional">
-                                            <div class="name-helpicon-flex">
-                                                <div i18n="pidTuningProportional"></div>
-                                                <!-- <div class="helpicon cf_tip" i18n_title="pidTuningProportionalHelp"></div> -->
-                                                <div></div>
-                                            </div>
-                                        </th>
-                                        <th class="derivative">
-                                            <div class="name-helpicon-flex">
-                                                <div i18n="pidTuningDerivative"></div>
-                                                <!-- <div class="helpicon cf_tip" i18n_title="pidTuningDerivativeHelp"></div> -->
-                                                <div></div>
-                                            </div>
-                                        </th>
-                                    </tr>
-                                </table>
-                                <table class="needed_by_LEVEL" L>
-                                    <tr class="HIGH pid_tuning needed_by_LEVEL">
-                                        <td class="pid_high needed_by_LEVEL">
-                                            <div class="name-helpicon-flex">
-                                                <div i18n="pidTuningAngleHigh" style="float:left;"></div>
-                                                <div class="helpicon cf_tip" i18n_title="pidTuningAngleHighHelp"></div>
-                                            </div>
-                                        </td>
-                                        <td class="pid_data"><input type="number" name="p_angle_high" step="1" min="0" max="200"></td>
-                                        <td class="pid_data"><input type="number" name="d_angle_high" step="1" min="0" max="200"></td>
-                                    </tr>
-                                    <tr class="LOW pid_tuning needed_by_LEVEL">
-                                        <td class="pid_low needed_by_LEVEL">
-                                            <div class="name-helpicon-flex">
-                                                <div i18n="pidTuningAngleLow" style="float:left;"></div>
-                                                <div class="helpicon cf_tip" i18n_title="pidTuningAngleLowHelp"></div>
-                                            </div>
-                                        </td>
-                                        <td class="pid_data"><input type="number" name="p_angle_low" step="1" min="0" max="200"></td>
-                                        <td class="pid_data"><input type="number" name="d_angle_low" step="1" min="0" max="200"></td>
-                                    </tr>
-                                </table>
-                                <table class="pid_titlebar needed_by_LEVEL">
-                                    <tr class="needed_by_LEVEL">
-                                        <th class="name"></th>
-                                        <th class="">
-                                            <div class="name-helpicon-flex">
-                                                <div i18n="pidTuningAngleFeedForward"></div>
-                                                <div class="helpicon cf_tip" i18n_title="pidTuningAngleFeedForwardHelp"></div>
-                                            </div>
-                                        </th>
-                                        <th class="">
-                                            <div class="name-helpicon-flex">
-                                                <div i18n="pidTuningAngleExpo"></div>
-                                                <div class="helpicon cf_tip" i18n_title="pidTuningAngleExpoHelp"></div>
-                                            </div>
-                                        </th>
-                                    </tr>
-                                </table>
-                                <table class="needed_by_LEVEL">
-                                    <tr class="pid_tuning needed_by_LEVEL">
-                                        <td class=""></td>
-                                        <td class="pid_data"><input type="number" name="f_angle" step="1" min="0" max="2000"></td>
-                                        <td class="pid_data"><input type="number" name="angle_expo" step="1" min="0" max="100"></td>
-                                    </tr>
-                                </table>
-                                <table class="pid_titlebar needed_by_LEVEL">
-                                    <tr class="needed_by_LEVEL">
-                                        <th class="name"></th>
-                                        <th class="">
-                                            <div class="name-helpicon-flex">
-                                                <div i18n="pidTuningHorizTiltEffect"></div>
-                                                <div class="helpicon cf_tip" i18n_title="pidTuningHorizTiltEffectHelp"></div>
-                                            </div>
-                                        </th>
-                                        <th class="">
-                                            <div class="name-helpicon-flex">
-                                                <div i18n="pidTuningHorizTransition"></div>
-                                                <div class="helpicon cf_tip" i18n_title="pidTuningHorizTransitionHelp"></div>
-                                            </div>
-                                        </th>
-                                    </tr>
-                                </table>
-                                <table class="needed_by_LEVEL">
-                                    <tr class="LEVEL">
-                                        <td class="third" i18n="pidTuningHorizon"></td>
-                                        <td class="third"><input type="number" name="horizon_tilt_effect" step="1" min="0" max="180"></td>
-                                        <td class="third"><input type="number" name="horizon_transition" step="1" min="0" max="200"></td>
-                                    </tr>
-                                </table>
-                            </div> <!-- class NEWANGLEUI -->
-                            <table class="needed_by_LEVEL pid_titlebar angleLimit">
-                                <tr class="needed_by_LEVEL">
-                                    <th class="name"></th>
-                                    <th class="">
-                                        <div class="name-helpicon-flex">
-                                            <div i18n="pidTuningLevelAngleLimit"></div>
-                                            <div class="helpicon cf_tip" i18n_title="pidTuningLevelAngleLimitHelp"></div>
-                                        </div>
-                                    </th>
-                                    <th class="">
-                                        <!-- empty -->
-                                    </th>
-                                </tr>
-                            </table>
-                            <table id="" class="angleLimit needed_by_LEVEL pid_tuning">
-                                <tr class="needed_by_LEVEL">
-                                    <td class="third"></td>
-                                    <td class="third"><input type="number" name="angleLimit" step="1" min="10" max="90"></td>
-                                    <td class="third">
-                                        <!-- empty -->
-                                    </td>
-                                </tr>
-                            </table>
-
-                        </div> <!-- END ENTIRE ANGLE UI -->
                     </div> <!-- end cf_column -->
                     <div class="cf_column">
                         <div class="gui_box grey pidTuningFeatures spacer_left">
@@ -664,6 +513,172 @@
                         </div>
                     </div>
                 </div>
+                <!-- STABLE PIDS SUBTAB -->
+                <div class="subtab-stable" style="display: none;">
+                    <div class="clear-both"></div>
+                    <div class="cf_column">
+                        <!-- BARO, MAG, GPS - Non-existent/Broken/Purged -->
+                        <!-- ENTIRE ANGLE UI -->
+                        <div id="pid_accel" class="pid_optional needed_by_LEVEL gui_box grey topspacer pid_tuning">
+                            <!-- show Angle/NFE/Horizon both old and new UI-->
+                            <table id="pid_level" class="pid_tuning needed_by_LEVEL">
+                                <tr class="needed_by_LEVEL">
+                                    <th colspan="3">
+                                        <div class="pid_mode">
+                                            <div i18n="pidTuningLevel" style="float:left;"></div>
+                                            <div class="helpicon cf_tip" i18n_title="pidTuningLevelHelp"></div>
+                                        </div>
+                                    </th>
+                                </tr>
+                            </table> <!-- END show Angle/NFE/Horizon both old and new UI-->
+                            <div class="OLDANGLEUI">
+                                <table class="pid_titlebar needed_by_LEVEL">
+                                    <tr class="needed_by_LEVEL">
+                                        <th class="third"></th>
+                                        <th class="third" i18n="pidTuningStrength" style="width: 33%;"></th>
+                                        <th class="third" i18n="pidTuningTransition" style="width: 33%;"></th>
+                                    </tr>
+                                </table>
+                                <table class="needed_by_LEVEL">
+                                    <tr class="LEVEL">
+                                        <!-- 7 -->
+                                        <td class="third" i18n="pidTuningAngle"></td>
+                                        <td class="third"><input type="number" name="p" step="1" min="0" max="255"></td>
+                                        <td class="third"></td>
+                                    </tr>
+                                    <tr class="LEVEL">
+                                        <!-- 7 -->
+                                        <td class="third" i18n="pidTuningHorizon"></td>
+                                        <td class="third"><input type="number" name="i" step="1" min="0" max="255"></td>
+                                        <td class="third"><input type="number" name="d" step="1" min="0" max="255"></td>
+                                    </tr>
+                                </table>
+                            </div> <!-- class OLDANGLEUI -->
+                            <!-- new angle code features-->
+                            <div class="NEWANGLEUI">
+                                <table class="pid_titlebar needed_by_LEVEL">
+                                    <tr class="needed_by_LEVEL">
+                                        <th class="name"></th>
+                                        <th class="proportional">
+                                            <div class="name-helpicon-flex">
+                                                <div i18n="pidTuningProportional"></div>
+                                                <div></div>
+                                            </div>
+                                        </th>
+                                        <th class="integral">
+                                            <div class="name-helpicon-flex">
+                                                <div i18n="pidTuningIntegral"></div>
+                                                <div class="helpicon cf_tip" i18n_title="pidTuningAngleITermNAHelp"></div>
+                                            </div>
+                                        </th>
+                                        <th class="derivative">
+                                            <div class="name-helpicon-flex">
+                                                <div i18n="pidTuningDerivative"></div>
+                                                <div></div>
+                                            </div>
+                                        </th>
+                                    </tr>
+                                </table>
+                                <table class="needed_by_LEVEL" L>
+                                    <tr class="HIGH pid_tuning needed_by_LEVEL">
+                                        <td class="pid_high needed_by_LEVEL">
+                                            <div class="name-helpicon-flex">
+                                                <div i18n="pidTuningAngleHigh" style="float:left;"></div>
+                                                <div class="helpicon cf_tip" i18n_title="pidTuningAngleHighHelp"></div>
+                                            </div>
+                                        </td>
+                                        <td class="pid_data"><input type="number" name="p_angle_high" step="1" min="0" max="200"></td>
+                                        <td class="pid_data"><input type="number" name="i_angle_high" step="1" min="0" max="255" disabled></td>
+                                        <td class="pid_data"><input type="number" name="d_angle_high" step="1" min="0" max="200"></td>
+                                    </tr>
+                                    <tr class="LOW pid_tuning needed_by_LEVEL">
+                                        <td class="pid_low needed_by_LEVEL">
+                                            <div class="name-helpicon-flex">
+                                                <div i18n="pidTuningAngleLow" style="float:left;"></div>
+                                                <div class="helpicon cf_tip" i18n_title="pidTuningAngleLowHelp"></div>
+                                            </div>
+                                        </td>
+                                        <td class="pid_data"><input type="number" name="p_angle_low" step="1" min="0" max="200"></td>
+                                        <td class="pid_data"><input type="number" name="i_angle_low" step="1" min="0" max="255" disabled></td>
+                                        <td class="pid_data"><input type="number" name="d_angle_low" step="1" min="0" max="200"></td>
+                                    </tr>
+                                </table>
+                                <table class="pid_titlebar needed_by_LEVEL">
+                                    <tr class="needed_by_LEVEL">
+                                        <th class="name"></th>
+                                        <th class="">
+                                            <div class="name-helpicon-flex">
+                                                <div i18n="pidTuningAngleFeedForward"></div>
+                                                <div class="helpicon cf_tip" i18n_title="pidTuningAngleFeedForwardHelp"></div>
+                                            </div>
+                                        </th>
+                                        <th class="">
+                                            <div class="name-helpicon-flex">
+                                                <div i18n="pidTuningAngleExpo"></div>
+                                                <div class="helpicon cf_tip" i18n_title="pidTuningAngleExpoHelp"></div>
+                                            </div>
+                                        </th>
+                                    </tr>
+                                </table>
+                                <table class="needed_by_LEVEL">
+                                    <tr class="pid_tuning needed_by_LEVEL">
+                                        <td class=""></td>
+                                        <td class="pid_data"><input type="number" name="f_angle" step="1" min="0" max="2000"></td>
+                                        <td class="pid_data"><input type="number" name="angle_expo" step="1" min="0" max="100"></td>
+                                    </tr>
+                                </table>
+                                <table class="pid_titlebar needed_by_LEVEL">
+                                    <tr class="needed_by_LEVEL">
+                                        <th class="name"></th>
+                                        <th class="">
+                                            <div class="name-helpicon-flex">
+                                                <div i18n="pidTuningHorizTiltEffect"></div>
+                                                <div class="helpicon cf_tip" i18n_title="pidTuningHorizTiltEffectHelp"></div>
+                                            </div>
+                                        </th>
+                                        <th class="">
+                                            <div class="name-helpicon-flex">
+                                                <div i18n="pidTuningHorizTransition"></div>
+                                                <div class="helpicon cf_tip" i18n_title="pidTuningHorizTransitionHelp"></div>
+                                            </div>
+                                        </th>
+                                    </tr>
+                                </table>
+                                <table class="needed_by_LEVEL">
+                                    <tr class="LEVEL">
+                                        <td class="third" i18n="pidTuningHorizon"></td>
+                                        <td class="third"><input type="number" name="horizon_tilt_effect" step="1" min="0" max="180"></td>
+                                        <td class="third"><input type="number" name="horizon_transition" step="1" min="0" max="200"></td>
+                                    </tr>
+                                </table>
+                            </div> <!-- class NEWANGLEUI -->
+                            <table class="needed_by_LEVEL pid_titlebar angleLimit">
+                                <tr class="needed_by_LEVEL">
+                                    <th class="name"></th>
+                                    <th class="">
+                                        <div class="name-helpicon-flex">
+                                            <div i18n="pidTuningLevelAngleLimit"></div>
+                                            <div class="helpicon cf_tip" i18n_title="pidTuningLevelAngleLimitHelp"></div>
+                                        </div>
+                                    </th>
+                                    <th class="">
+                                        <!-- empty -->
+                                    </th>
+                                </tr>
+                            </table>
+                            <table id="" class="angleLimit needed_by_LEVEL pid_tuning">
+                                <tr class="needed_by_LEVEL">
+                                    <td class="third"></td>
+                                    <td class="third"><input type="number" name="angleLimit" step="1" min="10" max="90"></td>
+                                    <td class="third">
+                                        <!-- empty -->
+                                    </td>
+                                </tr>
+                            </table>
+
+                        </div> <!-- END ENTIRE ANGLE UI -->
+                    </div> <!-- end cf_column -->
+                </div> <!-- end subtab-stable -->
                 <!-- RATES SUBTAB -->
                 <div class="subtab-rates" style="display: none;">
                     <div class="clear-both"></div>

--- a/src/tabs/pid_tuning.html
+++ b/src/tabs/pid_tuning.html
@@ -42,9 +42,6 @@
                 </div>
             </div>
             <div class="cf_column right">
-                <div class="default_btn show showAllPids">
-                    <a href="#" id="showAllPids" i18n="pidTuningShowAllPids"></a>
-                </div>
                 <div class="default_btn resetbt">
                     <a href="#" id="resetProfile" i18n="pidTuningResetProfile"></a>
                 </div>

--- a/src/tabs/pid_tuning.html
+++ b/src/tabs/pid_tuning.html
@@ -594,7 +594,10 @@
                                     <td class="pid_data"><input type="number" name="d_angle_low" step="1" min="0" max="200"></td>
                                     <td class="pid_data"><input type="number" name="f_angle" step="1" min="0" max="2000"></td>
                                 </tr>
-                                <tr class="pid_tuning pid_section_sep">
+                                <tr class="pid_titlebar2">
+                                    <th colspan="4"><div class="pid_mode"></div></th>
+                                </tr>
+                                <tr class="pid_tuning">
                                     <td>
                                         <div class="name-helpicon-flex">
                                             <div i18n="pidTuningAngleExpo" style="float:left;"></div>

--- a/src/tabs/pid_tuning.html
+++ b/src/tabs/pid_tuning.html
@@ -513,160 +513,145 @@
                 <!-- STABLE PIDS SUBTAB -->
                 <div class="subtab-stable" style="display: none;">
                     <div class="clear-both"></div>
-                    <div class="cf_column">
-                        <!-- BARO, MAG, GPS - Non-existent/Broken/Purged -->
-                        <!-- ENTIRE ANGLE UI -->
-                        <div id="pid_accel" class="pid_optional needed_by_LEVEL gui_box grey topspacer pid_tuning">
-                            <!-- show Angle/NFE/Horizon both old and new UI-->
-                            <table id="pid_level" class="pid_tuning needed_by_LEVEL">
-                                <tr class="needed_by_LEVEL">
-                                    <th colspan="3">
-                                        <div class="pid_mode">
+
+                    <!-- Left cf_column: Angle Mode PIDs -->
+                    <div class="cf_column pid_optional needed_by_LEVEL">
+
+                        <!-- OLDANGLEUI: legacy firmware (API < 1.46) -->
+                        <div class="OLDANGLEUI gui_box grey topspacer pid_tuning">
+                            <table class="pid_tuning">
+                                <tr class="pid_titlebar">
+                                    <th class="name">
+                                        <div class="name-helpicon-flex">
                                             <div i18n="pidTuningLevel" style="float:left;"></div>
                                             <div class="helpicon cf_tip" i18n_title="pidTuningLevelHelp"></div>
                                         </div>
                                     </th>
+                                    <th class="third" i18n="pidTuningStrength"></th>
+                                    <th class="third" i18n="pidTuningTransition"></th>
                                 </tr>
-                            </table> <!-- END show Angle/NFE/Horizon both old and new UI-->
-                            <div class="OLDANGLEUI">
-                                <table class="pid_titlebar needed_by_LEVEL">
-                                    <tr class="needed_by_LEVEL">
-                                        <th class="third"></th>
-                                        <th class="third" i18n="pidTuningStrength" style="width: 33%;"></th>
-                                        <th class="third" i18n="pidTuningTransition" style="width: 33%;"></th>
-                                    </tr>
-                                </table>
-                                <table class="needed_by_LEVEL">
-                                    <tr class="LEVEL">
-                                        <!-- 7 -->
-                                        <td class="third" i18n="pidTuningAngle"></td>
-                                        <td class="third"><input type="number" name="p" step="1" min="0" max="255"></td>
-                                        <td class="third"></td>
-                                    </tr>
-                                    <tr class="LEVEL">
-                                        <!-- 7 -->
-                                        <td class="third" i18n="pidTuningHorizon"></td>
-                                        <td class="third"><input type="number" name="i" step="1" min="0" max="255"></td>
-                                        <td class="third"><input type="number" name="d" step="1" min="0" max="255"></td>
-                                    </tr>
-                                </table>
-                            </div> <!-- class OLDANGLEUI -->
-                            <!-- new angle code features-->
-                            <div class="NEWANGLEUI">
-                                <table class="pid_titlebar needed_by_LEVEL">
-                                    <tr class="needed_by_LEVEL">
-                                        <th class="name"></th>
-                                        <th class="proportional">
-                                            <div class="name-helpicon-flex">
-                                                <div i18n="pidTuningProportional"></div>
-                                                <div></div>
-                                            </div>
-                                        </th>
-                                        <th class="derivative">
-                                            <div class="name-helpicon-flex">
-                                                <div i18n="pidTuningDerivative"></div>
-                                                <div></div>
-                                            </div>
-                                        </th>
-                                    </tr>
-                                </table>
-                                <table class="needed_by_LEVEL" L>
-                                    <tr class="HIGH pid_tuning needed_by_LEVEL">
-                                        <td class="pid_high needed_by_LEVEL">
-                                            <div class="name-helpicon-flex">
-                                                <div i18n="pidTuningAngleHigh" style="float:left;"></div>
-                                                <div class="helpicon cf_tip" i18n_title="pidTuningAngleHighHelp"></div>
-                                            </div>
-                                        </td>
-                                        <td class="pid_data"><input type="number" name="p_angle_high" step="1" min="0" max="200"></td>
-                                        <td class="pid_data"><input type="number" name="d_angle_high" step="1" min="0" max="200"></td>
-                                    </tr>
-                                    <tr class="LOW pid_tuning needed_by_LEVEL">
-                                        <td class="pid_low needed_by_LEVEL">
-                                            <div class="name-helpicon-flex">
-                                                <div i18n="pidTuningAngleLow" style="float:left;"></div>
-                                                <div class="helpicon cf_tip" i18n_title="pidTuningAngleLowHelp"></div>
-                                            </div>
-                                        </td>
-                                        <td class="pid_data"><input type="number" name="p_angle_low" step="1" min="0" max="200"></td>
-                                        <td class="pid_data"><input type="number" name="d_angle_low" step="1" min="0" max="200"></td>
-                                    </tr>
-                                </table>
-                                <table class="pid_titlebar needed_by_LEVEL">
-                                    <tr class="needed_by_LEVEL">
-                                        <th class="name"></th>
-                                        <th class="">
-                                            <div class="name-helpicon-flex">
-                                                <div i18n="pidTuningAngleFeedForward"></div>
-                                                <div class="helpicon cf_tip" i18n_title="pidTuningAngleFeedForwardHelp"></div>
-                                            </div>
-                                        </th>
-                                        <th class="">
-                                            <div class="name-helpicon-flex">
-                                                <div i18n="pidTuningAngleExpo"></div>
-                                                <div class="helpicon cf_tip" i18n_title="pidTuningAngleExpoHelp"></div>
-                                            </div>
-                                        </th>
-                                    </tr>
-                                </table>
-                                <table class="needed_by_LEVEL">
-                                    <tr class="pid_tuning needed_by_LEVEL">
-                                        <td class=""></td>
-                                        <td class="pid_data"><input type="number" name="f_angle" step="1" min="0" max="2000"></td>
-                                        <td class="pid_data"><input type="number" name="angle_expo" step="1" min="0" max="100"></td>
-                                    </tr>
-                                </table>
-                                <table class="pid_titlebar needed_by_LEVEL">
-                                    <tr class="needed_by_LEVEL">
-                                        <th class="name"></th>
-                                        <th class="">
-                                            <div class="name-helpicon-flex">
-                                                <div i18n="pidTuningHorizTiltEffect"></div>
-                                                <div class="helpicon cf_tip" i18n_title="pidTuningHorizTiltEffectHelp"></div>
-                                            </div>
-                                        </th>
-                                        <th class="">
-                                            <div class="name-helpicon-flex">
-                                                <div i18n="pidTuningHorizTransition"></div>
-                                                <div class="helpicon cf_tip" i18n_title="pidTuningHorizTransitionHelp"></div>
-                                            </div>
-                                        </th>
-                                    </tr>
-                                </table>
-                                <table class="needed_by_LEVEL">
-                                    <tr class="LEVEL">
-                                        <td class="third" i18n="pidTuningHorizon"></td>
-                                        <td class="third"><input type="number" name="horizon_tilt_effect" step="1" min="0" max="180"></td>
-                                        <td class="third"><input type="number" name="horizon_transition" step="1" min="0" max="200"></td>
-                                    </tr>
-                                </table>
-                            </div> <!-- class NEWANGLEUI -->
-                            <table class="needed_by_LEVEL pid_titlebar angleLimit">
-                                <tr class="needed_by_LEVEL">
-                                    <th class="name"></th>
-                                    <th class="">
+                                <tr class="LEVEL">
+                                    <td class="third" i18n="pidTuningAngle"></td>
+                                    <td class="third"><input type="number" name="p" step="1" min="0" max="255"></td>
+                                    <td class="third"></td>
+                                </tr>
+                                <tr class="LEVEL">
+                                    <td class="third" i18n="pidTuningHorizon"></td>
+                                    <td class="third"><input type="number" name="i" step="1" min="0" max="255"></td>
+                                    <td class="third"><input type="number" name="d" step="1" min="0" max="255"></td>
+                                </tr>
+                            </table>
+                        </div> <!-- OLDANGLEUI -->
+
+                        <!-- NEWANGLEUI: Angle Mode PIDs — Roll/Pitch P | D | FF -->
+                        <div class="NEWANGLEUI gui_box grey topspacer pid_tuning">
+                            <table class="pid_tuning">
+                                <tr class="pid_titlebar">
+                                    <th class="name">
                                         <div class="name-helpicon-flex">
-                                            <div i18n="pidTuningLevelAngleLimit"></div>
-                                            <div class="helpicon cf_tip" i18n_title="pidTuningLevelAngleLimitHelp"></div>
+                                            <div i18n="pidTuningLevel" style="float:left;"></div>
+                                            <div class="helpicon cf_tip" i18n_title="pidTuningLevelHelp"></div>
+                                        </div>
+                                    </th>
+                                    <th class="proportional">
+                                        <div class="name-helpicon-flex">
+                                            <div i18n="pidTuningProportional"></div>
+                                            <div></div>
+                                        </div>
+                                    </th>
+                                    <th class="derivative">
+                                        <div class="name-helpicon-flex">
+                                            <div i18n="pidTuningDerivative"></div>
+                                            <div></div>
                                         </div>
                                     </th>
                                     <th class="">
-                                        <!-- empty -->
+                                        <div class="name-helpicon-flex">
+                                            <div i18n="pidTuningAngleFeedForward"></div>
+                                            <div class="helpicon cf_tip" i18n_title="pidTuningAngleFeedForwardHelp"></div>
+                                        </div>
                                     </th>
                                 </tr>
-                            </table>
-                            <table id="" class="angleLimit needed_by_LEVEL pid_tuning">
-                                <tr class="needed_by_LEVEL">
-                                    <td class="third"></td>
-                                    <td class="third"><input type="number" name="angleLimit" step="1" min="10" max="90"></td>
-                                    <td class="third">
-                                        <!-- empty -->
+                                <tr class="HIGH pid_tuning">
+                                    <td class="pid_high">
+                                        <div class="name-helpicon-flex">
+                                            <div i18n="pidTuningAngleHigh" style="float:left;"></div>
+                                            <div class="helpicon cf_tip" i18n_title="pidTuningAngleHighHelp"></div>
+                                        </div>
                                     </td>
+                                    <td class="pid_data"><input type="number" name="p_angle_high" step="1" min="0" max="200"></td>
+                                    <td class="pid_data"><input type="number" name="d_angle_high" step="1" min="0" max="200"></td>
+                                    <td class="pid_data"><!-- no HIGH feedforward in MSP --></td>
+                                </tr>
+                                <tr class="LOW pid_tuning">
+                                    <td class="pid_low">
+                                        <div class="name-helpicon-flex">
+                                            <div i18n="pidTuningAngleLow" style="float:left;"></div>
+                                            <div class="helpicon cf_tip" i18n_title="pidTuningAngleLowHelp"></div>
+                                        </div>
+                                    </td>
+                                    <td class="pid_data"><input type="number" name="p_angle_low" step="1" min="0" max="200"></td>
+                                    <td class="pid_data"><input type="number" name="d_angle_low" step="1" min="0" max="200"></td>
+                                    <td class="pid_data"><input type="number" name="f_angle" step="1" min="0" max="2000"></td>
+                                </tr>
+                                <tr class="pid_tuning pid_section_sep">
+                                    <td>
+                                        <div class="name-helpicon-flex">
+                                            <div i18n="pidTuningAngleExpo" style="float:left;"></div>
+                                            <div class="helpicon cf_tip" i18n_title="pidTuningAngleExpoHelp"></div>
+                                        </div>
+                                    </td>
+                                    <td class="pid_data"><input type="number" name="angle_expo" step="1" min="0" max="100"></td>
+                                    <td class="pid_data"></td>
+                                    <td class="pid_data"></td>
+                                </tr>
+                                <tr class="pid_tuning angleLimit">
+                                    <td>
+                                        <div class="name-helpicon-flex">
+                                            <div i18n="pidTuningLevelAngleLimit" style="float:left;"></div>
+                                            <div class="helpicon cf_tip" i18n_title="pidTuningLevelAngleLimitHelp"></div>
+                                        </div>
+                                    </td>
+                                    <td class="pid_data"><input type="number" name="angleLimit" step="1" min="10" max="90"></td>
+                                    <td class="pid_data"></td>
+                                    <td class="pid_data"></td>
                                 </tr>
                             </table>
+                        </div> <!-- NEWANGLEUI: Angle Mode PIDs -->
 
-                        </div> <!-- END ENTIRE ANGLE UI -->
-                    </div> <!-- end cf_column -->
+                    </div> <!-- left cf_column -->
+
+                    <!-- Right cf_column: Horizon Mode -->
+                    <div class="cf_column pid_optional needed_by_LEVEL">
+
+                        <!-- NEWANGLEUI: Horizon Mode -->
+                        <div class="NEWANGLEUI gui_box grey topspacer pid_tuning">
+                            <table class="pid_tuning">
+                                <tr class="pid_titlebar">
+                                    <th class="name" i18n="pidTuningHorizon"></th>
+                                    <th class="">
+                                        <div class="name-helpicon-flex">
+                                            <div i18n="pidTuningHorizTiltEffect"></div>
+                                            <div class="helpicon cf_tip" i18n_title="pidTuningHorizTiltEffectHelp"></div>
+                                        </div>
+                                    </th>
+                                    <th class="">
+                                        <div class="name-helpicon-flex">
+                                            <div i18n="pidTuningHorizTransition"></div>
+                                            <div class="helpicon cf_tip" i18n_title="pidTuningHorizTransitionHelp"></div>
+                                        </div>
+                                    </th>
+                                </tr>
+                                <tr class="LEVEL">
+                                    <td class="third"></td>
+                                    <td class="third"><input type="number" name="horizon_tilt_effect" step="1" min="0" max="180"></td>
+                                    <td class="third"><input type="number" name="horizon_transition" step="1" min="0" max="200"></td>
+                                </tr>
+                            </table>
+                        </div> <!-- Horizon Mode -->
+
+                    </div> <!-- right cf_column -->
+
                 </div> <!-- end subtab-stable -->
                 <!-- RATES SUBTAB -->
                 <div class="subtab-rates" style="display: none;">


### PR DESCRIPTION
## Summary

- Adds a dedicated **Stable PIDs** sub-tab to the PID tuning page, moving all Angle/Horizon/NFE/RTH level-mode tuning fields out of Acro PIDs into their own tab
- Renames the existing `pid` sub-tab to **Acro PIDs** and shortens **Rateprofile Settings** → **Rate Settings**
- Two-column layout: left box = Angle Mode PIDs (P | D | FF table for Roll/Pitch High + Low, plus Angle Expo and Angle Limit rows); right box = Horizon Mode (Tilt Effect + Transition)
- Removes the **Show All PIDs** toggle — stable-mode content is always accessible via its own tab
- All exposed MSP fields verified against firmware `msp.c` / `pid.c`: `p_angle_low`, `d_angle_low`, `f_angle` (PID_LEVEL_LOW.F), `p_angle_high`, `d_angle_high`, `horizonTransition`, `horizon_tilt_effect`, `angleExpo`, `angleLimit`; no phantom fields added
- `PID_LEVEL_LOW.I` / `PID_LEVEL_HIGH.I` intentionally absent — hardcoded `0` in MSP send, discarded on receive; used internally as Direct Feedforward coefficients, not traditional I-terms
- Feed-Forward column only on Roll/Pitch Low row — `f_angle` (PID_LEVEL_LOW.F) has no HIGH equivalent in MSP
- Legacy firmware (API < 1.46) shows OLDANGLEUI fallback in the same tab
- Fixes `name-helpicon-flex` column headers wrapping tooltip icon to a new line at narrow window widths (`flex-flow: row nowrap` + `flex-shrink: 0` on helpicon)
- Adds RTH to `pidTuningLevel` label ("Angle / Horizon / NFE / RTH") — RTH uses `pidLevel()` same as the other modes
- Drops all five PID sub-tab i18n keys from non-English locales (no Crowdin pipeline; English fallback is more accurate than stale translations)

## Test plan

- [x] Connect FC with API ≥ 1.46 — verify Stable PIDs tab shows, reads, and saves all fields correctly
- [x] Connect FC with API < 1.46 — verify OLDANGLEUI fallback renders in Stable PIDs tab
- [x] Verify Acro PIDs tab no longer contains angle/horizon fields
- [x] Verify Show All PIDs button is gone
- [x] Resize window narrow — confirm column header tooltip icons stay on same line as label text
- [x] Verify non-English locale shows English sub-tab labels (Acro PIDs, Stable PIDs, Rate Settings, Filter, Feel)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Stable PIDs" subtab for angle-mode PID configuration
  * Introduced reset and copy actions for profiles and rate profiles
  * Added firmware version requirement messaging for PID controller changes

* **UI/UX Improvements**
  * Updated PID tuning tab labels for clarity ("Acro PIDs", "Rate Settings")
  * Reorganized angle-mode PID controls into the stable subtab
  * Removed "Show All PIDs" toolbar toggle

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/emuflight/EmuConfigurator/pull/590?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->