### PR TITLE
fix(firmware_flasher): sort versions newest-first, ISO date format

### DIFF
--- a/src/js/tabs/firmware_flasher.js
+++ b/src/js/tabs/firmware_flasher.js
@@ -182,18 +182,19 @@ TABS.firmware_flasher.initialize = function (callback) {
                         }
 
                         var date = new Date(release.published_at);
-                        var formattedDate = ("0" + date.getDate()).slice(-2) + "-" + ("0"+(date.getMonth()+1)).slice(-2) + "-" + date.getFullYear() + " " + ("0" + date.getHours()).slice(-2) + ":" + ("0" + date.getMinutes()).slice(-2);
+                        var formattedDate = date.getFullYear() + "-" + ("0"+(date.getMonth()+1)).slice(-2) + "-" + ("0" + date.getDate()).slice(-2) + " " + ("0" + date.getHours()).slice(-2) + ":" + ("0" + date.getMinutes()).slice(-2);
 
                         var displayVersion = (skipVersionFilter && match[1]) ? match[1] : version;
                         var descriptor = {
-                            "releaseUrl": release.html_url,
-                            "name"      : displayVersion,
-                            "version"   : displayVersion,
-                            "url"       : asset.browser_download_url,
-                            "file"      : asset.name,
-                            "target"    : target,
-                            "date"      : formattedDate,
-                            "notes"     : release.body
+                            "releaseUrl"  : release.html_url,
+                            "name"        : displayVersion,
+                            "version"     : displayVersion,
+                            "url"         : asset.browser_download_url,
+                            "file"        : asset.name,
+                            "target"      : target,
+                            "date"        : formattedDate,
+                            "published_at": release.published_at,
+                            "notes"       : release.body
                         };
 
                         // DO NOT LIST FIRMWARE >= 1.0.0
@@ -335,7 +336,9 @@ TABS.firmware_flasher.initialize = function (callback) {
                 } else {
                     versions_e.append($("<option value='0'>{0} {1}</option>".format(i18n.getMessage('firmwareFlasherOptionLabelSelectFirmwareVersionFor'), target)));
 
-                    TABS.firmware_flasher.releases[target].forEach(function(descriptor) {
+                    TABS.firmware_flasher.releases[target].slice().sort(function(a, b) {
+                        return new Date(b.published_at) - new Date(a.published_at);
+                    }).forEach(function(descriptor) {
                         var select_e =
                                 $("<option value='{0}'>{0} - {1} - {2}</option>".format(
                                         descriptor.version,

--- a/src/js/tabs/firmware_flasher.js
+++ b/src/js/tabs/firmware_flasher.js
@@ -182,7 +182,7 @@ TABS.firmware_flasher.initialize = function (callback) {
                         }
 
                         var date = new Date(release.published_at);
-                        var formattedDate = date.getFullYear() + "-" + ("0"+(date.getMonth()+1)).slice(-2) + "-" + ("0" + date.getDate()).slice(-2) + " " + ("0" + date.getHours()).slice(-2) + ":" + ("0" + date.getMinutes()).slice(-2);
+                        var formattedDate = date.getUTCFullYear() + "-" + ("0"+(date.getUTCMonth()+1)).slice(-2) + "-" + ("0" + date.getUTCDate()).slice(-2) + " " + ("0" + date.getUTCHours()).slice(-2) + ":" + ("0" + date.getUTCMinutes()).slice(-2);
 
                         var displayVersion = (skipVersionFilter && match[1]) ? match[1] : version;
                         var descriptor = {


### PR DESCRIPTION
AI Generated pull-request

## Summary
- Add `published_at` (ISO 8601) to each release descriptor as a stable sort key, independent of GitHub API response order
- Sort firmware version dropdown by `published_at` descending when a board is selected — latest build always listed first; prior code relied on undocumented API response order which could produce oldest-first under cache or pagination edge cases
- Change date display format from `DD-MM-YYYY HH:MM` to `YYYY-MM-DD HH:MM`; `formattedDate` is computed fresh from `published_at` on every release data load (1-hour cache TTL), so all displayed dates update automatically — `FirmwareCache` is unaffected (keyed on `release.file`)

## Test plan
- [ ] Build passes
- [ ] Firmware Flasher: select each build type (Release, RC, Pre-Release Master); confirm version dropdown lists newest build at top
- [ ] Confirm date column shows `YYYY-MM-DD HH:MM` format for all build types
- [ ] Hardware verified: n/a (UI/display change only)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Firmware version list now displays newest releases first for better navigation
  * Standardized date formatting for firmware versions to YYYY-MM-DD HH:MM format

<!-- end of auto-generated comment: release notes by coderabbit.ai -->