### PR TITLE
feat/fix(workflow): dev releases and official artifact fix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -421,7 +421,7 @@ jobs:
           draft: true
           prerelease: true
           allowUpdates: true
-          overwrite: true
+          replacesArtifacts: true
           artifacts: ./Artifacts/**/*.msi, ./Artifacts/**/*.deb, ./Artifacts/**/*.rpm, ./Artifacts/**/*.zip
           artifactContentType: raw
           name:  "DEV-UNSTABLE EmuConfig / Build ${{ github.run_number }}"
@@ -453,7 +453,7 @@ jobs:
           draft: true
           prerelease: true
           allowUpdates: true
-          overwrite: true
+          replacesArtifacts: true
           artifacts: ./Artifacts/**/*.msi, ./Artifacts/**/*.deb, ./Artifacts/**/*.rpm, ./Artifacts/**/*.zip
           artifactContentType: raw
           name:  "DEV-MASTER EmuConfig / Build ${{ github.run_number }}"
@@ -481,7 +481,7 @@ jobs:
           draft: true
           prerelease: true
           allowUpdates: true
-          overwrite: true
+          replacesArtifacts: true
           tag: ${{ github.ref_name }}
           artifacts: ./Artifacts/**/*.msi, ./Artifacts/**/*.deb, ./Artifacts/**/*.rpm, ./Artifacts/**/*.zip
           artifactContentType: raw

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -417,19 +417,15 @@ jobs:
           repo: dev-unstable
           owner: emuflight
           token: ${{ secrets.NC_PAT_EMUF }}
-          tag: "${{ env.NOW }}-app"
+          tag: "${{ env.NOW }}-cfg"
           draft: true
           prerelease: true
           allowUpdates: true
-          artifacts: |
-            ./Artifacts/**/*.msi
-            ./Artifacts/**/*.zip
-            ./Artifacts/**/*.deb
-            ./Artifacts/**/*.rpm
+          artifacts: ./Artifacts/**/EmuConfigurator-*.*
           artifactContentType: raw
-          name:  "DEV-UNSTABLE APP / Build ${{ github.run_number }}"
+          name:  "DEV-UNSTABLE EmuConfig / Build ${{ github.run_number }}"
           body: |
-            ## APP BUILD for TESTING
+            ## EmuConfigurator BUILD for TESTING
             ### Build ${{ github.run_number }}
             ### Commit SHA: ${{ needs.build.outputs.shortsha }} (${{ github.sha }})
             ### BuildTag: ${{ needs.build.outputs.buildtag }}
@@ -452,23 +448,18 @@ jobs:
           repo: dev-master
           owner: emuflight
           token: ${{ secrets.NC_PAT_EMUF }}
-          tag: "${{ env.NOW }}-app"
+          tag: "${{ env.NOW }}-cfg"
           draft: true
           prerelease: true
           allowUpdates: true
-          artifacts: |
-            ./Artifacts/**/*.msi
-            ./Artifacts/**/*.zip
-            ./Artifacts/**/*.deb
-            ./Artifacts/**/*.rpm
+          artifacts: ./Artifacts/**/EmuConfigurator-*.*
           artifactContentType: raw
-          name:  "DEV-MASTER APP / Build ${{ github.run_number }}"
+          name:  "DEV-MASTER EmuConfig / Build ${{ github.run_number }}"
           body: |
-            ## APP BUILD of MASTER
+            ## EmuConfigurator BUILD of MASTER
             ### Build ${{ github.run_number }}
             ### Commit SHA: ${{ needs.build.outputs.shortsha }} (${{ github.sha }})
             ### BuildTag: ${{ needs.build.outputs.buildtag }}
-            ### EmuConfigurator base plus committed code
             ### Feedback Welcome in EmuFlight's Discord or GitHub Discussions.
             <details><summary>Changes in this Build:</summary>
             <!-- require single blank line below -->
@@ -479,24 +470,35 @@ jobs:
             </details>
         continue-on-error: true
 
-      - name: Upload Release Assets
-        if: startsWith(github.ref, 'refs/tags/v')
-        uses: softprops/action-gh-release@v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # Draft Releases on main Repo
+      - name: Draft Release Main Repo
+        if: contains(github.ref, 'releas')
+        uses: ncipollo/release-action@v1
         with:
