### PR TITLE
Don't abandon an in-flight MSP save when switching tabs

### DIFF
--- a/src/js/gui.js
+++ b/src/js/gui.js
@@ -269,8 +269,8 @@ GUI_control.prototype.log = function (message) {
 GUI_control.prototype.tab_switch_cleanup = function (callback) {
     // we don't care about any old (non-save) data that might or might not arrive, so it's dropped, and any
     // MSP.promise() awaiting one of those requests is rejected instead of left hanging. Requests belonging
-    // to an in-flight save (MSP.saveInProgress) are left alone so the save completes instead of being
-    // abandoned by a tab switch (see issue #623).
+    // to an in-flight save (MSP.activeSaveCount > 0, see MSP.beginProtectedSave/endProtectedSave) are left
+    // alone so the save completes instead of being abandoned by a tab switch (see issue #623).
     MSP.callbacks_cleanup();
     GUI.interval_kill_all(); // all intervals (mostly data pulling) needs to be removed on tab switch
 

--- a/src/js/gui.js
+++ b/src/js/gui.js
@@ -267,7 +267,11 @@ GUI_control.prototype.log = function (message) {
 // callback = code to run when cleanup is finished
 // default switch doesn't require callback to be set
 GUI_control.prototype.tab_switch_cleanup = function (callback) {
-    MSP.callbacks_cleanup(); // we don't care about any old data that might or might not arrive
+    // we don't care about any old (non-save) data that might or might not arrive, so it's dropped, and any
+    // MSP.promise() awaiting one of those requests is rejected instead of left hanging. Requests belonging
+    // to an in-flight save (MSP.saveInProgress) are left alone so the save completes instead of being
+    // abandoned by a tab switch (see issue #623).
+    MSP.callbacks_cleanup();
     GUI.interval_kill_all(); // all intervals (mostly data pulling) needs to be removed on tab switch
 
     if (this.active_tab && TABS[this.active_tab]) {

--- a/src/js/msp.js
+++ b/src/js/msp.js
@@ -50,12 +50,17 @@ var MSP = {
     packet_error:               0,
     unsupported:                0,
 
-    // Set true by a tab's save handler for the duration of its save chain (including EEPROM_WRITE
-    // and, for save-and-reboot flows, the reboot command). While true, any MSP request issued is
-    // marked protected and survives a tab switch instead of being abandoned by callbacks_cleanup().
-    // Tabs MUST reset this to false once their chain settles (success or failure) or disconnect_cleanup()
-    // will do it for them as a safety net.
+    // Set true via beginProtectedSave() by a tab's save handler for the duration of its save chain
+    // (including EEPROM_WRITE and, for save-and-reboot flows, the reboot command). While true, any
+    // MSP request issued is marked protected and survives a tab switch instead of being abandoned by
+    // callbacks_cleanup(). Tabs call endProtectedSave() once their chain settles (success or failure);
+    // if a chain stalls and never calls it (e.g. a plain callback that never fires), the watchdog timer
+    // armed by beginProtectedSave() clears it after saveWatchdogTimeoutMs so a single stuck save can't
+    // protect every other tab's unrelated requests from cleanup forever. disconnect_cleanup() also
+    // clears it immediately, since nothing can complete once the connection is gone.
     saveInProgress:              false,
+    saveWatchdogTimer:           null,
+    saveWatchdogTimeoutMs:       15000,
 
     last_received_timestamp:   null,
     listeners:                  [],
@@ -374,8 +379,30 @@ var MSP = {
         var pending = self.send_message(code, data, false, function(data) {
           resolve(data);
         });
+        if (!pending) {
+          reject(new Error(`MSP.promise: invalid code (${code})`));
+          return;
+        }
         pending.reject = reject;
       });
+    },
+    // Marks the start of a tab's save chain: requests issued while saveInProgress is true survive a
+    // tab switch instead of being abandoned (see callbacks_cleanup below). Arms a watchdog so a chain
+    // that never calls endProtectedSave() (e.g. a plain callback that never fires) can't leave every
+    // other tab's unrelated requests permanently protected.
+    beginProtectedSave: function (timeoutMs) {
+        this.saveInProgress = true;
+        clearTimeout(this.saveWatchdogTimer);
+        var self = this;
+        this.saveWatchdogTimer = setTimeout(function () {
+            console.log('MSP save watchdog: chain did not settle within ' + (timeoutMs || self.saveWatchdogTimeoutMs) + 'ms, clearing saveInProgress');
+            self.saveInProgress = false;
+        }, timeoutMs || this.saveWatchdogTimeoutMs);
+    },
+    endProtectedSave: function () {
+        clearTimeout(this.saveWatchdogTimer);
+        this.saveWatchdogTimer = null;
+        this.saveInProgress = false;
     },
     // force=true (used by disconnect_cleanup) also clears protected/in-flight-save entries, since a real
     // disconnect means nothing can complete regardless. Plain tab switches leave protected entries alone
@@ -398,7 +425,7 @@ var MSP = {
     disconnect_cleanup: function () {
         this.state = 0; // reset packet state for "clean" initial entry (this is only required if user hot-disconnects)
         this.packet_error = 0; // reset CRC packet error counter for next session
-        this.saveInProgress = false; // any protected in-flight save is moot once the connection is gone
+        this.endProtectedSave(); // any protected in-flight save is moot once the connection is gone
 
         this.callbacks_cleanup(true);
     }

--- a/src/js/msp.js
+++ b/src/js/msp.js
@@ -50,16 +50,19 @@ var MSP = {
     packet_error:               0,
     unsupported:                0,
 
-    // Set true via beginProtectedSave() by a tab's save handler for the duration of its save chain
-    // (including EEPROM_WRITE and, for save-and-reboot flows, the reboot command). While true, any
-    // MSP request issued is marked protected and survives a tab switch instead of being abandoned by
-    // callbacks_cleanup(). Tabs call endProtectedSave() once their chain settles (success or failure);
-    // if a chain stalls and never calls it (e.g. a plain callback that never fires), the watchdog timer
-    // armed by beginProtectedSave() clears it after saveWatchdogTimeoutMs so a single stuck save can't
-    // protect every other tab's unrelated requests from cleanup forever. disconnect_cleanup() also
-    // clears it immediately, since nothing can complete once the connection is gone.
-    saveInProgress:              false,
-    saveWatchdogTimer:           null,
+    // Reentrant save protection: beginProtectedSave() returns a token identifying one tab's save
+    // chain and increments activeSaveCount; requests issued while activeSaveCount > 0 are marked
+    // protected and survive a tab switch instead of being abandoned by callbacks_cleanup(). Tabs call
+    // endProtectedSave(token) once their chain settles (success or failure); if a chain stalls and
+    // never calls it (e.g. a plain callback that never fires), the watchdog armed for that token
+    // releases it after saveWatchdogTimeoutMs so one stuck save can't protect every other tab's
+    // unrelated requests forever. Using a per-token count instead of a single boolean means one save
+    // chain finishing (or timing out) can't prematurely end protection for a second, still-running
+    // save chain from another tab. disconnect_cleanup() releases every outstanding token immediately,
+    // since nothing can complete once the connection is gone.
+    activeSaveCount:             0,
+    saveWatchdogTimers:          {},
+    nextSaveToken:               1,
     saveWatchdogTimeoutMs:       15000,
 
     last_received_timestamp:   null,
@@ -333,7 +336,7 @@ var MSP = {
             bufferOut = this.encode_message_v2(code, data);
         }
 
-        var obj = {'code': code, 'requestBuffer': bufferOut, 'callback': callback_msp ? callback_msp : false, 'timer': false, 'callbackOnError': doCallbackOnError, 'protected': this.saveInProgress};
+        var obj = {'code': code, 'requestBuffer': bufferOut, 'callback': callback_msp ? callback_msp : false, 'timer': false, 'callbackOnError': doCallbackOnError, 'protected': this.activeSaveCount > 0};
 
         var requestExists = false;
         for (var i = 0; i < MSP.callbacks.length; i++) {
@@ -386,23 +389,33 @@ var MSP = {
         pending.reject = reject;
       });
     },
-    // Marks the start of a tab's save chain: requests issued while saveInProgress is true survive a
-    // tab switch instead of being abandoned (see callbacks_cleanup below). Arms a watchdog so a chain
-    // that never calls endProtectedSave() (e.g. a plain callback that never fires) can't leave every
-    // other tab's unrelated requests permanently protected.
+    // Marks the start of one tab's save chain: while activeSaveCount > 0, requests issued survive a
+    // tab switch instead of being abandoned (see callbacks_cleanup below). Returns a token that the
+    // caller MUST pass to endProtectedSave() once its chain settles (success or failure). Arms a
+    // watchdog scoped to that token so a chain that never calls endProtectedSave() (e.g. a plain
+    // callback that never fires) can't leave protection stuck on forever.
     beginProtectedSave: function (timeoutMs) {
-        this.saveInProgress = true;
-        clearTimeout(this.saveWatchdogTimer);
+        var token = this.nextSaveToken++;
+        this.activeSaveCount++;
         var self = this;
-        this.saveWatchdogTimer = setTimeout(function () {
-            console.log('MSP save watchdog: chain did not settle within ' + (timeoutMs || self.saveWatchdogTimeoutMs) + 'ms, clearing saveInProgress');
-            self.saveInProgress = false;
+        this.saveWatchdogTimers[token] = setTimeout(function () {
+            console.log('MSP save watchdog: save token ' + token + ' did not settle within ' + (timeoutMs || self.saveWatchdogTimeoutMs) + 'ms, releasing its protection');
+            self._releaseSaveToken(token);
         }, timeoutMs || this.saveWatchdogTimeoutMs);
+        return token;
     },
-    endProtectedSave: function () {
-        clearTimeout(this.saveWatchdogTimer);
-        this.saveWatchdogTimer = null;
-        this.saveInProgress = false;
+    endProtectedSave: function (token) {
+        this._releaseSaveToken(token);
+    },
+    // Shared by endProtectedSave() and the per-token watchdog; safe to call twice for the same token
+    // (e.g. if both the watchdog and a late endProtectedSave() fire) since the second call is a no-op.
+    _releaseSaveToken: function (token) {
+        if (!Object.prototype.hasOwnProperty.call(this.saveWatchdogTimers, token)) {
+            return;
+        }
+        clearTimeout(this.saveWatchdogTimers[token]);
+        delete this.saveWatchdogTimers[token];
+        this.activeSaveCount = Math.max(0, this.activeSaveCount - 1);
     },
     // force=true (used by disconnect_cleanup) also clears protected/in-flight-save entries, since a real
     // disconnect means nothing can complete regardless. Plain tab switches leave protected entries alone
@@ -426,7 +439,13 @@ var MSP = {
     disconnect_cleanup: function () {
         this.state = 0; // reset packet state for "clean" initial entry (this is only required if user hot-disconnects)
         this.packet_error = 0; // reset CRC packet error counter for next session
-        this.endProtectedSave(); // any protected in-flight save is moot once the connection is gone
+
+        // release every outstanding save token — any protected in-flight save is moot once the connection is gone
+        for (var token in this.saveWatchdogTimers) {
+            clearTimeout(this.saveWatchdogTimers[token]);
+        }
+        this.saveWatchdogTimers = {};
+        this.activeSaveCount = 0;
 
         this.callbacks_cleanup(true);
     }

--- a/src/js/msp.js
+++ b/src/js/msp.js
@@ -464,3 +464,27 @@ var MSP = {
         this.callbacks_cleanup(true);
     }
 };
+
+// window.Promise is Bluebird (see main.html), whose default handling of an unhandled rejection
+// is a multi-frame "Unhandled rejection" trace dump straight to console — accurate, but alarming
+// for the one case we know is expected: a background MSP read abandoned by callbacks_cleanup()/
+// disconnect_cleanup() above (tab switch or real disconnect, not a bug). This hook replaces
+// Bluebird's default reporter app-wide with calmer, explanatory logging for that specific case;
+// anything else still logs normally so a genuine bug is never silently hidden.
+if (window.Promise && typeof window.Promise.onPossiblyUnhandledRejection === 'function') {
+    var MSP_ABANDONED_REQUEST_PATTERN = /^MSP request (\d+) aborted before a response arrived \(tab switch or disconnect\)$/;
+    var mspCodeNamesByValue = {};
+    for (var mspCodeName in MSPCodes) {
+        mspCodeNamesByValue[MSPCodes[mspCodeName]] = mspCodeName;
+    }
+
+    window.Promise.onPossiblyUnhandledRejection(function (error) {
+        var match = error instanceof Error && MSP_ABANDONED_REQUEST_PATTERN.exec(error.message);
+        if (match) {
+            var code = match[1];
+            console.log(`MSP: request ${mspCodeNamesByValue[code] || code} was abandoned before a response arrived (tab switch or disconnect) — expected for a non-critical background read, no data was lost.`);
+        } else {
+            console.error('Unhandled rejection:', error);
+        }
+    });
+}

--- a/src/js/msp.js
+++ b/src/js/msp.js
@@ -410,6 +410,7 @@ var MSP = {
     callbacks_cleanup: function (force) {
         for (var i = this.callbacks.length - 1; i >= 0; i--) {
             if (this.callbacks[i].protected && !force) {
+                console.log(`MSP: preserving in-flight request ${this.callbacks[i].code} through tab switch (save in progress)`);
                 continue;
             }
 

--- a/src/js/msp.js
+++ b/src/js/msp.js
@@ -336,7 +336,7 @@ var MSP = {
             bufferOut = this.encode_message_v2(code, data);
         }
 
-        var obj = {'code': code, 'requestBuffer': bufferOut, 'callback': callback_msp ? callback_msp : false, 'timer': false, 'callbackOnError': doCallbackOnError, 'protected': this.activeSaveCount > 0};
+        var obj = {'code': code, 'requestBuffer': bufferOut, 'callback': callback_msp ? callback_msp : false, 'timer': false, 'callbackOnError': doCallbackOnError};
 
         var requestExists = false;
         for (var i = 0; i < MSP.callbacks.length; i++) {
@@ -431,12 +431,21 @@ var MSP = {
         delete this.saveWatchdogTimers[token];
         this.activeSaveCount = Math.max(0, this.activeSaveCount - 1);
     },
-    // force=true (used by disconnect_cleanup) also clears protected/in-flight-save entries, since a real
-    // disconnect means nothing can complete regardless. Plain tab switches leave protected entries alone
-    // so an in-flight save (including EEPROM_WRITE) is not abandoned, per issue #623.
+    // force=true (used by disconnect_cleanup) also clears in-flight-save entries, since a real
+    // disconnect means nothing can complete regardless. Plain tab switches leave everything alone
+    // while a save is CURRENTLY active (activeSaveCount > 0, checked live here, not a flag stored on
+    // the request at creation time) so an in-flight save (including EEPROM_WRITE) is not abandoned,
+    // per issue #623 — but the moment the save ends, protection ends with it for everything, including
+    // unrelated background polls that happened to be issued during that window. A per-request flag
+    // frozen at creation time was tried first and was a real bug: a periodic poll created during any
+    // save anywhere in the session would stay "protected" forever, even long after that save finished,
+    // silently defeating cleanup calls other code depends on (e.g. cli.js's tab_switch_cleanup ->
+    // callbacks_cleanup() flush of stale retransmit timers before its CLI-exit/reboot/reconnect
+    // sequence) and leaving a retry timer stuck hammering a connection that had already moved on.
     callbacks_cleanup: function (force) {
+        var protectAll = this.activeSaveCount > 0 && !force;
         for (var i = this.callbacks.length - 1; i >= 0; i--) {
-            if (this.callbacks[i].protected && !force) {
+            if (protectAll) {
                 console.log(`MSP: preserving in-flight request ${this.callbacks[i].code} through tab switch (save in progress)`);
                 continue;
             }

--- a/src/js/msp.js
+++ b/src/js/msp.js
@@ -50,6 +50,13 @@ var MSP = {
     packet_error:               0,
     unsupported:                0,
 
+    // Set true by a tab's save handler for the duration of its save chain (including EEPROM_WRITE
+    // and, for save-and-reboot flows, the reboot command). While true, any MSP request issued is
+    // marked protected and survives a tab switch instead of being abandoned by callbacks_cleanup().
+    // Tabs MUST reset this to false once their chain settles (success or failure) or disconnect_cleanup()
+    // will do it for them as a safety net.
+    saveInProgress:              false,
+
     last_received_timestamp:   null,
     listeners:                  [],
 
@@ -321,7 +328,7 @@ var MSP = {
             bufferOut = this.encode_message_v2(code, data);
         }
 
-        var obj = {'code': code, 'requestBuffer': bufferOut, 'callback': callback_msp ? callback_msp : false, 'timer': false, 'callbackOnError': doCallbackOnError};
+        var obj = {'code': code, 'requestBuffer': bufferOut, 'callback': callback_msp ? callback_msp : false, 'timer': false, 'callbackOnError': doCallbackOnError, 'protected': this.saveInProgress};
 
         var requestExists = false;
         for (var i = 0; i < MSP.callbacks.length; i++) {
@@ -353,31 +360,46 @@ var MSP = {
             });
         }
 
-        return true;
+        return obj;
     },
 
     /**
      * resolves: {command: code, data: data, length: message_length}
+     * rejects: Error, if the request is abandoned by callbacks_cleanup() (e.g. tab switch or disconnect
+     * before a response arrives) instead of being left to hang forever.
      */
     promise: function(code, data) {
       var self = this;
-      return new Promise(function(resolve) {
-        self.send_message(code, data, false, function(data) {
+      return new Promise(function(resolve, reject) {
+        var pending = self.send_message(code, data, false, function(data) {
           resolve(data);
         });
+        pending.reject = reject;
       });
     },
-    callbacks_cleanup: function () {
-        for (var i = 0; i < this.callbacks.length; i++) {
-            clearInterval(this.callbacks[i].timer);
-        }
+    // force=true (used by disconnect_cleanup) also clears protected/in-flight-save entries, since a real
+    // disconnect means nothing can complete regardless. Plain tab switches leave protected entries alone
+    // so an in-flight save (including EEPROM_WRITE) is not abandoned, per issue #623.
+    callbacks_cleanup: function (force) {
+        for (var i = this.callbacks.length - 1; i >= 0; i--) {
+            if (this.callbacks[i].protected && !force) {
+                continue;
+            }
 
-        this.callbacks = [];
+            clearInterval(this.callbacks[i].timer);
+
+            if (typeof this.callbacks[i].reject === 'function') {
+                this.callbacks[i].reject(new Error(`MSP request ${this.callbacks[i].code} aborted before a response arrived (tab switch or disconnect)`));
+            }
+
+            this.callbacks.splice(i, 1);
+        }
     },
     disconnect_cleanup: function () {
         this.state = 0; // reset packet state for "clean" initial entry (this is only required if user hot-disconnects)
         this.packet_error = 0; // reset CRC packet error counter for next session
+        this.saveInProgress = false; // any protected in-flight save is moot once the connection is gone
 
-        this.callbacks_cleanup();
+        this.callbacks_cleanup(true);
     }
 };

--- a/src/js/msp.js
+++ b/src/js/msp.js
@@ -397,15 +397,29 @@ var MSP = {
     beginProtectedSave: function (timeoutMs) {
         var token = this.nextSaveToken++;
         this.activeSaveCount++;
+        this._armSaveWatchdog(token, timeoutMs);
+        return token;
+    },
+    endProtectedSave: function (token) {
+        this._releaseSaveToken(token);
+    },
+    // Re-arms an existing token's watchdog without touching activeSaveCount, for a chain that legitimately
+    // runs longer than one watchdog window (e.g. many sequential requests in a loop) — call this between
+    // steps so only a stalled step expires protection, instead of the chain's total duration. No-op if the
+    // token was already released (e.g. by a disconnect).
+    touchProtectedSave: function (token, timeoutMs) {
+        if (!Object.prototype.hasOwnProperty.call(this.saveWatchdogTimers, token)) {
+            return;
+        }
+        clearTimeout(this.saveWatchdogTimers[token]);
+        this._armSaveWatchdog(token, timeoutMs);
+    },
+    _armSaveWatchdog: function (token, timeoutMs) {
         var self = this;
         this.saveWatchdogTimers[token] = setTimeout(function () {
             console.log('MSP save watchdog: save token ' + token + ' did not settle within ' + (timeoutMs || self.saveWatchdogTimeoutMs) + 'ms, releasing its protection');
             self._releaseSaveToken(token);
         }, timeoutMs || this.saveWatchdogTimeoutMs);
-        return token;
-    },
-    endProtectedSave: function (token) {
-        this._releaseSaveToken(token);
     },
     // Shared by endProtectedSave() and the per-token watchdog; safe to call twice for the same token
     // (e.g. if both the watchdog and a late endProtectedSave() fire) since the second call is a no-op.

--- a/src/js/tabs/adjustments.js
+++ b/src/js/tabs/adjustments.js
@@ -163,7 +163,7 @@ TABS.adjustments.initialize = function (callback) {
         $('a.save').click(function () {
             // protect this save chain (through EEPROM_WRITE) from being abandoned if the
             // user switches tabs before the FC responds; cleared once EEPROM_WRITE completes below
-            MSP.beginProtectedSave();
+            var protectedSaveToken = MSP.beginProtectedSave();
 
             // update internal data structures based on current UI elements
             var requiredAdjustmentRangeCount = ADJUSTMENT_RANGES.length;
@@ -214,7 +214,7 @@ TABS.adjustments.initialize = function (callback) {
             
             function save_to_eeprom() {
                 MSP.send_message(MSPCodes.MSP_EEPROM_WRITE, false, false, function () {
-                    MSP.endProtectedSave();
+                    MSP.endProtectedSave(protectedSaveToken);
                     GUI.log(i18n.getMessage('adjustmentsEepromSaved'));
                 });
             }

--- a/src/js/tabs/adjustments.js
+++ b/src/js/tabs/adjustments.js
@@ -161,6 +161,9 @@ TABS.adjustments.initialize = function (callback) {
 
         // UI Hooks
         $('a.save').click(function () {
+            // protect this save chain (through EEPROM_WRITE) from being abandoned if the
+            // user switches tabs before the FC responds; cleared once EEPROM_WRITE completes below
+            MSP.saveInProgress = true;
 
             // update internal data structures based on current UI elements
             var requiredAdjustmentRangeCount = ADJUSTMENT_RANGES.length;
@@ -211,6 +214,7 @@ TABS.adjustments.initialize = function (callback) {
             
             function save_to_eeprom() {
                 MSP.send_message(MSPCodes.MSP_EEPROM_WRITE, false, false, function () {
+                    MSP.saveInProgress = false;
                     GUI.log(i18n.getMessage('adjustmentsEepromSaved'));
                 });
             }

--- a/src/js/tabs/adjustments.js
+++ b/src/js/tabs/adjustments.js
@@ -163,7 +163,7 @@ TABS.adjustments.initialize = function (callback) {
         $('a.save').click(function () {
             // protect this save chain (through EEPROM_WRITE) from being abandoned if the
             // user switches tabs before the FC responds; cleared once EEPROM_WRITE completes below
-            MSP.saveInProgress = true;
+            MSP.beginProtectedSave();
 
             // update internal data structures based on current UI elements
             var requiredAdjustmentRangeCount = ADJUSTMENT_RANGES.length;
@@ -214,7 +214,7 @@ TABS.adjustments.initialize = function (callback) {
             
             function save_to_eeprom() {
                 MSP.send_message(MSPCodes.MSP_EEPROM_WRITE, false, false, function () {
-                    MSP.saveInProgress = false;
+                    MSP.endProtectedSave();
                     GUI.log(i18n.getMessage('adjustmentsEepromSaved'));
                 });
             }

--- a/src/js/tabs/auxiliary.js
+++ b/src/js/tabs/auxiliary.js
@@ -298,7 +298,7 @@ TABS.auxiliary.initialize = function (callback) {
         $('a.save').click(function () {
             // protect this save chain (through EEPROM_WRITE) from being abandoned if the
             // user switches tabs before the FC responds; cleared once EEPROM_WRITE completes below
-            MSP.saveInProgress = true;
+            MSP.beginProtectedSave();
 
             // update internal data structures based on current UI elements
             
@@ -384,7 +384,7 @@ TABS.auxiliary.initialize = function (callback) {
 
             function save_to_eeprom() {
                 MSP.send_message(MSPCodes.MSP_EEPROM_WRITE, false, false, function () {
-                    MSP.saveInProgress = false;
+                    MSP.endProtectedSave();
                     GUI.log(i18n.getMessage('auxiliaryEepromSaved'));
                 });
             }

--- a/src/js/tabs/auxiliary.js
+++ b/src/js/tabs/auxiliary.js
@@ -298,7 +298,7 @@ TABS.auxiliary.initialize = function (callback) {
         $('a.save').click(function () {
             // protect this save chain (through EEPROM_WRITE) from being abandoned if the
             // user switches tabs before the FC responds; cleared once EEPROM_WRITE completes below
-            MSP.beginProtectedSave();
+            var protectedSaveToken = MSP.beginProtectedSave();
 
             // update internal data structures based on current UI elements
             
@@ -384,7 +384,7 @@ TABS.auxiliary.initialize = function (callback) {
 
             function save_to_eeprom() {
                 MSP.send_message(MSPCodes.MSP_EEPROM_WRITE, false, false, function () {
-                    MSP.endProtectedSave();
+                    MSP.endProtectedSave(protectedSaveToken);
                     GUI.log(i18n.getMessage('auxiliaryEepromSaved'));
                 });
             }

--- a/src/js/tabs/auxiliary.js
+++ b/src/js/tabs/auxiliary.js
@@ -296,6 +296,9 @@ TABS.auxiliary.initialize = function (callback) {
 
         // UI Hooks
         $('a.save').click(function () {
+            // protect this save chain (through EEPROM_WRITE) from being abandoned if the
+            // user switches tabs before the FC responds; cleared once EEPROM_WRITE completes below
+            MSP.saveInProgress = true;
 
             // update internal data structures based on current UI elements
             
@@ -381,6 +384,7 @@ TABS.auxiliary.initialize = function (callback) {
 
             function save_to_eeprom() {
                 MSP.send_message(MSPCodes.MSP_EEPROM_WRITE, false, false, function () {
+                    MSP.saveInProgress = false;
                     GUI.log(i18n.getMessage('auxiliaryEepromSaved'));
                 });
             }

--- a/src/js/tabs/configuration.js
+++ b/src/js/tabs/configuration.js
@@ -1064,6 +1064,10 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
         }
 
         $('a.save').click(function () {
+            // protect this save chain (through EEPROM_WRITE + reboot) from being abandoned if the
+            // user switches tabs before the FC responds; cleared once EEPROM_WRITE completes below
+            MSP.saveInProgress = true;
+
             // gather data that doesn't have automatic change event bound
             BOARD_ALIGNMENT_CONFIG.roll = parseInt($('input[name="board_align_roll"]').val());
             BOARD_ALIGNMENT_CONFIG.pitch = parseInt($('input[name="board_align_pitch"]').val());
@@ -1293,6 +1297,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
             }
 
             function reboot() {
+                MSP.saveInProgress = false;
                 GUI.log(i18n.getMessage('configurationEepromSaved'));
 
                 GUI.tab_switch_cleanup(function() {

--- a/src/js/tabs/configuration.js
+++ b/src/js/tabs/configuration.js
@@ -1066,7 +1066,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
         $('a.save').click(function () {
             // protect this save chain (through EEPROM_WRITE + reboot) from being abandoned if the
             // user switches tabs before the FC responds; cleared once EEPROM_WRITE completes below
-            MSP.saveInProgress = true;
+            MSP.beginProtectedSave();
 
             // gather data that doesn't have automatic change event bound
             BOARD_ALIGNMENT_CONFIG.roll = parseInt($('input[name="board_align_roll"]').val());
@@ -1297,7 +1297,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
             }
 
             function reboot() {
-                MSP.saveInProgress = false;
+                MSP.endProtectedSave();
                 GUI.log(i18n.getMessage('configurationEepromSaved'));
 
                 GUI.tab_switch_cleanup(function() {

--- a/src/js/tabs/configuration.js
+++ b/src/js/tabs/configuration.js
@@ -1066,7 +1066,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
         $('a.save').click(function () {
             // protect this save chain (through EEPROM_WRITE + reboot) from being abandoned if the
             // user switches tabs before the FC responds; cleared once EEPROM_WRITE completes below
-            MSP.beginProtectedSave();
+            var protectedSaveToken = MSP.beginProtectedSave();
 
             // gather data that doesn't have automatic change event bound
             BOARD_ALIGNMENT_CONFIG.roll = parseInt($('input[name="board_align_roll"]').val());
@@ -1297,7 +1297,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
             }
 
             function reboot() {
-                MSP.endProtectedSave();
+                MSP.endProtectedSave(protectedSaveToken);
                 GUI.log(i18n.getMessage('configurationEepromSaved'));
 
                 GUI.tab_switch_cleanup(function() {

--- a/src/js/tabs/configuration.js
+++ b/src/js/tabs/configuration.js
@@ -1297,13 +1297,14 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
             }
 
             function reboot() {
-                MSP.endProtectedSave(protectedSaveToken);
                 GUI.log(i18n.getMessage('configurationEepromSaved'));
 
                 GUI.tab_switch_cleanup(function() {
                     MSP.send_message(MSPCodes.MSP_SET_REBOOT, false, false);
                     reinitialiseConnection(self);
                 });
+
+                MSP.endProtectedSave(protectedSaveToken);
             }
 
             save_serial_config();

--- a/src/js/tabs/failsafe.js
+++ b/src/js/tabs/failsafe.js
@@ -308,6 +308,10 @@ TABS.failsafe.initialize = function (callback, scrollPosition) {
 
 
         $('a.save').click(function () {
+            // protect this save chain (through EEPROM_WRITE + reboot) from being abandoned if the
+            // user switches tabs before the FC responds; cleared once EEPROM_WRITE completes below
+            MSP.saveInProgress = true;
+
             // gather data that doesn't have automatic change event bound
 
             FEATURE_CONFIG.features.updateData($('input[name="FAILSAFE"]'));
@@ -370,6 +374,7 @@ TABS.failsafe.initialize = function (callback, scrollPosition) {
             }
 
             function reboot() {
+                MSP.saveInProgress = false;
                 GUI.log(i18n.getMessage('configurationEepromSaved'));
 
                 GUI.tab_switch_cleanup(function() {

--- a/src/js/tabs/failsafe.js
+++ b/src/js/tabs/failsafe.js
@@ -374,13 +374,14 @@ TABS.failsafe.initialize = function (callback, scrollPosition) {
             }
 
             function reboot() {
-                MSP.endProtectedSave(protectedSaveToken);
                 GUI.log(i18n.getMessage('configurationEepromSaved'));
 
                 GUI.tab_switch_cleanup(function() {
                     MSP.send_message(MSPCodes.MSP_SET_REBOOT, false, false);
                     reinitialiseConnection(self);
                 });
+
+                MSP.endProtectedSave(protectedSaveToken);
             }
 
             MSP.send_message(MSPCodes.MSP_SET_RX_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_RX_CONFIG), false, save_failssafe_config);

--- a/src/js/tabs/failsafe.js
+++ b/src/js/tabs/failsafe.js
@@ -310,7 +310,7 @@ TABS.failsafe.initialize = function (callback, scrollPosition) {
         $('a.save').click(function () {
             // protect this save chain (through EEPROM_WRITE + reboot) from being abandoned if the
             // user switches tabs before the FC responds; cleared once EEPROM_WRITE completes below
-            MSP.saveInProgress = true;
+            MSP.beginProtectedSave();
 
             // gather data that doesn't have automatic change event bound
 
@@ -374,7 +374,7 @@ TABS.failsafe.initialize = function (callback, scrollPosition) {
             }
 
             function reboot() {
-                MSP.saveInProgress = false;
+                MSP.endProtectedSave();
                 GUI.log(i18n.getMessage('configurationEepromSaved'));
 
                 GUI.tab_switch_cleanup(function() {

--- a/src/js/tabs/failsafe.js
+++ b/src/js/tabs/failsafe.js
@@ -310,7 +310,7 @@ TABS.failsafe.initialize = function (callback, scrollPosition) {
         $('a.save').click(function () {
             // protect this save chain (through EEPROM_WRITE + reboot) from being abandoned if the
             // user switches tabs before the FC responds; cleared once EEPROM_WRITE completes below
-            MSP.beginProtectedSave();
+            var protectedSaveToken = MSP.beginProtectedSave();
 
             // gather data that doesn't have automatic change event bound
 
@@ -374,7 +374,7 @@ TABS.failsafe.initialize = function (callback, scrollPosition) {
             }
 
             function reboot() {
-                MSP.endProtectedSave();
+                MSP.endProtectedSave(protectedSaveToken);
                 GUI.log(i18n.getMessage('configurationEepromSaved'));
 
                 GUI.tab_switch_cleanup(function() {

--- a/src/js/tabs/led_strip.js
+++ b/src/js/tabs/led_strip.js
@@ -570,7 +570,7 @@ TABS.led_strip.initialize = function (callback, scrollPosition) {
         $('a.save').click(function () {
             // protect this save chain (through EEPROM_WRITE) from being abandoned if the
             // user switches tabs before the FC responds; cleared once EEPROM_WRITE completes below
-            MSP.beginProtectedSave();
+            var protectedSaveToken = MSP.beginProtectedSave();
 
             mspHelper.sendLedStripConfig(send_led_strip_colors);
 
@@ -587,7 +587,7 @@ TABS.led_strip.initialize = function (callback, scrollPosition) {
 
             function save_to_eeprom() {
                 MSP.send_message(MSPCodes.MSP_EEPROM_WRITE, false, false, function() {
-                    MSP.endProtectedSave();
+                    MSP.endProtectedSave(protectedSaveToken);
                     GUI.log(i18n.getMessage('ledStripEepromSaved'));
                 });
             }

--- a/src/js/tabs/led_strip.js
+++ b/src/js/tabs/led_strip.js
@@ -568,6 +568,9 @@ TABS.led_strip.initialize = function (callback, scrollPosition) {
         });
 
         $('a.save').click(function () {
+            // protect this save chain (through EEPROM_WRITE) from being abandoned if the
+            // user switches tabs before the FC responds; cleared once EEPROM_WRITE completes below
+            MSP.saveInProgress = true;
 
             mspHelper.sendLedStripConfig(send_led_strip_colors);
 
@@ -584,6 +587,7 @@ TABS.led_strip.initialize = function (callback, scrollPosition) {
 
             function save_to_eeprom() {
                 MSP.send_message(MSPCodes.MSP_EEPROM_WRITE, false, false, function() {
+                    MSP.saveInProgress = false;
                     GUI.log(i18n.getMessage('ledStripEepromSaved'));
                 });
             }

--- a/src/js/tabs/led_strip.js
+++ b/src/js/tabs/led_strip.js
@@ -570,7 +570,7 @@ TABS.led_strip.initialize = function (callback, scrollPosition) {
         $('a.save').click(function () {
             // protect this save chain (through EEPROM_WRITE) from being abandoned if the
             // user switches tabs before the FC responds; cleared once EEPROM_WRITE completes below
-            MSP.saveInProgress = true;
+            MSP.beginProtectedSave();
 
             mspHelper.sendLedStripConfig(send_led_strip_colors);
 
@@ -587,7 +587,7 @@ TABS.led_strip.initialize = function (callback, scrollPosition) {
 
             function save_to_eeprom() {
                 MSP.send_message(MSPCodes.MSP_EEPROM_WRITE, false, false, function() {
-                    MSP.saveInProgress = false;
+                    MSP.endProtectedSave();
                     GUI.log(i18n.getMessage('ledStripEepromSaved'));
                 });
             }

--- a/src/js/tabs/onboard_logging.js
+++ b/src/js/tabs/onboard_logging.js
@@ -52,13 +52,14 @@ TABS.onboard_logging.initialize = function (callback) {
     }
 
     function reboot(token) {
-        MSP.endProtectedSave(token);
         GUI.log(i18n.getMessage('configurationEepromSaved'));
 
         GUI.tab_switch_cleanup(function() {
             MSP.send_message(MSPCodes.MSP_SET_REBOOT, false, false);
             reinitialiseConnection(self);
         });
+
+        MSP.endProtectedSave(token);
     }
     
     function load_html() {

--- a/src/js/tabs/onboard_logging.js
+++ b/src/js/tabs/onboard_logging.js
@@ -47,6 +47,7 @@ TABS.onboard_logging.initialize = function (callback) {
     }
 
     function reboot() {
+        MSP.saveInProgress = false;
         GUI.log(i18n.getMessage('configurationEepromSaved'));
 
         GUI.tab_switch_cleanup(function() {
@@ -104,6 +105,10 @@ TABS.onboard_logging.initialize = function (callback) {
 
             if (BLACKBOX.supported) {
                 $(".tab-onboard_logging a.save-settings").click(function() {
+                    // protect this save chain (through EEPROM_WRITE + reboot) from being abandoned if
+                    // the user switches tabs before the FC responds; cleared in reboot() above
+                    MSP.saveInProgress = true;
+
                     if (semver.gte(CONFIG.apiVersion, "1.36.0")) {
                         BLACKBOX.blackboxPDenom = parseInt(loggingRatesSelect.val(), 10);
                     } else {

--- a/src/js/tabs/onboard_logging.js
+++ b/src/js/tabs/onboard_logging.js
@@ -12,9 +12,10 @@ TABS.onboard_logging = {
     VCP_BLOCK_SIZE: 4096
 };
 TABS.onboard_logging.initialize = function (callback) {
-    var 
+    var
         self = this,
-        saveCancelled, eraseCancelled;
+        saveCancelled, eraseCancelled,
+        protectedSaveToken; // set by the save-settings click handler below, read by reboot()
 
     if (GUI.active_tab !== 'onboard_logging') {
         GUI.active_tab = 'onboard_logging';
@@ -47,7 +48,7 @@ TABS.onboard_logging.initialize = function (callback) {
     }
 
     function reboot() {
-        MSP.endProtectedSave();
+        MSP.endProtectedSave(protectedSaveToken);
         GUI.log(i18n.getMessage('configurationEepromSaved'));
 
         GUI.tab_switch_cleanup(function() {
@@ -107,7 +108,7 @@ TABS.onboard_logging.initialize = function (callback) {
                 $(".tab-onboard_logging a.save-settings").click(function() {
                     // protect this save chain (through EEPROM_WRITE + reboot) from being abandoned if
                     // the user switches tabs before the FC responds; cleared in reboot() above
-                    MSP.beginProtectedSave();
+                    protectedSaveToken = MSP.beginProtectedSave();
 
                     if (semver.gte(CONFIG.apiVersion, "1.36.0")) {
                         BLACKBOX.blackboxPDenom = parseInt(loggingRatesSelect.val(), 10);

--- a/src/js/tabs/onboard_logging.js
+++ b/src/js/tabs/onboard_logging.js
@@ -47,7 +47,7 @@ TABS.onboard_logging.initialize = function (callback) {
     }
 
     function reboot() {
-        MSP.saveInProgress = false;
+        MSP.endProtectedSave();
         GUI.log(i18n.getMessage('configurationEepromSaved'));
 
         GUI.tab_switch_cleanup(function() {
@@ -107,7 +107,7 @@ TABS.onboard_logging.initialize = function (callback) {
                 $(".tab-onboard_logging a.save-settings").click(function() {
                     // protect this save chain (through EEPROM_WRITE + reboot) from being abandoned if
                     // the user switches tabs before the FC responds; cleared in reboot() above
-                    MSP.saveInProgress = true;
+                    MSP.beginProtectedSave();
 
                     if (semver.gte(CONFIG.apiVersion, "1.36.0")) {
                         BLACKBOX.blackboxPDenom = parseInt(loggingRatesSelect.val(), 10);

--- a/src/js/tabs/onboard_logging.js
+++ b/src/js/tabs/onboard_logging.js
@@ -14,8 +14,7 @@ TABS.onboard_logging = {
 TABS.onboard_logging.initialize = function (callback) {
     var
         self = this,
-        saveCancelled, eraseCancelled,
-        protectedSaveToken; // set by the save-settings click handler below, read by reboot()
+        saveCancelled, eraseCancelled;
 
     if (GUI.active_tab !== 'onboard_logging') {
         GUI.active_tab = 'onboard_logging';
@@ -43,12 +42,17 @@ TABS.onboard_logging.initialize = function (callback) {
         return gcd(b, a % b);
     }
     
-    function save_to_eeprom() {
-        MSP.send_message(MSPCodes.MSP_EEPROM_WRITE, false, false, reboot);
+    // token is threaded explicitly through this chain rather than a shared closure variable,
+    // so two overlapping clicks (before the first one's response arrives) each track their own
+    // protection instead of one click's completion releasing the other's still-in-flight token
+    function save_to_eeprom(token) {
+        MSP.send_message(MSPCodes.MSP_EEPROM_WRITE, false, false, function() {
+            reboot(token);
+        });
     }
 
-    function reboot() {
-        MSP.endProtectedSave(protectedSaveToken);
+    function reboot(token) {
+        MSP.endProtectedSave(token);
         GUI.log(i18n.getMessage('configurationEepromSaved'));
 
         GUI.tab_switch_cleanup(function() {
@@ -107,8 +111,10 @@ TABS.onboard_logging.initialize = function (callback) {
             if (BLACKBOX.supported) {
                 $(".tab-onboard_logging a.save-settings").click(function() {
                     // protect this save chain (through EEPROM_WRITE + reboot) from being abandoned if
-                    // the user switches tabs before the FC responds; cleared in reboot() above
-                    protectedSaveToken = MSP.beginProtectedSave();
+                    // the user switches tabs before the FC responds; cleared in reboot() above. Scoped
+                    // to this click's own closure (not a shared variable) so a second click before this
+                    // one settles can't overwrite the token this chain needs to release.
+                    var protectedSaveToken = MSP.beginProtectedSave();
 
                     if (semver.gte(CONFIG.apiVersion, "1.36.0")) {
                         BLACKBOX.blackboxPDenom = parseInt(loggingRatesSelect.val(), 10);
@@ -118,7 +124,9 @@ TABS.onboard_logging.initialize = function (callback) {
                         BLACKBOX.blackboxRateDenom = parseInt(rate[1], 10);
                     }
                     BLACKBOX.blackboxDevice = parseInt(deviceSelect.val(), 10);
-                    MSP.send_message(MSPCodes.MSP_SET_BLACKBOX_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_BLACKBOX_CONFIG), false, save_to_eeprom);
+                    MSP.send_message(MSPCodes.MSP_SET_BLACKBOX_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_BLACKBOX_CONFIG), false, function() {
+                        save_to_eeprom(protectedSaveToken);
+                    });
                 });
             }
             

--- a/src/js/tabs/osd.js
+++ b/src/js/tabs/osd.js
@@ -234,6 +234,10 @@ FONT.upload = function ($progress) {
     // tabs mid-upload; cleared once the chain settles (success or failure) below
     var protectedSaveToken = MSP.beginProtectedSave();
     return Promise.mapSeries(FONT.data.characters, function (data, i) {
+        // a full upload (hundreds of characters) can legitimately run longer than one watchdog
+        // window, so refresh it on every character instead of racing a single fixed timeout
+        // against the whole loop — only a stalled character write should expire protection
+        MSP.touchProtectedSave(protectedSaveToken);
         $progress.val((i / FONT.data.characters.length) * 100);
         return MSP.promise(MSPCodes.MSP_OSD_CHAR_WRITE, FONT.msp.encode(i));
     })

--- a/src/js/tabs/osd.js
+++ b/src/js/tabs/osd.js
@@ -232,7 +232,7 @@ FONT.msp = {
 FONT.upload = function ($progress) {
     // protect this multi-step upload+reboot chain from being abandoned if the user switches
     // tabs mid-upload; cleared once the chain settles (success or failure) below
-    MSP.saveInProgress = true;
+    MSP.beginProtectedSave();
     return Promise.mapSeries(FONT.data.characters, function (data, i) {
         $progress.val((i / FONT.data.characters.length) * 100);
         return MSP.promise(MSPCodes.MSP_OSD_CHAR_WRITE, FONT.msp.encode(i));
@@ -247,11 +247,11 @@ FONT.upload = function ($progress) {
             return MSP.promise(MSPCodes.MSP_SET_REBOOT);
         })
         .then(function (result) {
-            MSP.saveInProgress = false;
+            MSP.endProtectedSave();
             return result;
         })
         .catch(function (error) {
-            MSP.saveInProgress = false;
+            MSP.endProtectedSave();
             throw error;
         });
 };
@@ -2904,13 +2904,13 @@ TABS.osd.initialize = function (callback) {
         $('a.save').click(function () {
             var self = this;
             // protect this save from being abandoned if the user switches tabs before the FC responds
-            MSP.saveInProgress = true;
+            MSP.beginProtectedSave();
             MSP.promise(MSPCodes.MSP_EEPROM_WRITE)
                 .then(function () {
-                    MSP.saveInProgress = false;
+                    MSP.endProtectedSave();
                 })
                 .catch(function (error) {
-                    MSP.saveInProgress = false;
+                    MSP.endProtectedSave();
                     console.error(error);
                 });
             GUI.log(i18n.getMessage('osdSettingsSaved'));

--- a/src/js/tabs/osd.js
+++ b/src/js/tabs/osd.js
@@ -230,6 +230,9 @@ FONT.msp = {
 };
 
 FONT.upload = function ($progress) {
+    // protect this multi-step upload+reboot chain from being abandoned if the user switches
+    // tabs mid-upload; cleared once the chain settles (success or failure) below
+    MSP.saveInProgress = true;
     return Promise.mapSeries(FONT.data.characters, function (data, i) {
         $progress.val((i / FONT.data.characters.length) * 100);
         return MSP.promise(MSPCodes.MSP_OSD_CHAR_WRITE, FONT.msp.encode(i));
@@ -242,6 +245,14 @@ FONT.upload = function ($progress) {
             OSD.GUI.fontManager.close();
 
             return MSP.promise(MSPCodes.MSP_SET_REBOOT);
+        })
+        .then(function (result) {
+            MSP.saveInProgress = false;
+            return result;
+        })
+        .catch(function (error) {
+            MSP.saveInProgress = false;
+            throw error;
         });
 };
 
@@ -2892,7 +2903,16 @@ TABS.osd.initialize = function (callback) {
 
         $('a.save').click(function () {
             var self = this;
-            MSP.promise(MSPCodes.MSP_EEPROM_WRITE);
+            // protect this save from being abandoned if the user switches tabs before the FC responds
+            MSP.saveInProgress = true;
+            MSP.promise(MSPCodes.MSP_EEPROM_WRITE)
+                .then(function () {
+                    MSP.saveInProgress = false;
+                })
+                .catch(function (error) {
+                    MSP.saveInProgress = false;
+                    console.error(error);
+                });
             GUI.log(i18n.getMessage('osdSettingsSaved'));
             var oldText = $(this).text();
             $(this).html(i18n.getMessage('osdButtonSaved'));

--- a/src/js/tabs/osd.js
+++ b/src/js/tabs/osd.js
@@ -232,7 +232,7 @@ FONT.msp = {
 FONT.upload = function ($progress) {
     // protect this multi-step upload+reboot chain from being abandoned if the user switches
     // tabs mid-upload; cleared once the chain settles (success or failure) below
-    MSP.beginProtectedSave();
+    var protectedSaveToken = MSP.beginProtectedSave();
     return Promise.mapSeries(FONT.data.characters, function (data, i) {
         $progress.val((i / FONT.data.characters.length) * 100);
         return MSP.promise(MSPCodes.MSP_OSD_CHAR_WRITE, FONT.msp.encode(i));
@@ -248,10 +248,10 @@ FONT.upload = function ($progress) {
             // connection before any ack can arrive, so waiting on a promise for it only produces
             // an unhandled rejection once disconnect_cleanup() settles it.
             MSP.send_message(MSPCodes.MSP_SET_REBOOT, false, false);
-            MSP.endProtectedSave();
+            MSP.endProtectedSave(protectedSaveToken);
         })
         .catch(function (error) {
-            MSP.endProtectedSave();
+            MSP.endProtectedSave(protectedSaveToken);
             throw error;
         });
 };
@@ -2904,13 +2904,13 @@ TABS.osd.initialize = function (callback) {
         $('a.save').click(function () {
             var self = this;
             // protect this save from being abandoned if the user switches tabs before the FC responds
-            MSP.beginProtectedSave();
+            var protectedSaveToken = MSP.beginProtectedSave();
             MSP.promise(MSPCodes.MSP_EEPROM_WRITE)
                 .then(function () {
-                    MSP.endProtectedSave();
+                    MSP.endProtectedSave(protectedSaveToken);
                 })
                 .catch(function (error) {
-                    MSP.endProtectedSave();
+                    MSP.endProtectedSave(protectedSaveToken);
                     console.error(error);
                 });
             GUI.log(i18n.getMessage('osdSettingsSaved'));

--- a/src/js/tabs/osd.js
+++ b/src/js/tabs/osd.js
@@ -244,11 +244,11 @@ FONT.upload = function ($progress) {
 
             OSD.GUI.fontManager.close();
 
-            return MSP.promise(MSPCodes.MSP_SET_REBOOT);
-        })
-        .then(function (result) {
+            // fire-and-forget, matching every other tab's reboot dispatch: a reboot severs the
+            // connection before any ack can arrive, so waiting on a promise for it only produces
+            // an unhandled rejection once disconnect_cleanup() settles it.
+            MSP.send_message(MSPCodes.MSP_SET_REBOOT, false, false);
             MSP.endProtectedSave();
-            return result;
         })
         .catch(function (error) {
             MSP.endProtectedSave();

--- a/src/js/tabs/pid_tuning.js
+++ b/src/js/tabs/pid_tuning.js
@@ -2817,7 +2817,7 @@ TABS.pid_tuning.initialize = function(callback) {
             self.updating = true;
             // protect this save chain (through EEPROM_WRITE + reboot) from being abandoned if the
             // user switches tabs before the FC responds; cleared once EEPROM_WRITE completes below
-            MSP.beginProtectedSave();
+            var protectedSaveToken = MSP.beginProtectedSave();
             Promise.resolve(true)
                 .then(function() {
                     var promise;
@@ -2887,9 +2887,9 @@ TABS.pid_tuning.initialize = function(callback) {
                             reinitialiseConnection(self);
                         });
                     }
-                    MSP.endProtectedSave();
+                    MSP.endProtectedSave(protectedSaveToken);
                 }).catch(function(error) {
-                    MSP.endProtectedSave();
+                    MSP.endProtectedSave(protectedSaveToken);
                     self.updating = false;
                     console.error(error);
                 });
@@ -3032,7 +3032,11 @@ TABS.pid_tuning.refresh = function(callback) {
             FEATURE_CONFIG.features.setMask(existingEepromFeatureBitMask);
         }
         //end MSP 1.51 Experimental - Preset Dynamic_Filter toggle
-        self.initialize();
+        // this can fire from a protected save's deferred refresh after the user has switched
+        // tabs, so only reload pid_tuning's own DOM if it's still the active tab
+        if (GUI.active_tab === 'pid_tuning') {
+            self.initialize();
+        }
         self.setDirty(false);
         if (callback) {
             callback();

--- a/src/js/tabs/pid_tuning.js
+++ b/src/js/tabs/pid_tuning.js
@@ -2817,7 +2817,7 @@ TABS.pid_tuning.initialize = function(callback) {
             self.updating = true;
             // protect this save chain (through EEPROM_WRITE + reboot) from being abandoned if the
             // user switches tabs before the FC responds; cleared once EEPROM_WRITE completes below
-            MSP.saveInProgress = true;
+            MSP.beginProtectedSave();
             Promise.resolve(true)
                 .then(function() {
                     var promise;
@@ -2861,7 +2861,7 @@ TABS.pid_tuning.initialize = function(callback) {
                 }).then(function() {
                     return MSP.promise(MSPCodes.MSP_EEPROM_WRITE);
                 }).then(function() {
-                    MSP.saveInProgress = false;
+                    MSP.endProtectedSave();
                     self.updating = false;
                     self.setDirty(false);
 
@@ -2889,7 +2889,7 @@ TABS.pid_tuning.initialize = function(callback) {
                         });
                     }
                 }).catch(function(error) {
-                    MSP.saveInProgress = false;
+                    MSP.endProtectedSave();
                     self.updating = false;
                     console.error(error);
                 });

--- a/src/js/tabs/pid_tuning.js
+++ b/src/js/tabs/pid_tuning.js
@@ -2861,7 +2861,6 @@ TABS.pid_tuning.initialize = function(callback) {
                 }).then(function() {
                     return MSP.promise(MSPCodes.MSP_EEPROM_WRITE);
                 }).then(function() {
-                    MSP.endProtectedSave();
                     self.updating = false;
                     self.setDirty(false);
 
@@ -2888,6 +2887,7 @@ TABS.pid_tuning.initialize = function(callback) {
                             reinitialiseConnection(self);
                         });
                     }
+                    MSP.endProtectedSave();
                 }).catch(function(error) {
                     MSP.endProtectedSave();
                     self.updating = false;

--- a/src/js/tabs/pid_tuning.js
+++ b/src/js/tabs/pid_tuning.js
@@ -2815,6 +2815,9 @@ TABS.pid_tuning.initialize = function(callback) {
             form_to_pid_and_rc();
 
             self.updating = true;
+            // protect this save chain (through EEPROM_WRITE + reboot) from being abandoned if the
+            // user switches tabs before the FC responds; cleared once EEPROM_WRITE completes below
+            MSP.saveInProgress = true;
             Promise.resolve(true)
                 .then(function() {
                     var promise;
@@ -2858,6 +2861,7 @@ TABS.pid_tuning.initialize = function(callback) {
                 }).then(function() {
                     return MSP.promise(MSPCodes.MSP_EEPROM_WRITE);
                 }).then(function() {
+                    MSP.saveInProgress = false;
                     self.updating = false;
                     self.setDirty(false);
 
@@ -2884,6 +2888,10 @@ TABS.pid_tuning.initialize = function(callback) {
                             reinitialiseConnection(self);
                         });
                     }
+                }).catch(function(error) {
+                    MSP.saveInProgress = false;
+                    self.updating = false;
+                    console.error(error);
                 });
         });
 

--- a/src/js/tabs/ports.js
+++ b/src/js/tabs/ports.js
@@ -382,14 +382,14 @@ TABS.ports.initialize = function (callback, scrollPosition) {
         }
 
         function on_saved_handler() {
-            MSP.endProtectedSave(protectedSaveToken);
-
             GUI.log(i18n.getMessage('configurationEepromSaved'));
 
             GUI.tab_switch_cleanup(function() {
                 MSP.send_message(MSPCodes.MSP_SET_REBOOT, false, false);
                 reinitialiseConnection(self);
             });
+
+            MSP.endProtectedSave(protectedSaveToken);
         }
     }
 };

--- a/src/js/tabs/ports.js
+++ b/src/js/tabs/ports.js
@@ -300,7 +300,7 @@ TABS.ports.initialize = function (callback, scrollPosition) {
    function on_save_handler() {
         // protect this save chain (through EEPROM_WRITE + reboot) from being abandoned if the
         // user switches tabs before the FC responds; cleared once EEPROM_WRITE completes below
-        MSP.saveInProgress = true;
+        MSP.beginProtectedSave();
 
         // update configuration based on current ui state
         SERIAL_CONFIG.ports = [];
@@ -382,7 +382,7 @@ TABS.ports.initialize = function (callback, scrollPosition) {
         }
 
         function on_saved_handler() {
-            MSP.saveInProgress = false;
+            MSP.endProtectedSave();
 
             GUI.log(i18n.getMessage('configurationEepromSaved'));
 

--- a/src/js/tabs/ports.js
+++ b/src/js/tabs/ports.js
@@ -300,7 +300,7 @@ TABS.ports.initialize = function (callback, scrollPosition) {
    function on_save_handler() {
         // protect this save chain (through EEPROM_WRITE + reboot) from being abandoned if the
         // user switches tabs before the FC responds; cleared once EEPROM_WRITE completes below
-        MSP.beginProtectedSave();
+        var protectedSaveToken = MSP.beginProtectedSave();
 
         // update configuration based on current ui state
         SERIAL_CONFIG.ports = [];
@@ -382,7 +382,7 @@ TABS.ports.initialize = function (callback, scrollPosition) {
         }
 
         function on_saved_handler() {
-            MSP.endProtectedSave();
+            MSP.endProtectedSave(protectedSaveToken);
 
             GUI.log(i18n.getMessage('configurationEepromSaved'));
 

--- a/src/js/tabs/ports.js
+++ b/src/js/tabs/ports.js
@@ -298,6 +298,10 @@ TABS.ports.initialize = function (callback, scrollPosition) {
     }
 
    function on_save_handler() {
+        // protect this save chain (through EEPROM_WRITE + reboot) from being abandoned if the
+        // user switches tabs before the FC responds; cleared once EEPROM_WRITE completes below
+        MSP.saveInProgress = true;
+
         // update configuration based on current ui state
         SERIAL_CONFIG.ports = [];
 
@@ -378,6 +382,8 @@ TABS.ports.initialize = function (callback, scrollPosition) {
         }
 
         function on_saved_handler() {
+            MSP.saveInProgress = false;
+
             GUI.log(i18n.getMessage('configurationEepromSaved'));
 
             GUI.tab_switch_cleanup(function() {

--- a/src/js/tabs/power.js
+++ b/src/js/tabs/power.js
@@ -6,6 +6,7 @@ TABS.power = {
 
 TABS.power.initialize = function (callback) {
     var self = this;
+    var protectedSaveToken; // set by the save handler below, read by save_completed()
 
     if (GUI.active_tab != 'power') {
         GUI.active_tab = 'power';
@@ -414,7 +415,7 @@ TABS.power.initialize = function (callback) {
         $('a.save').click(function () {
             // protect this save chain (through EEPROM_WRITE) from being abandoned if the
             // user switches tabs before the FC responds; cleared in save_completed() below
-            MSP.beginProtectedSave();
+            protectedSaveToken = MSP.beginProtectedSave();
 
             for (var index = 0; index < VOLTAGE_METER_CONFIGS.length; index++) {
                 VOLTAGE_METER_CONFIGS[index].vbatscale = parseInt($('input[name="vbatscale-' + index + '"]').val());
@@ -464,10 +465,14 @@ TABS.power.initialize = function (callback) {
         }
 
         function save_completed() {
-            MSP.endProtectedSave();
+            MSP.endProtectedSave(protectedSaveToken);
             GUI.log(i18n.getMessage('configurationEepromSaved'));
 
-            TABS.power.initialize();
+            // this callback survives a tab switch (protected save), so only refresh Power if
+            // it's still the tab the user is actually looking at
+            if (GUI.active_tab === 'power') {
+                TABS.power.initialize();
+            }
         }
 
         save_battery_config();

--- a/src/js/tabs/power.js
+++ b/src/js/tabs/power.js
@@ -6,7 +6,6 @@ TABS.power = {
 
 TABS.power.initialize = function (callback) {
     var self = this;
-    var protectedSaveToken; // set by the save handler below, read by save_completed()
 
     if (GUI.active_tab != 'power') {
         GUI.active_tab = 'power';
@@ -414,8 +413,10 @@ TABS.power.initialize = function (callback) {
 
         $('a.save').click(function () {
             // protect this save chain (through EEPROM_WRITE) from being abandoned if the
-            // user switches tabs before the FC responds; cleared in save_completed() below
-            protectedSaveToken = MSP.beginProtectedSave();
+            // user switches tabs before the FC responds; cleared in save_completed() below.
+            // Scoped to this click's own closure (not a shared variable) so a second click
+            // before this one settles can't overwrite the token this chain needs to release.
+            var protectedSaveToken = MSP.beginProtectedSave();
 
             for (var index = 0; index < VOLTAGE_METER_CONFIGS.length; index++) {
                 VOLTAGE_METER_CONFIGS[index].vbatscale = parseInt($('input[name="vbatscale-' + index + '"]').val());
@@ -433,13 +434,16 @@ TABS.power.initialize = function (callback) {
             BATTERY_CONFIG.vbatwarningcellvoltage = parseFloat($('input[name="warningcellvoltage"]').val());
             BATTERY_CONFIG.capacity = parseInt($('input[name="capacity"]').val());
 
-            save_power_config();
+            save_power_config(protectedSaveToken);
         });
 
         GUI.interval_add('setup_data_pull_slow', get_slow_data, 200, true); // 5hz
     }
 
-    function save_power_config() {
+    // token is a parameter here (not the old shared closure variable) so every function nested
+    // below reads the token belonging to THIS invocation's click, even if another click starts
+    // and finishes a separate save_power_config() call before this one settles
+    function save_power_config(token) {
         function save_battery_config() {
             MSP.send_message(MSPCodes.MSP_SET_BATTERY_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_BATTERY_CONFIG), false, save_voltage_config);
         }
@@ -465,7 +469,7 @@ TABS.power.initialize = function (callback) {
         }
 
         function save_completed() {
-            MSP.endProtectedSave(protectedSaveToken);
+            MSP.endProtectedSave(token);
             GUI.log(i18n.getMessage('configurationEepromSaved'));
 
             // this callback survives a tab switch (protected save), so only refresh Power if

--- a/src/js/tabs/power.js
+++ b/src/js/tabs/power.js
@@ -412,6 +412,10 @@ TABS.power.initialize = function (callback) {
         });
 
         $('a.save').click(function () {
+            // protect this save chain (through EEPROM_WRITE) from being abandoned if the
+            // user switches tabs before the FC responds; cleared in save_completed() below
+            MSP.saveInProgress = true;
+
             for (var index = 0; index < VOLTAGE_METER_CONFIGS.length; index++) {
                 VOLTAGE_METER_CONFIGS[index].vbatscale = parseInt($('input[name="vbatscale-' + index + '"]').val());
                 VOLTAGE_METER_CONFIGS[index].vbatresdivval = parseInt($('input[name="vbatresdivval-' + index + '"]').val());
@@ -460,6 +464,7 @@ TABS.power.initialize = function (callback) {
         }
 
         function save_completed() {
+            MSP.saveInProgress = false;
             GUI.log(i18n.getMessage('configurationEepromSaved'));
 
             TABS.power.initialize();

--- a/src/js/tabs/power.js
+++ b/src/js/tabs/power.js
@@ -414,7 +414,7 @@ TABS.power.initialize = function (callback) {
         $('a.save').click(function () {
             // protect this save chain (through EEPROM_WRITE) from being abandoned if the
             // user switches tabs before the FC responds; cleared in save_completed() below
-            MSP.saveInProgress = true;
+            MSP.beginProtectedSave();
 
             for (var index = 0; index < VOLTAGE_METER_CONFIGS.length; index++) {
                 VOLTAGE_METER_CONFIGS[index].vbatscale = parseInt($('input[name="vbatscale-' + index + '"]').val());
@@ -464,7 +464,7 @@ TABS.power.initialize = function (callback) {
         }
 
         function save_completed() {
-            MSP.saveInProgress = false;
+            MSP.endProtectedSave();
             GUI.log(i18n.getMessage('configurationEepromSaved'));
 
             TABS.power.initialize();

--- a/src/js/tabs/receiver.js
+++ b/src/js/tabs/receiver.js
@@ -239,7 +239,7 @@ TABS.receiver.initialize = function (callback) {
         $('a.update').click(function () {
             // protect this save chain (through EEPROM_WRITE) from being abandoned if the
             // user switches tabs before the FC responds; cleared once EEPROM_WRITE completes below
-            MSP.saveInProgress = true;
+            MSP.beginProtectedSave();
 
             if (semver.gte(CONFIG.apiVersion, "1.15.0")) {
                 RX_CONFIG.stick_max = parseInt($('.sticks input[name="stick_max"]').val());
@@ -305,7 +305,7 @@ TABS.receiver.initialize = function (callback) {
 
             function save_to_eeprom() {
                 MSP.send_message(MSPCodes.MSP_EEPROM_WRITE, false, false, function () {
-                    MSP.saveInProgress = false;
+                    MSP.endProtectedSave();
                     GUI.log(i18n.getMessage('receiverEepromSaved'));
                 });
             }

--- a/src/js/tabs/receiver.js
+++ b/src/js/tabs/receiver.js
@@ -237,6 +237,10 @@ TABS.receiver.initialize = function (callback) {
         });
 
         $('a.update').click(function () {
+            // protect this save chain (through EEPROM_WRITE) from being abandoned if the
+            // user switches tabs before the FC responds; cleared once EEPROM_WRITE completes below
+            MSP.saveInProgress = true;
+
             if (semver.gte(CONFIG.apiVersion, "1.15.0")) {
                 RX_CONFIG.stick_max = parseInt($('.sticks input[name="stick_max"]').val());
                 RX_CONFIG.stick_center = parseInt($('.sticks input[name="stick_center"]').val());
@@ -301,6 +305,7 @@ TABS.receiver.initialize = function (callback) {
 
             function save_to_eeprom() {
                 MSP.send_message(MSPCodes.MSP_EEPROM_WRITE, false, false, function () {
+                    MSP.saveInProgress = false;
                     GUI.log(i18n.getMessage('receiverEepromSaved'));
                 });
             }

--- a/src/js/tabs/receiver.js
+++ b/src/js/tabs/receiver.js
@@ -239,7 +239,7 @@ TABS.receiver.initialize = function (callback) {
         $('a.update').click(function () {
             // protect this save chain (through EEPROM_WRITE) from being abandoned if the
             // user switches tabs before the FC responds; cleared once EEPROM_WRITE completes below
-            MSP.beginProtectedSave();
+            var protectedSaveToken = MSP.beginProtectedSave();
 
             if (semver.gte(CONFIG.apiVersion, "1.15.0")) {
                 RX_CONFIG.stick_max = parseInt($('.sticks input[name="stick_max"]').val());
@@ -305,7 +305,7 @@ TABS.receiver.initialize = function (callback) {
 
             function save_to_eeprom() {
                 MSP.send_message(MSPCodes.MSP_EEPROM_WRITE, false, false, function () {
-                    MSP.endProtectedSave();
+                    MSP.endProtectedSave(protectedSaveToken);
                     GUI.log(i18n.getMessage('receiverEepromSaved'));
                 });
             }

--- a/src/js/tabs/servos.js
+++ b/src/js/tabs/servos.js
@@ -105,8 +105,9 @@ TABS.servos.initialize = function (callback) {
         function servos_update(save_configuration_to_eeprom) {
             // protect this save chain (through EEPROM_WRITE) from being abandoned if the
             // user switches tabs before the FC responds; cleared once EEPROM_WRITE completes below
+            var protectedSaveToken;
             if (save_configuration_to_eeprom) {
-                MSP.beginProtectedSave();
+                protectedSaveToken = MSP.beginProtectedSave();
             }
 
             $('div.tab-servos table.fields tr:not(".main")').each(function () {
@@ -142,7 +143,7 @@ TABS.servos.initialize = function (callback) {
             function save_to_eeprom() {
                 if (save_configuration_to_eeprom) {
                     MSP.send_message(MSPCodes.MSP_EEPROM_WRITE, false, false, function () {
-                        MSP.endProtectedSave();
+                        MSP.endProtectedSave(protectedSaveToken);
                         GUI.log(i18n.getMessage('servosEepromSave'));
                     });
                 }

--- a/src/js/tabs/servos.js
+++ b/src/js/tabs/servos.js
@@ -106,7 +106,7 @@ TABS.servos.initialize = function (callback) {
             // protect this save chain (through EEPROM_WRITE) from being abandoned if the
             // user switches tabs before the FC responds; cleared once EEPROM_WRITE completes below
             if (save_configuration_to_eeprom) {
-                MSP.saveInProgress = true;
+                MSP.beginProtectedSave();
             }
 
             $('div.tab-servos table.fields tr:not(".main")').each(function () {
@@ -142,7 +142,7 @@ TABS.servos.initialize = function (callback) {
             function save_to_eeprom() {
                 if (save_configuration_to_eeprom) {
                     MSP.send_message(MSPCodes.MSP_EEPROM_WRITE, false, false, function () {
-                        MSP.saveInProgress = false;
+                        MSP.endProtectedSave();
                         GUI.log(i18n.getMessage('servosEepromSave'));
                     });
                 }

--- a/src/js/tabs/servos.js
+++ b/src/js/tabs/servos.js
@@ -103,6 +103,12 @@ TABS.servos.initialize = function (callback) {
         }
 
         function servos_update(save_configuration_to_eeprom) {
+            // protect this save chain (through EEPROM_WRITE) from being abandoned if the
+            // user switches tabs before the FC responds; cleared once EEPROM_WRITE completes below
+            if (save_configuration_to_eeprom) {
+                MSP.saveInProgress = true;
+            }
+
             $('div.tab-servos table.fields tr:not(".main")').each(function () {
                 var info = $(this).data('info');
 
@@ -136,6 +142,7 @@ TABS.servos.initialize = function (callback) {
             function save_to_eeprom() {
                 if (save_configuration_to_eeprom) {
                     MSP.send_message(MSPCodes.MSP_EEPROM_WRITE, false, false, function () {
+                        MSP.saveInProgress = false;
                         GUI.log(i18n.getMessage('servosEepromSave'));
                     });
                 }

--- a/src/js/tabs/transponder.js
+++ b/src/js/tabs/transponder.js
@@ -293,12 +293,17 @@ TABS.transponder.initialize = function(callback, scrollPosition) {
             $('a.save').click(function() {
                 let _this = this;
 
+                // protect this save chain (through EEPROM_WRITE + reboot) from being abandoned if the
+                // user switches tabs before the FC responds; cleared once EEPROM_WRITE completes below
+                MSP.saveInProgress = true;
+
                 function save_transponder_data() {
                     MSP.send_message(MSPCodes.MSP_SET_TRANSPONDER_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_TRANSPONDER_CONFIG), false, save_to_eeprom);
                 }
 
                 function save_to_eeprom() {
                     MSP.send_message(MSPCodes.MSP_EEPROM_WRITE, false, false, function() {
+                        MSP.saveInProgress = false;
                         GUI.log(i18n.getMessage('transponderEepromSaved'));
                         if ( $(_this).hasClass('reboot') ) {
                             GUI.tab_switch_cleanup(function() {

--- a/src/js/tabs/transponder.js
+++ b/src/js/tabs/transponder.js
@@ -300,7 +300,6 @@ TABS.transponder.initialize = function(callback, scrollPosition) {
 
                 function save_to_eeprom() {
                     MSP.send_message(MSPCodes.MSP_EEPROM_WRITE, false, false, function() {
-                        MSP.endProtectedSave(protectedSaveToken);
                         GUI.log(i18n.getMessage('transponderEepromSaved'));
                         if ( $(_this).hasClass('reboot') ) {
                             GUI.tab_switch_cleanup(function() {
@@ -308,6 +307,7 @@ TABS.transponder.initialize = function(callback, scrollPosition) {
                                 reinitialiseConnection(self);
                             });
                         }
+                        MSP.endProtectedSave(protectedSaveToken);
                     });
                 }
 

--- a/src/js/tabs/transponder.js
+++ b/src/js/tabs/transponder.js
@@ -295,7 +295,7 @@ TABS.transponder.initialize = function(callback, scrollPosition) {
 
                 // protect this save chain (through EEPROM_WRITE + reboot) from being abandoned if the
                 // user switches tabs before the FC responds; cleared once EEPROM_WRITE completes below
-                MSP.beginProtectedSave();
+                var protectedSaveToken = MSP.beginProtectedSave();
 
                 function save_transponder_data() {
                     MSP.send_message(MSPCodes.MSP_SET_TRANSPONDER_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_TRANSPONDER_CONFIG), false, save_to_eeprom);
@@ -303,7 +303,7 @@ TABS.transponder.initialize = function(callback, scrollPosition) {
 
                 function save_to_eeprom() {
                     MSP.send_message(MSPCodes.MSP_EEPROM_WRITE, false, false, function() {
-                        MSP.endProtectedSave();
+                        MSP.endProtectedSave(protectedSaveToken);
                         GUI.log(i18n.getMessage('transponderEepromSaved'));
                         if ( $(_this).hasClass('reboot') ) {
                             GUI.tab_switch_cleanup(function() {

--- a/src/js/tabs/transponder.js
+++ b/src/js/tabs/transponder.js
@@ -295,7 +295,7 @@ TABS.transponder.initialize = function(callback, scrollPosition) {
 
                 // protect this save chain (through EEPROM_WRITE + reboot) from being abandoned if the
                 // user switches tabs before the FC responds; cleared once EEPROM_WRITE completes below
-                MSP.saveInProgress = true;
+                MSP.beginProtectedSave();
 
                 function save_transponder_data() {
                     MSP.send_message(MSPCodes.MSP_SET_TRANSPONDER_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_TRANSPONDER_CONFIG), false, save_to_eeprom);
@@ -303,7 +303,7 @@ TABS.transponder.initialize = function(callback, scrollPosition) {
 
                 function save_to_eeprom() {
                     MSP.send_message(MSPCodes.MSP_EEPROM_WRITE, false, false, function() {
-                        MSP.saveInProgress = false;
+                        MSP.endProtectedSave();
                         GUI.log(i18n.getMessage('transponderEepromSaved'));
                         if ( $(_this).hasClass('reboot') ) {
                             GUI.tab_switch_cleanup(function() {

--- a/src/js/tabs/transponder.js
+++ b/src/js/tabs/transponder.js
@@ -292,10 +292,7 @@ TABS.transponder.initialize = function(callback, scrollPosition) {
 
             $('a.save').click(function() {
                 let _this = this;
-
-                // protect this save chain (through EEPROM_WRITE + reboot) from being abandoned if the
-                // user switches tabs before the FC responds; cleared once EEPROM_WRITE completes below
-                var protectedSaveToken = MSP.beginProtectedSave();
+                var protectedSaveToken;
 
                 function save_transponder_data() {
                     MSP.send_message(MSPCodes.MSP_SET_TRANSPONDER_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_TRANSPONDER_CONFIG), false, save_to_eeprom);
@@ -319,6 +316,11 @@ TABS.transponder.initialize = function(callback, scrollPosition) {
                     }).dataLength ) {
                     GUI.log(i18n.getMessage('transponderDataInvalid'));
                 } else {
+                    // protect this save chain (through EEPROM_WRITE + reboot) from being abandoned if the
+                    // user switches tabs before the FC responds; cleared once EEPROM_WRITE completes above.
+                    // Only armed once validation passes, so a rejected save doesn't leave a stray token
+                    // protecting unrelated traffic until its watchdog expires.
+                    protectedSaveToken = MSP.beginProtectedSave();
                     save_transponder_data();
                 }
             });

--- a/src/js/tabs/vtx.js
+++ b/src/js/tabs/vtx.js
@@ -275,7 +275,7 @@ TABS.vtx.initialize = function(callback) {
         self.updating = true;
         // protect this save chain (through EEPROM_WRITE) from being abandoned if the
         // user switches tabs before the FC responds; cleared in save_completed() below
-        MSP.beginProtectedSave();
+        var protectedSaveToken = MSP.beginProtectedSave();
         dump_html_to_msp();
 
         //console.log('save_vtx(): type:'+VTX_CONFIG.vtx_type
@@ -301,7 +301,7 @@ TABS.vtx.initialize = function(callback) {
 
         function save_completed() {
             //console.log('enter save_completed()');
-            MSP.endProtectedSave();
+            MSP.endProtectedSave(protectedSaveToken);
             GUI.log(i18n.getMessage('configurationEepromSaved'));
             const oldText = $("#save_button").text();
             $("#save_button").html(i18n.getMessage('vtxButtonSaved'));
@@ -311,13 +311,19 @@ TABS.vtx.initialize = function(callback) {
                 clearTimeout(saveTimeout);
             }, 2000);
 
-            TABS.vtx.initialize();
+            // this callback survives a tab switch (protected save), so only refresh VTX if
+            // it's still the tab the user is actually looking at
+            if (GUI.active_tab === 'vtx') {
+                TABS.vtx.initialize();
+            }
 
             // if pitmode, then wait and refresh again (is 3000ms enough?)
             if (VTX_CONFIG.vtx_pit_mode) {
                 //console.log('pitmode true, pause and refresh again due to slow VTX setting');
                 let refreshTimeout = setTimeout(function() {
-                    TABS.vtx.initialize();
+                    if (GUI.active_tab === 'vtx') {
+                        TABS.vtx.initialize();
+                    }
                     clearTimeout(refreshTimeout);
                 }, 3000);
             }

--- a/src/js/tabs/vtx.js
+++ b/src/js/tabs/vtx.js
@@ -275,7 +275,7 @@ TABS.vtx.initialize = function(callback) {
         self.updating = true;
         // protect this save chain (through EEPROM_WRITE) from being abandoned if the
         // user switches tabs before the FC responds; cleared in save_completed() below
-        MSP.saveInProgress = true;
+        MSP.beginProtectedSave();
         dump_html_to_msp();
 
         //console.log('save_vtx(): type:'+VTX_CONFIG.vtx_type
@@ -301,7 +301,7 @@ TABS.vtx.initialize = function(callback) {
 
         function save_completed() {
             //console.log('enter save_completed()');
-            MSP.saveInProgress = false;
+            MSP.endProtectedSave();
             GUI.log(i18n.getMessage('configurationEepromSaved'));
             const oldText = $("#save_button").text();
             $("#save_button").html(i18n.getMessage('vtxButtonSaved'));

--- a/src/js/tabs/vtx.js
+++ b/src/js/tabs/vtx.js
@@ -273,6 +273,9 @@ TABS.vtx.initialize = function(callback) {
     function save_vtx() {
         //console.log('enter save_vtx()');
         self.updating = true;
+        // protect this save chain (through EEPROM_WRITE) from being abandoned if the
+        // user switches tabs before the FC responds; cleared in save_completed() below
+        MSP.saveInProgress = true;
         dump_html_to_msp();
 
         //console.log('save_vtx(): type:'+VTX_CONFIG.vtx_type
@@ -298,6 +301,7 @@ TABS.vtx.initialize = function(callback) {
 
         function save_completed() {
             //console.log('enter save_completed()');
+            MSP.saveInProgress = false;
             GUI.log(i18n.getMessage('configurationEepromSaved'));
             const oldText = $("#save_button").text();
             $("#save_button").html(i18n.getMessage('vtxButtonSaved'));


### PR DESCRIPTION
AI Generated pull-request

## Summary

Fixes #623. Switching tabs during an in-flight MSP save could silently abandon the save (including a save-and-reboot chain never actually rebooting), because `MSP.promise()` never had a reject path and `GUI.tab_switch_cleanup()`'s `MSP.callbacks_cleanup()` unconditionally wiped every pending MSP request on every tab switch — including one belonging to a save the user just clicked.

Acceptance criteria this PR was built against: switching tabs with no save in flight is fine to abandon pending reads (unchanged); clicking Save (including save-and-reboot) and then fast-switching tabs must not abandon or break the save, and a save-and-reboot must still reboot as intended.

- `MSP.promise()` now has a working reject path instead of hanging forever when a request is abandoned.
- New `MSP.beginProtectedSave()` / `endProtectedSave(token)` / `touchProtectedSave(token)`: a tab's save handler marks its save chain as protected for its duration (through `MSP_EEPROM_WRITE` and, for save-and-reboot flows, the reboot dispatch). Requests issued while protected survive `callbacks_cleanup()` on a tab switch instead of being abandoned. Protection is reference-counted (`MSP.activeSaveCount`) via a token returned from `beginProtectedSave()`, so two tabs' overlapping save chains — or two clicks of the same Save button — don't clear protection for each other. Each token has its own 15s watchdog so a chain that never settles (e.g. the FC never responds) can't leave protection stuck on forever; long-running loops (e.g. the OSD font upload's per-character requests) call `touchProtectedSave()` to refresh their token's watchdog so only a stalled step expires protection, not the loop's total duration. A real disconnect (`disconnect_cleanup()`) still clears everything unconditionally, since nothing can complete once the connection is gone.
- Applied across all 12 tabs with an EEPROM_WRITE save flow: `pid_tuning`, `ports`, `osd` (settings save + font upload), `configuration`, `failsafe`, `transponder`, `onboard_logging`, `adjustments`, `led_strip`, `receiver`, `vtx`, `power`, `auxiliary`, `servos`. In two of those (`onboard_logging`, `power`), the token is threaded through as an explicit function parameter rather than a shared variable, since a double-click before the first save's response arrived could otherwise overwrite it.
- Save-completion callbacks that reload their own tab's DOM (`TABS.power.initialize()`, `TABS.vtx.initialize()`, `pid_tuning`'s dynamic-filter refresh) now check `GUI.active_tab` first, since those callbacks can now fire after the user has switched to a different tab.
- `beginProtectedSave()` on the transponder tab is now only armed once its data-length validation passes, so a rejected save doesn't leave a stray protection token active until its watchdog expires.

Went through two local CodeRabbit review rounds, one GitHub CodeRabbit bot review round, and an independent self-audit of every begin/end call site; findings from all passes are fixed in follow-up commits on this branch — see PR comments for the itemized responses.

**Real-hardware verification**: tested OSD tab's "Upload Font" (256 sequential MSP round-trips, then reboot — the longest-running save chain in the app) with repeated fast tab-switches. A diagnostic log confirmed the protection mechanism actually engaged during the switches, the upload ran to completion, and the FC rebooted successfully. That test also surfaced and led to fixing one real defect: the font-upload's reboot dispatch used `MSP.promise()` instead of the fire-and-forget dispatch every other tab uses for reboot, which produced a harmless-but-alarming unhandled-rejection console trace once the reboot's own disconnect settled it. Fixed to match the rest of the codebase's convention.

**Honesty check on test coverage**: only the OSD font-upload path above has been exercised on real hardware. The other 11 tabs are verified by code reading, lint, syntax-check, and a headless boot only (no FC attached in headless mode, so no real MSP traffic is exercised there). The reentrant/overlapping-save path has no hardware test at all — it's a defensive fix for a review-identified code-level gap, not a response to an observed failure. Recommend at least a normal (non-racing) Save-and-Reboot smoke test on one more tab (e.g. Configuration or Failsafe) before merge.

**Known, deliberate non-goal**: MSP response dispatch (`MSPHelper.js` `process_data`) still matches by request code only, not request identity. Analyzed this in depth against how this app's save chains and MSP codes are actually structured and could not construct a realistic data-corruption or stability-breaking scenario from it in the current codebase (write acks here don't carry differentiated payload data the callbacks branch on, and the one shared write code across tabs, `MSP_EEPROM_WRITE`, already coalesces safely). Not addressed in this PR; would be a separate, evidence-driven follow-up if a real-world case ever surfaces.

**Known, accepted side effect**: some `MSP.promise()` call sites elsewhere in the app (e.g. ~10 in `osd.js`'s small per-field auto-saves) have no `.catch()`. Abandoning one via a normal, non-protected tab switch now produces a harmless "Unhandled rejection" console warning instead of the previous silent-forever hang. Strictly better (nothing leaks/hangs), but new console noise; not silenced everywhere, only where a real test surfaced actual impact (the font-upload reboot above).

## Test plan
- [x] `yarn lint` — 0 errors, same pre-existing warning baseline (685) as before this branch
- [x] Every changed file syntax-checked (`node --check`)
- [x] App boots headlessly (`xvfb-run yarn dev`) with no JS errors
- [x] Two local CodeRabbit review passes + one GitHub CodeRabbit bot review pass + one independent self-audit, all findings addressed
- [x] Hardware verification: fast tab-switch during OSD font-upload (save-and-reboot equivalent) on a real FC — confirmed working
- [ ] Hardware verification: a normal, non-racing Save-and-Reboot on any tab other than OSD (minimum recommended check before merge)
- [ ] Hardware verification: fast tab-switch during a plain tab's Save-and-Reboot (e.g. Configuration/Failsafe) — narrower race window, not yet tried
- [ ] Hardware verification: two overlapping saves from different tabs, or a double-click on one tab's Save button (reentrant protection paths) — not yet tried, no reported failure mode to reproduce against

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Save actions are now protected during tab switching, improving reliability of EEPROM write + reboot-style save flows across the UI.

* **Bug Fixes**
  * Enhanced save handling so in-flight operations are preserved when appropriate and properly released/canceled when switching tabs or disconnecting.
  * Improved reliability across configuration, receiver, power, OSD, VTX, LEDs, servos, transponder, failsafe, auxiliary, PID tuning, onboard logging, and adjustments.
  * Reduced noisy console errors for expected “abandoned before response” scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
