### PR TITLE
Add Pre-Release Master firmware source to Firmware Flasher

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -2522,6 +2522,9 @@
     "firmwareFlasherOptionLabelBuildTypeReleaseCandidate": {
         "message": "Release And Release Candidate"
     },
+    "firmwareFlasherOptionLabelBuildTypePreReleaseMaster": {
+        "message": "Pre-Release Master"
+    },
     "firmwareFlasherOptionLabelSelectFirmware": {
         "message": "Choose a Firmware / Board"
     },

--- a/src/js/tabs/firmware_flasher.js
+++ b/src/js/tabs/firmware_flasher.js
@@ -3,6 +3,7 @@
 TABS.firmware_flasher = {
     releases: null,
     releaseChecker: new ReleaseChecker('firmware', 'https://api.github.com/repos/emuflight/EmuFlight/releases'),
+    masterChecker: new ReleaseChecker('master', 'https://api.github.com/repos/emuflight/dev-master/releases'),
     localFileLoaded: false,
 };
 
@@ -130,7 +131,7 @@ TABS.firmware_flasher.initialize = function (callback) {
             });
         }
 
-        function buildBoardOptions(releaseData, showDevReleases) {
+        function buildBoardOptions(releaseData, showDevReleases, skipVersionFilter) {
             if (!releaseData) {
                 $('select[name="board"]').empty().append('<option value="0">Offline</option>');
                 $('select[name="firmware_version"]').empty().append('<option value="0">Offline</option>');
@@ -149,7 +150,7 @@ TABS.firmware_flasher.initialize = function (callback) {
                         if ((!showDevReleases && release.prerelease) || !match) {
                             return;
                         }
-                        var target = match[2];
+                        var target = match[2].replace(/_Build_\d+_\w+$/i, '');
                         if($.inArray(target, unsortedTargets) == -1) {
                             unsortedTargets.push(target);
                         }
@@ -173,7 +174,7 @@ TABS.firmware_flasher.initialize = function (callback) {
                             return;
                         }
 
-                        var target = match[2];
+                        var target = match[2].replace(/_Build_\d+_\w+$/i, '');
                         var format = match[4];
 
                         if (format != 'hex') {
@@ -183,10 +184,11 @@ TABS.firmware_flasher.initialize = function (callback) {
                         var date = new Date(release.published_at);
                         var formattedDate = ("0" + date.getDate()).slice(-2) + "-" + ("0"+(date.getMonth()+1)).slice(-2) + "-" + date.getFullYear() + " " + ("0" + date.getHours()).slice(-2) + ":" + ("0" + date.getMinutes()).slice(-2);
 
+                        var displayVersion = (skipVersionFilter && match[1]) ? match[1] : version;
                         var descriptor = {
                             "releaseUrl": release.html_url,
-                            "name"      : version,
-                            "version"   : version,
+                            "name"      : displayVersion,
+                            "version"   : displayVersion,
                             "url"       : asset.browser_download_url,
                             "file"      : asset.name,
                             "target"    : target,
@@ -195,7 +197,7 @@ TABS.firmware_flasher.initialize = function (callback) {
                         };
 
                         // DO NOT LIST FIRMWARE >= 1.0.0
-                        if (version > '0.9.9') {
+                        if (!skipVersionFilter && version > '0.9.9') {
                             console.log("Firmware release is > 0.9.9: [" + version + "]. Do not list it.");
                             return; //exit loop
                         }
@@ -239,6 +241,10 @@ TABS.firmware_flasher.initialize = function (callback) {
             {
                 tag: 'firmwareFlasherOptionLabelBuildTypeReleaseCandidate',
                 loader: () => self.releaseChecker.loadReleaseData(releaseData => buildBoardOptions(releaseData, true))
+            },
+            {
+                tag: 'firmwareFlasherOptionLabelBuildTypePreReleaseMaster',
+                loader: () => self.masterChecker.loadReleaseData(releaseData => buildBoardOptions(releaseData, true, true))
             }
         ];
 
@@ -263,6 +269,7 @@ TABS.firmware_flasher.initialize = function (callback) {
             } else {
                 $('tr.build_type').hide();
                 $('tr.expert_mode').hide();
+                buildType_e.val(0).trigger('change');
             }
         }
 

--- a/src/js/tabs/firmware_flasher.js
+++ b/src/js/tabs/firmware_flasher.js
@@ -596,9 +596,11 @@ TABS.firmware_flasher.initialize = function (callback) {
             });
         });
 
-        chrome.storage.local.get('selected_build_type', function (result) {
-            // ensure default build type is selected
-            buildType_e.val(result.selected_build_type || 0).trigger('change');
+        chrome.storage.local.get(['selected_build_type', 'show_development_releases'], function (result) {
+            // ensure default build type is selected, but only restore non-zero index when unstable releases are enabled
+            var showUnstable = !!result.show_development_releases;
+            var selectedBuildType = showUnstable ? (result.selected_build_type || 0) : 0;
+            buildType_e.val(selectedBuildType).trigger('change');
         });
 
         chrome.storage.local.get('no_reboot_sequence', function (result) {


### PR DESCRIPTION
AI Generated pull-request

## Summary
Adds a third "Pre-Release Master" option to the Firmware Flasher build
type dropdown, sourcing .hex firmware from emuflight/dev-master releases.

- New `masterChecker` ReleaseChecker instance pointing to dev-master
- Pre-Release Master lists both releases and pre-releases equally
  (no distinction — all dev-master builds are treated as equivalent)
- Version display uses the firmware version embedded in the filename
  (e.g. `0.4.3`) rather than the date-based tag, matching Release format
- `_Build_XXXX_COMMITSHA` suffix stripped from target/board names
- Version gate (>0.9.9) bypassed for dev-master only; Release and RC
  behaviour unchanged
- Selecting "Show unstable releases" toggle OFF resets build type to
  official Release, preventing stale dev-master state in the UI

## Test plan
- [x] Lint passes
- [x] Pre-Release Master option appears in dropdown
- [x] Boards and firmware versions populate from dev-master repo
- [x] Release and Release Candidate sources unchanged
- [x] Toggling off "Show unstable releases" resets to Release

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Pre-Release Master" build type option for firmware selection in the firmware flasher.

* **Improvements**
  * Enhanced firmware target parsing and version filtering.
  * Build type dropdown now resets when hidden and only restores selection if development/unstable releases are enabled.

* **Localization**
  * Added English string for "Pre-Release Master".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->