-          tag_name: ${{ github.ref_name }}
-          name: "EmuConfigurator ${{ github.ref_name }}"
-          files: |
-            ./Artifacts/**/EmuConfigurator-*.msi
-            ./Artifacts/**/EmuConfigurator-*.zip
-            ./Artifacts/**/EmuConfigurator-*.deb
-            ./Artifacts/**/EmuConfigurator-*.rpm
+          token: ${{ secrets.GITHUB_TOKEN }}
           draft: true
-          prerelease: ${{ contains(github.ref, 'rc') }}
+          prerelease: true
+          allowUpdates: true
+          tag: ${{ github.ref_name }}
+          artifacts: ./Artifacts/**/EmuConfigurator-*.*
+          artifactContentType: raw
+          name:  "DRAFT / EmuConfigurator / GitHub Build ${{ github.run_number }}"
+          body: |
+            ## EmuConfigurator
+            ### Build ${{ github.run_number }}
+            ### Commit SHA: ${{ needs.build.outputs.shortsha }} (${{ github.sha }})
+            ### BuildTag: ${{ needs.build.outputs.buildtag }}
+            <details><summary>Changes in this Release:</summary>
+            <!-- require single blank line below -->
+
+            ```
+            [insert commit history here]
+            ```
+            </details>
+        continue-on-error: false
 
       - name: Release Failed Notification
-        if: failure() && startsWith(github.ref, 'refs/tags/v')
+        if: failure() && contains(github.ref, 'releas')
         run: |
           echo "[ERROR] Release upload failed for ${{ github.ref_name }}"
           exit 1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -331,7 +331,7 @@ jobs:
 
       # Upload Linux .deb
       - name: Upload Artifact (linux .deb)
-        if: matrix.os == 'ubuntu-24.04'
+        if: startsWith(matrix.os, 'ubuntu')
         uses: actions/upload-artifact@v4
         with:
           name: EmuConfigurator-linux-deb
@@ -340,7 +340,7 @@ jobs:
 
       # Upload Linux .rpm
       - name: Upload Artifact (linux .rpm)
-        if: matrix.os == 'ubuntu-24.04'
+        if: startsWith(matrix.os, 'ubuntu')
         uses: actions/upload-artifact@v4
         with:
           name: EmuConfigurator-linux-rpm
@@ -349,7 +349,7 @@ jobs:
 
       # Upload Linux .zip
       - name: Upload Artifact (linux .zip)
-        if: matrix.os == 'ubuntu-24.04'
+        if: startsWith(matrix.os, 'ubuntu')
         uses: actions/upload-artifact@v4
         with:
           name: EmuConfigurator-linux-zip
@@ -376,7 +376,7 @@ jobs:
 
       # Upload Windows .msi (WiX installer)
       - name: Upload Artifact (windows .msi)
-        if: matrix.os == 'windows-2025'
+        if: startsWith(matrix.os, 'windows')
         uses: actions/upload-artifact@v4
         with:
           name: EmuConfigurator-windows-msi-${{ matrix.arch }}
@@ -385,7 +385,7 @@ jobs:
 
       # Upload Windows .zip (portable)
       - name: Upload Artifact (windows .zip)
