### PR TITLE
fix(linux): skip usb source rebuild to avoid post-flash DFU crash on glibc 2.34+

### DIFF
--- a/forge.config.js
+++ b/forge.config.js
@@ -60,11 +60,18 @@ module.exports = {
     },
   },
   rebuildConfig: {
+    // On Linux, @electron/rebuild looks for `node.napi.node` prebuilts but usb@2.x
+    // ships `node.napi.glibc.node` (prebuildify libc-variant naming). The mismatch
+    // causes a source rebuild that references __pthread_cond_timedwait64, an internal
+    // glibc symbol not exported on Debian glibc 2.34+. Skip the rebuild so node-gyp-build
+    // falls through to the clean prebuilt at runtime. usb is NAPI so no ABI concern.
+    //
     // exe-icon-extractor is a Windows-only native module pulled in by maker-wix.
     // Rebuilding it on Linux/macOS fails node-gyp; skip it on non-Windows.
-    ...(process.platform !== 'win32' ? {
-      ignoreModules: ['@bitdisaster/exe-icon-extractor'],
-    } : {}),
+    ignoreModules: [
+      ...(process.platform !== 'win32' ? ['@bitdisaster/exe-icon-extractor'] : []),
+      ...(process.platform === 'linux' ? ['usb'] : []),
+    ],
   },
   makers: [
     {


### PR DESCRIPTION
AI Generated [pull-request]

## Summary

- On Linux with glibc 2.34+ (Debian Trixie, Ubuntu 24.04+), `pthread.h` redirects `pthread_cond_timedwait` → `__pthread_cond_timedwait64` via `__USE_TIME64_REDIRECTS`. glibc does not export this symbol dynamically, so any native module compiled from source on such systems crashes at runtime with `undefined symbol: __pthread_cond_timedwait64`.
- `@electron/rebuild` v3.7.2 looks for `node.napi.node` prebuilts but `usb@2.x` ships `node.napi.glibc.node` (prebuildify libc-variant naming). The naming mismatch causes `@electron/rebuild` to fall back to a source compile, producing the broken binary.
- This regressed with the Electron 41→42 bump — Electron 41 reused a cached prebuilt; Electron 42 forced a fresh rebuild that exposed the bug. Symptom: configurator crashes and exits at the end of DFU flash verification.

## Fix

Add `usb` to `ignoreModules` on Linux in `rebuildConfig` so `@electron/rebuild` skips the source rebuild entirely. At runtime, `node-gyp-build` falls through to `prebuilds/linux-x64/node.napi.glibc.node` — a clean prebuilt that uses the standard versioned `pthread_cond_timedwait@GLIBC_2.3.2` symbol. `usb` is NAPI so there is no ABI compatibility concern across Electron versions.

## Test plan

- [ ] `git clean -dxf && nvm use && yarn install && yarn dev` on Linux with glibc 2.34+ (Debian 13 Trixie)
- [ ] Flash a FC via DFU (FoxeerF722v4 confirmed) — verify app does not crash at end of verification
- [ ] Confirm `yarn make` still works on Linux, macOS, Windows (fix is Linux-gated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration for improved platform compatibility, preventing native module build failures on Linux and non-Windows platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->