### PR TITLE
Fix switch-case fallthrough bugs (MSPHelper.js, configuration.js)

### DIFF
--- a/src/js/msp/MSPHelper.js
+++ b/src/js/msp/MSPHelper.js
@@ -628,6 +628,7 @@ MspHelper.prototype.process_data = function(dataHandler) {
                 break;
             case MSPCodes.MSP_SET_VOLTAGE_METER_CONFIG:
                 console.log('Voltage config saved');
+                break;
             case MSPCodes.MSP_DEBUG:
                 for (var i = 0; i < 4; i++)
                     SENSOR_DATA.debug[i] = data.read16();

--- a/src/js/serial.js
+++ b/src/js/serial.js
@@ -128,6 +128,7 @@ var serial = {
                         case 'frame_error':
                         case 'parity_error':
                             GUI.log(i18n.getMessage('serialError' + inflection.camelize(info.error)));
+                            // falls through
                         case 'break': // This seems to be the error that is thrown under NW.js in Windows when the device reboots after typing 'exit' in CLI
                         case 'disconnected':
                         case 'device_lost':

--- a/src/js/tabs/configuration.js
+++ b/src/js/tabs/configuration.js
@@ -999,6 +999,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
                         checkUpdateCurrentControls();
                     }
 
+                    break;
                 case 'GPS':
                     checkUpdateGpsControls();
                     break;


### PR DESCRIPTION
AI Generated pull-request

## Summary
Fixes the two genuine switch-case fallthrough bugs itemized in #620:

- `src/js/msp/MSPHelper.js`: `MSP_SET_VOLTAGE_METER_CONFIG` fell through into `MSP_DEBUG`, corrupting `SENSOR_DATA.debug[0..3]` with garbage reads on every voltage config save. Added missing `break;`.
- `src/js/tabs/configuration.js`: `CURRENT_METER` fell through into `GPS`, unconditionally running `checkUpdateGpsControls()` on every `CURRENT_METER` feature-toggle event. Added missing `break;`, matching the sibling `VBAT` case's pattern.
- `src/js/serial.js`: `frame_error`/`parity_error` intentionally cascades into shared disconnect handling (correct behavior, per #620's analysis). Added a `// falls through` comment to satisfy the `no-fallthrough` lint rule without changing behavior.

Closes #620.

## Test plan
- [x] `yarn lint` — 0 `no-fallthrough` violations remaining (previously 3)
- [x] Local CodeRabbit review — 0 findings
- [ ] Hardware/functional verification: n/a (logic-only fix, no build/runtime change beyond correcting fallthrough behavior)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where changing certain configuration options could trigger the wrong follow-up behavior in the UI.
  * Corrected a case where voltage meter settings could affect subsequent processing unexpectedly.
  * Improved handling of serial receive errors to avoid unintended downstream effects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->