### PR TITLE
fix(cli): suppress MSP garbage before CLI welcome message

### DIFF
--- a/src/js/tabs/cli.js
+++ b/src/js/tabs/cli.js
@@ -404,9 +404,8 @@ TABS.cli.read = function (readInfo) {
         const currentChar = String.fromCharCode(data[i]);
 
         if (!CONFIGURATOR.cliValid) {
-            // try to catch part of valid CLI enter message
+            // Accumulate silently; MSP garbage before welcome message is not shown
             validateText += currentChar;
-            writeToOutput(currentChar);
             continue;
         }
 
@@ -466,6 +465,19 @@ TABS.cli.read = function (readInfo) {
     if (!CONFIGURATOR.cliValid && validateText.indexOf('CLI') !== -1) {
         GUI.log(i18n.getMessage('cliEnter'));
         CONFIGURATOR.cliValid = true;
+        // Display only from 'Entering CLI Mode' onwards; MSP garbage before it is discarded
+        const cliMsgStart = validateText.indexOf('Entering CLI');
+        if (cliMsgStart >= 0) {
+            const welcomeText = validateText.substring(cliMsgStart);
+            const lines = welcomeText.split(/\r?\n|\r/);
+            for (let j = 0; j < lines.length; j++) {
+                if (j < lines.length - 1) {
+                    writeLineToOutput(lines[j]);
+                } else if (lines[j].length > 0) {
+                    writeToOutput(lines[j]); // prompt line — no trailing <br>
+                }
+            }
+        }
         // begin output history with the prompt (last line of welcome message)
         // this is to match the content of the history with what the user sees on this tab
         const lastLine = validateText.split("\n").pop();


### PR DESCRIPTION
AI Generated pull-request

## Summary

- Before this fix, every byte received while `CONFIGURATOR.cliValid` was `false` was written directly to the CLI output display via `writeToOutput(currentChar)`. Buffered MSP response frames (e.g. repeated `MSP_BOXNAMES` polls from a previous tab) appeared as binary garbage characters before \"Entering CLI Mode\" on every CLI tab open.
- Fix: accumulate bytes silently until `'CLI'` is found in the welcome message, then display only from `'Entering CLI Mode'` onwards. MSP frames queued before the welcome message are discarded from the display without affecting serial communication or protocol state.
- The garbage became more visible recently as more firmware features were enabled (more/larger MSP responses buffered during initial connection), surfacing this latent display bug.
- Possible side-effect: may also stabilise the autocomplete cache build, which begins immediately after `cliValid` transitions to `true`.

## Test plan

- [x] Open CLI tab — no MSP binary garbage appears before \"Entering CLI Mode, type 'exit' to return, or 'help'\"
- [x] Welcome message and `#` prompt display correctly
- [x] Autocomplete builds normally after connection
- [x] `exit` and reconnect cycle works correctly
- [x] Hardware verified: HELIOSPRING (F405)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced CLI initialization to filter extraneous startup text and properly display the welcome message and command prompt.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->