### PR TITLE
feat(pid_tuning): show SVF label for filter type index 1 on fw >= 0.5.0

### DIFF
--- a/src/js/tabs/pid_tuning.js
+++ b/src/js/tabs/pid_tuning.js
@@ -2384,7 +2384,8 @@ TABS.pid_tuning.initialize = function(callback) {
         function loadFilterTypeValues() {
             var filterTypeValues = [];
             filterTypeValues.push("PT1");
-            filterTypeValues.push("BIQUAD");
+            // fw >= 0.5.0: index 1 CLI string renamed BIQUAD -> SVF (SVF backport, EF PR #1245)
+            filterTypeValues.push(semver.gte(CONFIG.flightControllerVersion, "0.5.0") ? "SVF" : "BIQUAD");
             if (semver.lte(CONFIG.apiVersion, "1.41.0")) {
                 filterTypeValues.push("KALMAN");
             }


### PR DESCRIPTION
AI Generated pull-request

## Summary

Companion configurator change for EmuFlight firmware PR emuflight/EmuFlight#1245 (SVF filter backport).

Firmware PR #1245 renames the CLI string for filter type index 1 from `BIQUAD` to `SVF` starting in firmware `0.5.0` (not yet released). This change gates the dropdown label in the PID tuning filter selectors on `flightControllerVersion >= 0.5.0`:

- **fw >= 0.5.0** → dropdown shows `SVF` at index 1 (gyro lpf1, gyro lpf2 dyn, dterm lpf1, dterm lpf2)
- **fw < 0.5.0** → dropdown shows `BIQUAD` (no change for legacy firmware users)

RC-smoothing filter type is **not affected** — that firmware path still calls `biquadFilterApplyDF1` internally and the label stays `BIQUAD` unconditionally.

### Change

`src/js/tabs/pid_tuning.js` — `loadFilterTypeValues()`:

```js
// before
filterTypeValues.push("BIQUAD");

// after
filterTypeValues.push(semver.gte(CONFIG.flightControllerVersion, "0.5.0") ? "SVF" : "BIQUAD");
```

All five selectors (`gyroLowpassType`, `gyroLowpassDynType`, `gyroLowpass2Type`, `dtermLowpassType`, `dtermLowpass2Type`) call `loadFilterTypeValues()`, so one change covers all.

## Test plan

- [x] Lint passes (0 errors)
- [ ] Verified against fw >= 0.5.0 build: index 1 shows "SVF"
- [ ] Verified against fw < 0.5.0 build: index 1 shows "BIQUAD"
- [ ] Hardware verified: pending EF PR #1245 merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected D-term/gyro filter type options in the PID tuning interface to dynamically adjust available filter types based on flight controller firmware version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->