### PR TITLE
fix(forge): skip exe-icon-extractor rebuild on all platforms

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,10 +31,10 @@ jobs:
             artifact-suffix: macos-arm64
           - os: macos-26-intel
             artifact-suffix: macos-x86_64
-          - os: windows-2025
+          - os: windows-2022
             artifact-suffix: windows-x64
             arch: x64
-          - os: windows-2025
+          - os: windows-2022
             artifact-suffix: windows-ia32
             arch: ia32
     outputs:

--- a/forge.config.js
+++ b/forge.config.js
@@ -66,10 +66,12 @@ module.exports = {
     // glibc symbol not exported on Debian glibc 2.34+. Skip the rebuild so node-gyp-build
     // falls through to the clean prebuilt at runtime. usb is NAPI so no ABI concern.
     //
-    // exe-icon-extractor is a Windows-only native module pulled in by maker-wix.
-    // Rebuilding it on Linux/macOS fails node-gyp; skip it on non-Windows.
+    // exe-icon-extractor is an optionalDependency of electron-wix-msi (maker-wix).
+    // Rebuilding it fails on Linux/macOS (node-gyp) and on Windows with the
+    // windows-2025 runner (MSVC C2664: string literals passed as char* rejected).
+    // It provides icon extraction only; maker-wix degrades gracefully without it.
     ignoreModules: [
-      ...(process.platform !== 'win32' ? ['@bitdisaster/exe-icon-extractor'] : []),
+      '@bitdisaster/exe-icon-extractor',
       ...(process.platform === 'linux' ? ['usb'] : []),
     ],
   },

--- a/forge.config.js
+++ b/forge.config.js
@@ -70,6 +70,8 @@ module.exports = {
     // Rebuilding it fails on Linux/macOS (node-gyp) and on Windows with the
     // windows-2025 runner (MSVC C2664: string literals passed as char* rejected).
     // It provides icon extraction only; maker-wix degrades gracefully without it.
+    // Versions 1.0.9 and 1.0.10 both fail; no upstream fix yet.
+    // Track: https://github.com/bitdisaster/exe-icon-extractor
     ignoreModules: [
       '@bitdisaster/exe-icon-extractor',
       ...(process.platform === 'linux' ? ['usb'] : []),


### PR DESCRIPTION
AI Generated pull-request

## Summary

Two separate issues both caused by the \`windows-2025\` runner image being updated ~2026-06-16 to install Visual Studio 2025 (version 18) where VS 2022 (version 17) was previously installed:

**Fix 1 — \`forge.config.js\`: skip \`@bitdisaster/exe-icon-extractor\` rebuild unconditionally**
- Already excluded on Linux/macOS; extended to all platforms.
- On updated \`windows-2025\`, its source fails MSVC C2664 (string literals as \`char*\`). No upstream fix — versions 1.0.9 and 1.0.10 both fail.
- Safe to skip everywhere: \`forge.config.js\` always provides an explicit \`icon:\` path so icon-extraction is never invoked.
- Track upstream: https://github.com/bitdisaster/exe-icon-extractor

**Fix 2 — \`build.yml\`: use \`windows-2022\` runner instead of \`windows-2025\`**
- Updated \`windows-2025\` image replaced VS 2022 (v17) with VS 2025 (v18). No published version of \`node-gyp\` or \`@electron/node-gyp\` maps major version 18 to a year, causing VS detection to fail with \`ERR_CHILD_PROCESS_STDIO_MAXBUFFER\` — breaking \`@serialport/bindings-cpp\` rebuild during \`electron-forge make\`.
- \`windows-2022\` provides VS 2022 (v17) which all existing node-gyp versions recognize.
- Long-term fix (tracked separately): upgrade to \`@electron-forge@8\` + \`node-gyp@12\` which will gain VS 2025 support upstream, then revert runner to \`windows-2025\`.

## Test plan
- [ ] Windows CI passes (\`build (windows-2022, windows-x64, x64)\` and \`ia32\`)
- [ ] Linux and macOS builds unaffected
- [ ] MSI and ZIP artifacts produced