### PR TITLE
fix(stm32): restore flash button when serial connect fails

### DIFF
--- a/src/js/protocols/stm32.js
+++ b/src/js/protocols/stm32.js
@@ -82,6 +82,7 @@ STM32_protocol.prototype.connect = function (port, baud, hex, options, callback)
                 self.initialize();
             } else {
                 GUI.log(i18n.getMessage('serialPortOpenFail'));
+                if (self.callback) self.callback();
             }
         });
     } else {
@@ -124,6 +125,7 @@ STM32_protocol.prototype.connect = function (port, baud, hex, options, callback)
                                             } else {
                                                 GUI.connect_lock = false;
                                                 GUI.log(i18n.getMessage('serialPortOpenFail'));
+                                                if (self.callback) self.callback();
                                             }
                                         });
                                     }
@@ -133,12 +135,15 @@ STM32_protocol.prototype.connect = function (port, baud, hex, options, callback)
                             // Initial 500ms delay for the board to begin re-enumeration
                             setTimeout(pollForDFU, 500);
                         } else {
+                            console.log('STM32 - serial.disconnect failed after reboot command');
                             GUI.connect_lock = false;
+                            if (self.callback) self.callback();
                         }
                     });
                 });
             } else {
                 GUI.log(i18n.getMessage('serialPortOpenFail'));
+                if (self.callback) self.callback();
             }
         });
     }


### PR DESCRIPTION
## Problem

When flashing firmware without a board plugged in (or on any serial port open failure), the Flash button turns gray and stays gray permanently. The only recovery is to leave the Firmware Flasher tab, re-enter it, and reload the hex file.

**Root cause:** `STM32_protocol.prototype.connect` calls `serial.connect()` but never invokes the completion callback (`flashComplete`) in any of the four failure/error branches. `flashComplete` is responsible for re-enabling the flash button and all related controls.

## Fix

Add `if (self.callback) self.callback()` to all four failure paths in `STM32_protocol.prototype.connect`:

- **no_reboot path** — `serial.connect` returns no `openInfo`
- **reboot path** — initial `serial.connect` returns no `openInfo`
- **reboot path** — `serial.disconnect` returns falsy during reboot sequence
- **reboot path** — fallback `serial.connect` fails after DFU poll timeout

## Behaviour after fix

- Flash button is re-enabled on any serial connect failure
- Loaded hex file is retained (closure variables `intel_hex`/`parsed_hex` are untouched by `flashComplete`)
- User can plug in the board and click Flash immediately — no need to reload the file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where STM32 device connection failures did not properly trigger callbacks in certain scenarios. Connection failures now consistently invoke error callbacks for improved error handling and UI notifications.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/emuflight/EmuConfigurator/pull/593?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->