### PR TITLE
feat(main): keep flash/erase running when window loses focus

### DIFF
--- a/main.js
+++ b/main.js
@@ -1021,6 +1021,7 @@ function createWindow() {
       nodeIntegration: true,
       contextIsolation: false,
       preload: path.join(__dirname, 'dist', 'support', 'preload.js'),
+      backgroundThrottling: false, // keep flash/erase timers running at full rate when window is unfocused
     },
     icon: windowIconPath,
   });


### PR DESCRIPTION
AI Generated pull-request

## Summary

- Electron/Chromium throttles `setTimeout` and `setInterval` to ~1 Hz when the `BrowserWindow` loses OS focus
- Flash, erase, and blackbox-download operations in `stm32usbdfu.js` are driven entirely by these timers, so they effectively paused when the user switched to another application
- Fix: add `backgroundThrottling: false` to `webPreferences` in `createWindow()` — the official Electron API knob for this exact use case
- One line change in `main.js`; no renderer changes required

## Test plan

- [x] `yarn lint` — 0 errors
- [x] Flash a FC, switch focus to another app mid-flash — operation continues uninterrupted
- [x] Erase flash / erase blackbox — continues in background
- [ ] Hardware verified on Linux (DFU mode)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved background stability and performance: Background timers and processes no longer slow down when the application window is unfocused. Previously, background operations were automatically throttled during periods of window inactivity, which could cause unexpected delays and performance issues. Now background tasks execute at normal speeds consistently, enhancing overall application reliability and user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->