### PR TITLE
fix(linux): nativeImage for window icon; hicolor theme for panel/launcher icon

### DIFF
--- a/forge.config.js
+++ b/forge.config.js
@@ -101,6 +101,13 @@ module.exports = {
           maintainer: 'EmuFlight',
           homepage: 'https://github.com/EmuFlight/EmuConfigurator',
           icon: LINUX_ICON,
+          // Debian lifecycle scripts: install/remove the icon from the hicolor XDG
+          // icon theme so desktop environments resolve Icon=emuflight-configurator
+          // by name (XFCE panel, GNOME, KDE). /usr/share/pixmaps is legacy only.
+          scripts: {
+            postinst: path.resolve(__dirname, 'scripts/deb-postinst.sh'),
+            prerm: path.resolve(__dirname, 'scripts/deb-prerm.sh'),
+          },
         },
       },
     },

--- a/main.js
+++ b/main.js
@@ -75,7 +75,10 @@ function getWindowIconPath() {
       // and packaged (.deb) modes.
       if (process.platform === 'linux') {
         const img = nativeImage.createFromPath(iconPath);
-        return img.isEmpty() ? undefined : img;
+        if (!img.isEmpty()) {
+          return img;
+        }
+        continue;
       }
       return iconPath;
     }

--- a/main.js
+++ b/main.js
@@ -1,4 +1,4 @@
-const { app, BrowserWindow, ipcMain, Menu, screen, shell, globalShortcut } = require('electron');
+const { app, BrowserWindow, ipcMain, Menu, nativeImage, screen, shell, globalShortcut } = require('electron');
 const path = require('path');
 const fs = require('fs');
 
@@ -68,6 +68,15 @@ function getWindowIconPath() {
   const candidates = iconCandidatesByPlatform[process.platform] || [];
   for (const iconPath of candidates) {
     if (fs.existsSync(iconPath)) {
+      // On Linux, BrowserWindow's icon option requires a real filesystem path;
+      // it cannot read from inside an asar archive. nativeImage.createFromPath()
+      // reads the PNG data into memory within Electron's process (asar-aware),
+      // so passing the nativeImage object to BrowserWindow works in both dev
+      // and packaged (.deb) modes.
+      if (process.platform === 'linux') {
+        const img = nativeImage.createFromPath(iconPath);
+        return img.isEmpty() ? undefined : img;
+      }
       return iconPath;
     }
   }

--- a/scripts/deb-postinst.sh
+++ b/scripts/deb-postinst.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -e
+
+# Install icon into the hicolor XDG icon theme so desktop environments
+# (XFCE, GNOME, KDE, etc.) resolve Icon=emuflight-configurator by name.
+# /usr/share/pixmaps is legacy; hicolor is the authoritative lookup path.
+install -Dm644 /usr/share/pixmaps/emuflight-configurator.png \
+    /usr/share/icons/hicolor/128x128/apps/emuflight-configurator.png
+
+if command -v gtk-update-icon-cache >/dev/null 2>&1; then
+    gtk-update-icon-cache -f -t /usr/share/icons/hicolor || true
+fi

--- a/scripts/deb-postinst.sh
+++ b/scripts/deb-postinst.sh
@@ -4,8 +4,9 @@ set -e
 # Install icon into the hicolor XDG icon theme so desktop environments
 # (XFCE, GNOME, KDE, etc.) resolve Icon=emuflight-configurator by name.
 # /usr/share/pixmaps is legacy; hicolor is the authoritative lookup path.
+# Non-fatal: icon is cosmetic; a failure must not break dpkg installation.
 install -Dm644 /usr/share/pixmaps/emuflight-configurator.png \
-    /usr/share/icons/hicolor/128x128/apps/emuflight-configurator.png
+    /usr/share/icons/hicolor/128x128/apps/emuflight-configurator.png || true
 
 if command -v gtk-update-icon-cache >/dev/null 2>&1; then
     gtk-update-icon-cache -f -t /usr/share/icons/hicolor || true

--- a/scripts/deb-prerm.sh
+++ b/scripts/deb-prerm.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
 set -e
 
-rm -f /usr/share/icons/hicolor/128x128/apps/emuflight-configurator.png
+# Non-fatal: icon removal is cosmetic; a failure must not break dpkg uninstall.
+rm -f /usr/share/icons/hicolor/128x128/apps/emuflight-configurator.png || true
 
 if command -v gtk-update-icon-cache >/dev/null 2>&1; then
     gtk-update-icon-cache -f -t /usr/share/icons/hicolor || true

--- a/scripts/deb-prerm.sh
+++ b/scripts/deb-prerm.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+rm -f /usr/share/icons/hicolor/128x128/apps/emuflight-configurator.png
+
+if command -v gtk-update-icon-cache >/dev/null 2>&1; then
+    gtk-update-icon-cache -f -t /usr/share/icons/hicolor || true
+fi


### PR DESCRIPTION
AI Generated pull-request

## Summary

- **`main.js`** — use `nativeImage.createFromPath()` on Linux for `BrowserWindow({ icon })`. Passing a raw path string silently fails when the app is asar-packaged: `fs.existsSync` returns `true` for virtual asar paths (Electron patches `fs`), but the OS window manager receives the path string directly and cannot read inside the archive. `nativeImage` reads the PNG into memory within Electron's asar-aware process and passes the decoded image object instead.
- **`forge.config.js` + `scripts/`** — add Debian `postinst`/`prerm` scripts that install/remove the icon in `/usr/share/icons/hicolor/128x128/apps/`. `maker-deb` installs only to `/usr/share/pixmaps/` (legacy GTK fallback); XDG desktop environments (XFCE, GNOME, KDE) resolve `Icon=emuflight-configurator` via the hicolor theme, so the panel launcher icon was blank without it. All icon operations are guarded with `|| true` so any filesystem or permission failure is non-fatal and never aborts `dpkg`.

Closes #614
Ref: #609 (comment)

## Test plan
- [x] `yarn make:dev` produces a `.deb` without errors
- [x] `sudo dpkg -i` installs cleanly; `/usr/share/icons/hicolor/128x128/apps/emuflight-configurator.png` present after install
- [x] XFCE panel launcher shows the EmuFlight icon without manual icon selection (verified)
- [ ] GNOME/KDE panel launcher shows the EmuFlight icon (same hicolor mechanism; not verified)
- [x] `sudo dpkg -r emuflight-configurator` uninstalls cleanly; hicolor icon removed
- [x] `yarn dev` still shows correct taskbar icon on Linux