-        if: matrix.os == 'windows-2025'
+        if: startsWith(matrix.os, 'windows')
         uses: actions/upload-artifact@v4
         with:
           name: EmuConfigurator-windows-zip-${{ matrix.arch }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -409,12 +409,22 @@ jobs:
           find ./Artifacts -type f \( -name "*.msi" -o -name "*.deb" -o -name "*.rpm" -o -name "*.zip" \) -exec ls -lh {} \;
           echo "NOW=$(date +'%Y%m%d.%H%M%S')" >> $GITHUB_ENV
 
-      - name: Unzip Artifacts
+      - name: Extract and Flatten Artifacts
         run: |
-          echo "### Unzipping Artifacts ###"
+          echo "### Extracting and Flattening Artifacts ###"
+          mkdir -p ./Artifacts/unzipped
+          
+          # Extract root zip containers
           find ./Artifacts -maxdepth 1 -name "*.zip" -exec unzip -o {} -d ./Artifacts/unzipped/ \;
-          # Flatten the unzipped files (including any nested zips) to the main Artifacts directory
+          
+          # Remove the root container zips so they aren't part of the final release
+          find ./Artifacts -maxdepth 1 -name "*.zip" -exec rm {} \;
+          
+          # Flatten contents (installers and portable zips) back to the main Artifacts directory
           find ./Artifacts/unzipped -type f \( -name "*.msi" -o -name "*.deb" -o -name "*.rpm" -o -name "*.exe" -o -name "*.dmg" -o -name "*.zip" \) -exec mv {} ./Artifacts/ \;
+          
+          # Cleanup
+          rm -rf ./Artifacts/unzipped
 
       # Draft Dev-Unstable releases via ncipollo/release-action
       - name: Draft Release Dev-Unstable repo

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -476,7 +476,8 @@ jobs:
           draft: true
           prerelease: true
           allowUpdates: true
-          artifacts: ./Artifacts/**/EmuConfigurator-*.*
+          overwrite: true
+          artifacts: ./Artifacts/**/*.msi, ./Artifacts/**/*.deb, ./Artifacts/**/*.rpm, ./Artifacts/**/*.zip
           artifactContentType: raw
           name:  "DEV-UNSTABLE EmuConfig / Build ${{ github.run_number }}"
           body: |
@@ -507,7 +508,8 @@ jobs:
           draft: true
           prerelease: true
           allowUpdates: true
-          artifacts: ./Artifacts/**/EmuConfigurator-*.*
+          overwrite: true
+          artifacts: ./Artifacts/**/*.msi, ./Artifacts/**/*.deb, ./Artifacts/**/*.rpm, ./Artifacts/**/*.zip
           artifactContentType: raw
           name:  "DEV-MASTER EmuConfig / Build ${{ github.run_number }}"
           body: |
@@ -534,8 +536,9 @@ jobs:
           draft: true
           prerelease: true
           allowUpdates: true
+          overwrite: true
           tag: ${{ github.ref_name }}
-          artifacts: ./Artifacts/**/EmuConfigurator-*.*
+          artifacts: ./Artifacts/**/*.msi, ./Artifacts/**/*.deb, ./Artifacts/**/*.rpm, ./Artifacts/**/*.zip
           artifactContentType: raw
           name:  "DRAFT / EmuConfigurator / GitHub Build ${{ github.run_number }}"
           body: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -320,6 +320,18 @@ jobs:
             echo "[OK] Renamed $filename -> $(basename "$dest")"
           done
 
+      - name: Rename Windows x64 zip (win32 -> win64)
+        if: startsWith(matrix.os, 'windows') && matrix.arch == 'x64'
+        shell: bash
+        run: |
+          set -euo pipefail
+          for src in out/make/zip/EmuConfigurator-win32-x64-*.zip; do
+            [ -f "$src" ] || continue
+            dest="${src/win32/win64}"
+            mv -f "$src" "$dest"
+            echo "[OK] Renamed $(basename "$src") -> $(basename "$dest")"
+          done
+
       - name: Validate Artifacts Exist
         shell: bash
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -411,9 +411,19 @@ jobs:
 
       - name: Flatten Artifacts
         run: |
+          echo "### Listing Zip Contents ###"
+          find ./Artifacts -maxdepth 1 -name "*.zip" -exec unzip -l {} \;
+          
           echo "### Flattening Artifacts ###"
-          # Find all desired files in subdirectories and move them to the root Artifacts directory
-          find ./Artifacts -mindepth 2 -type f \( -name "*.msi" -o -name "*.deb" -o -name "*.rpm" -o -name "*.exe" -o -name "*.dmg" -o -name "*.zip" \) -exec mv -v {} ./Artifacts/ \;
+          mkdir -p ./Artifacts/unzipped
+          # Extract root zip containers
+          find ./Artifacts -maxdepth 1 -name "*.zip" -exec unzip -o {} -d ./Artifacts/unzipped/ \;
+          
+          # Remove the root container zips so they aren't part of the final release
+          find ./Artifacts -maxdepth 1 -name "*.zip" -exec rm -v {} \;
+          
+          # Flatten contents back to the main Artifacts directory
+          find ./Artifacts/unzipped -type f -exec mv -v {} ./Artifacts/ \;
           
           # Clean up empty subdirectories
           find ./Artifacts -mindepth 1 -type d -empty -delete

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -392,8 +392,41 @@ jobs:
           path: out/make/zip/*.zip
           retention-days: 20
 
-  release:
+  extract-artifacts:
     needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download All Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: ./Artifacts
+
+      - name: Extract Zipped Artifacts
+        run: |
+          echo "### Contents BEFORE Extraction ###"
+          ls -R ./Artifacts
+          
+          # Create a directory to hold extracted contents
+          mkdir -p ./Artifacts/extracted
+          
+          # Extract all zips found in Artifacts
+          find ./Artifacts -type f -name "*.zip" -exec unzip -o {} -d ./Artifacts/extracted/ \;
+          
+          # Move installers to the main Artifacts dir (they should have been there, but this ensures it)
+          find ./Artifacts/extracted -type f \( -name "*.msi" -o -name "*.deb" -o -name "*.rpm" -o -name "*.exe" -o -name "*.dmg" \) -exec mv -v {} ./Artifacts/ \;
+          
+          echo "### Contents AFTER Extraction ###"
+          ls -R ./Artifacts
+
+      - name: Upload Extracted Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: EmuConfigurator-Extracted
+          path: ./Artifacts/
+          retention-days: 20
+
+  release:
+    needs: extract-artifacts
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -298,7 +298,7 @@ jobs:
           done
 
       - name: Rename Windows MSI artifacts
-        if: matrix.os == 'windows-latest'
+        if: startsWith(matrix.os, 'windows')
         shell: bash
         env:
           EMUCFG_ARCH: ${{ matrix.arch }}
@@ -392,41 +392,8 @@ jobs:
           path: out/make/zip/*.zip
           retention-days: 20
 
-  extract-artifacts:
-    needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - name: Download All Artifacts
-        uses: actions/download-artifact@v4
-        with:
-          path: ./Artifacts
-
-      - name: Extract Zipped Artifacts
-        run: |
-          echo "### Contents BEFORE Extraction ###"
-          ls -R ./Artifacts
-          
-          # Create a directory to hold extracted contents
-          mkdir -p ./Artifacts/extracted
-          
-          # Extract all zips found in Artifacts
-          find ./Artifacts -type f -name "*.zip" -exec unzip -o {} -d ./Artifacts/extracted/ \;
-          
-          # Move installers to the main Artifacts dir (they should have been there, but this ensures it)
-          find ./Artifacts/extracted -type f \( -name "*.msi" -o -name "*.deb" -o -name "*.rpm" -o -name "*.exe" -o -name "*.dmg" \) -exec mv -v {} ./Artifacts/ \;
-          
-          echo "### Contents AFTER Extraction ###"
-          ls -R ./Artifacts
-
-      - name: Upload Extracted Artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: EmuConfigurator-Extracted
-          path: ./Artifacts/
-          retention-days: 20
-
   release:
-    needs: extract-artifacts
+    needs: build
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
     steps:
@@ -441,28 +408,6 @@ jobs:
           echo "### Release Artifacts ###"
           find ./Artifacts -type f \( -name "*.msi" -o -name "*.deb" -o -name "*.rpm" -o -name "*.zip" \) -exec ls -lh {} \;
           echo "NOW=$(date +'%Y%m%d.%H%M%S')" >> $GITHUB_ENV
-
-      - name: Flatten Artifacts
-        run: |
-          echo "### Listing Zip Contents ###"
-          find ./Artifacts -maxdepth 1 -name "*.zip" -exec unzip -l {} \;
-          
-          echo "### Flattening Artifacts ###"
-          mkdir -p ./Artifacts/unzipped
-          # Extract root zip containers
-          find ./Artifacts -maxdepth 1 -name "*.zip" -exec unzip -o {} -d ./Artifacts/unzipped/ \;
-          
-          # Remove the root container zips so they aren't part of the final release
-          find ./Artifacts -maxdepth 1 -name "*.zip" -exec rm -v {} \;
-          
-          # Flatten contents back to the main Artifacts directory
-          find ./Artifacts/unzipped -type f -exec mv -v {} ./Artifacts/ \;
-          
-          # Clean up empty subdirectories
-          find ./Artifacts -mindepth 1 -type d -empty -delete
-          
-          echo "### Contents of Artifacts after Flattening ###"
-          ls -R ./Artifacts
 
       # Draft Dev-Unstable releases via ncipollo/release-action
       - name: Draft Release Dev-Unstable repo

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -331,7 +331,7 @@ jobs:
 
       # Upload Linux .deb
       - name: Upload Artifact (linux .deb)
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-24.04'
         uses: actions/upload-artifact@v4
         with:
           name: EmuConfigurator-linux-deb
@@ -340,7 +340,7 @@ jobs:
 
       # Upload Linux .rpm
       - name: Upload Artifact (linux .rpm)
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-24.04'
         uses: actions/upload-artifact@v4
         with:
           name: EmuConfigurator-linux-rpm
@@ -349,7 +349,7 @@ jobs:
 
       # Upload Linux .zip
       - name: Upload Artifact (linux .zip)
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-24.04'
         uses: actions/upload-artifact@v4
         with:
           name: EmuConfigurator-linux-zip
@@ -358,7 +358,7 @@ jobs:
 
       # Upload macOS ARM64 .zip (contains EmuConfigurator-arm64.app at root)
       - name: Upload Artifact (macos arm64 .app)
-        if: matrix.os == 'macos-latest'
+        if: matrix.os == 'macos-26'
         uses: actions/upload-artifact@v4
         with:
           name: EmuConfigurator-macos-arm64
@@ -376,7 +376,7 @@ jobs:
 
       # Upload Windows .msi (WiX installer)
       - name: Upload Artifact (windows .msi)
-        if: matrix.os == 'windows-latest'
+        if: matrix.os == 'windows-2025'
         uses: actions/upload-artifact@v4
         with:
           name: EmuConfigurator-windows-msi-${{ matrix.arch }}
@@ -385,7 +385,7 @@ jobs:
 
       # Upload Windows .zip (portable)
       - name: Upload Artifact (windows .zip)
-        if: matrix.os == 'windows-latest'
+        if: matrix.os == 'windows-2025'
         uses: actions/upload-artifact@v4
         with:
           name: EmuConfigurator-windows-zip-${{ matrix.arch }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -412,9 +412,9 @@ jobs:
       - name: Unzip Artifacts
         run: |
           echo "### Unzipping Artifacts ###"
-          find ./Artifacts -name "*.zip" -exec unzip -o {} -d ./Artifacts/unzipped/ \;
-          # Flatten the unzipped files to the main Artifacts directory
-          find ./Artifacts/unzipped -type f \( -name "*.msi" -o -name "*.deb" -o -name "*.rpm" -o -name "*.exe" -o -name "*.dmg" \) -exec mv {} ./Artifacts/ \;
+          find ./Artifacts -maxdepth 1 -name "*.zip" -exec unzip -o {} -d ./Artifacts/unzipped/ \;
+          # Flatten the unzipped files (including any nested zips) to the main Artifacts directory
+          find ./Artifacts/unzipped -type f \( -name "*.msi" -o -name "*.deb" -o -name "*.rpm" -o -name "*.exe" -o -name "*.dmg" -o -name "*.zip" \) -exec mv {} ./Artifacts/ \;
 
       # Draft Dev-Unstable releases via ncipollo/release-action
       - name: Draft Release Dev-Unstable repo

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -395,7 +395,7 @@ jobs:
   release:
     needs: build
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: startsWith(github.ref, 'refs/tags/')
     steps:
       - name: Download All Artifacts
         uses: actions/download-artifact@v4
@@ -407,8 +407,80 @@ jobs:
         run: |
           echo "### Release Artifacts ###"
           find ./Artifacts -type f \( -name "*.msi" -o -name "*.deb" -o -name "*.rpm" -o -name "*.zip" \) -exec ls -lh {} \;
+          echo "NOW=$(date +'%Y%m%d.%H%M%S')" >> $GITHUB_ENV
+
+      # Draft Dev-Unstable releases via ncipollo/release-action
+      - name: Draft Release Dev-Unstable repo
+        if: contains(github.ref, 'test') || contains(github.ref, 'unstab')
+        uses: ncipollo/release-action@v1
+        with:
+          repo: dev-unstable
+          owner: emuflight
+          token: ${{ secrets.NC_PAT_EMUF }}
+          tag: "${{ env.NOW }}-app"
+          draft: true
+          prerelease: true
+          allowUpdates: true
+          artifacts: |
+            ./Artifacts/**/*.msi
+            ./Artifacts/**/*.zip
+            ./Artifacts/**/*.deb
+            ./Artifacts/**/*.rpm
+          artifactContentType: raw
+          name:  "DEV-UNSTABLE APP / Build ${{ github.run_number }}"
+          body: |
+            ## APP BUILD for TESTING
+            ### Build ${{ github.run_number }}
+            ### Commit SHA: ${{ needs.build.outputs.shortsha }} (${{ github.sha }})
+            ### BuildTag: ${{ needs.build.outputs.buildtag }}
+            ### EmuConfigurator base plus test code
+            ### What to Test/Feedback: (Feedback in EmuFlight's Discord or GitHub Discussions)
+            <details><summary>Changes in this Build:</summary>
+            <!-- require single blank line below -->
+
+            ```
+            [insert commit history here]
+            ```
+            </details>
+        continue-on-error: true
+
+      # Draft Dev-master releases via ncipollo/release-action
+      - name: Draft Release Dev-Master repo
+        if: contains(github.ref, 'master')
+        uses: ncipollo/release-action@v1
+        with:
+          repo: dev-master
+          owner: emuflight
+          token: ${{ secrets.NC_PAT_EMUF }}
+          tag: "${{ env.NOW }}-app"
+          draft: true
+          prerelease: true
+          allowUpdates: true
+          artifacts: |
+            ./Artifacts/**/*.msi
+            ./Artifacts/**/*.zip
+            ./Artifacts/**/*.deb
+            ./Artifacts/**/*.rpm
+          artifactContentType: raw
+          name:  "DEV-MASTER APP / Build ${{ github.run_number }}"
+          body: |
+            ## APP BUILD of MASTER
+            ### Build ${{ github.run_number }}
+            ### Commit SHA: ${{ needs.build.outputs.shortsha }} (${{ github.sha }})
+            ### BuildTag: ${{ needs.build.outputs.buildtag }}
+            ### EmuConfigurator base plus committed code
+            ### Feedback Welcome in EmuFlight's Discord or GitHub Discussions.
+            <details><summary>Changes in this Build:</summary>
+            <!-- require single blank line below -->
+
+            ```
+            [insert commit history here]
+            ```
+            </details>
+        continue-on-error: true
 
       - name: Upload Release Assets
+        if: startsWith(github.ref, 'refs/tags/v')
         uses: softprops/action-gh-release@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -424,7 +496,7 @@ jobs:
           prerelease: ${{ contains(github.ref, 'rc') }}
 
       - name: Release Failed Notification
-        if: failure()
+        if: failure() && startsWith(github.ref, 'refs/tags/v')
         run: |
           echo "[ERROR] Release upload failed for ${{ github.ref_name }}"
           exit 1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -411,17 +411,27 @@ jobs:
 
       - name: Extract and Flatten Artifacts
         run: |
-          echo "### Extracting and Flattening Artifacts ###"
+          echo "### Contents BEFORE Extraction ###"
+          ls -R ./Artifacts
+          
           mkdir -p ./Artifacts/unzipped
           
           # Extract root zip containers
           find ./Artifacts -maxdepth 1 -name "*.zip" -exec unzip -o {} -d ./Artifacts/unzipped/ \;
           
+          echo "### Contents AFTER Extraction ###"
+          ls -R ./Artifacts
+          
           # Remove the root container zips so they aren't part of the final release
-          find ./Artifacts -maxdepth 1 -name "*.zip" -exec rm {} \;
+          echo "### Removing Root Container Zips ###"
+          find ./Artifacts -maxdepth 1 -name "*.zip" -exec rm -v {} \;
           
           # Flatten contents (installers and portable zips) back to the main Artifacts directory
-          find ./Artifacts/unzipped -type f \( -name "*.msi" -o -name "*.deb" -o -name "*.rpm" -o -name "*.exe" -o -name "*.dmg" -o -name "*.zip" \) -exec mv {} ./Artifacts/ \;
+          echo "### Flattening Contents ###"
+          find ./Artifacts/unzipped -type f \( -name "*.msi" -o -name "*.deb" -o -name "*.rpm" -o -name "*.exe" -o -name "*.dmg" -o -name "*.zip" \) -exec mv -v {} ./Artifacts/ \;
+          
+          echo "### Contents AFTER Flattening ###"
+          ls -R ./Artifacts
           
           # Cleanup
           rm -rf ./Artifacts/unzipped

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -409,32 +409,17 @@ jobs:
           find ./Artifacts -type f \( -name "*.msi" -o -name "*.deb" -o -name "*.rpm" -o -name "*.zip" \) -exec ls -lh {} \;
           echo "NOW=$(date +'%Y%m%d.%H%M%S')" >> $GITHUB_ENV
 
-      - name: Extract and Flatten Artifacts
+      - name: Flatten Artifacts
         run: |
-          echo "### Contents BEFORE Extraction ###"
+          echo "### Flattening Artifacts ###"
+          # Find all desired files in subdirectories and move them to the root Artifacts directory
+          find ./Artifacts -mindepth 2 -type f \( -name "*.msi" -o -name "*.deb" -o -name "*.rpm" -o -name "*.exe" -o -name "*.dmg" -o -name "*.zip" \) -exec mv -v {} ./Artifacts/ \;
+          
+          # Clean up empty subdirectories
+          find ./Artifacts -mindepth 1 -type d -empty -delete
+          
+          echo "### Contents of Artifacts after Flattening ###"
           ls -R ./Artifacts
-          
-          mkdir -p ./Artifacts/unzipped
-          
-          # Extract root zip containers
-          find ./Artifacts -maxdepth 1 -name "*.zip" -exec unzip -o {} -d ./Artifacts/unzipped/ \;
-          
-          echo "### Contents AFTER Extraction ###"
-          ls -R ./Artifacts
-          
-          # Remove the root container zips so they aren't part of the final release
-          echo "### Removing Root Container Zips ###"
-          find ./Artifacts -maxdepth 1 -name "*.zip" -exec rm -v {} \;
-          
-          # Flatten contents (installers and portable zips) back to the main Artifacts directory
-          echo "### Flattening Contents ###"
-          find ./Artifacts/unzipped -type f \( -name "*.msi" -o -name "*.deb" -o -name "*.rpm" -o -name "*.exe" -o -name "*.dmg" -o -name "*.zip" \) -exec mv -v {} ./Artifacts/ \;
-          
-          echo "### Contents AFTER Flattening ###"
-          ls -R ./Artifacts
-          
-          # Cleanup
-          rm -rf ./Artifacts/unzipped
 
       # Draft Dev-Unstable releases via ncipollo/release-action
       - name: Draft Release Dev-Unstable repo

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -409,6 +409,13 @@ jobs:
           find ./Artifacts -type f \( -name "*.msi" -o -name "*.deb" -o -name "*.rpm" -o -name "*.zip" \) -exec ls -lh {} \;
           echo "NOW=$(date +'%Y%m%d.%H%M%S')" >> $GITHUB_ENV
 
+      - name: Unzip Artifacts
+        run: |
+          echo "### Unzipping Artifacts ###"
+          find ./Artifacts -name "*.zip" -exec unzip -o {} -d ./Artifacts/unzipped/ \;
+          # Flatten the unzipped files to the main Artifacts directory
+          find ./Artifacts/unzipped -type f \( -name "*.msi" -o -name "*.deb" -o -name "*.rpm" -o -name "*.exe" -o -name "*.dmg" \) -exec mv {} ./Artifacts/ \;
+
       # Draft Dev-Unstable releases via ncipollo/release-action
       - name: Draft Release Dev-Unstable repo
         if: contains(github.ref, 'test') || contains(github.ref, 'unstab')


### PR DESCRIPTION
AI Generated pull-request

## Summary

- **Fix step gates**: all `*-latest` OS conditions replaced with `startsWith()` / pinned values so upload and rename steps actually execute against the pinned matrix runners (`ubuntu-24.04`, `macos-26`, `windows-2025`).
- **Fix MSI filename collision**: the Windows MSI rename step was gated on `matrix.os == 'windows-latest'` (never matched), causing both x64 and ia32 MSIs to keep identical WiX-default filenames and overwrite each other in the release. Now uses `startsWith(matrix.os, 'windows')`.
- **Fix x64 portable zip name**: renames `EmuConfigurator-win32-x64-*.zip` → `EmuConfigurator-win64-x64-*.zip`; ia32 portable zip retains `win32` (accurate).
- **Expand release job**: trigger widened from `v`-prefixed tags only to any tag. Replaced `softprops/action-gh-release@v2` with `ncipollo/release-action@v1`. Added conditional draft releases to `dev-unstable` and `dev-master` repos with timestamped tags. Replaced deprecated `overwrite` input with `replacesArtifacts`. Scoped failure notification to `releas`-prefixed tags only.

## Result

9 correctly named, unique release assets per run:
`EmuConfigurator-x64-*.msi`, `EmuConfigurator-ia32-*.msi`, `EmuConfigurator-win64-x64-*.zip`, `EmuConfigurator-win32-ia32-*.zip`, `EmuConfigurator-darwin-arm64-*.zip`, `EmuConfigurator-darwin-x86_64-*.zip`, `EmuConfigurator-linux-x64-*.zip`, `*.deb`, `*.rpm`