### PR TITLE
Remove misleading file-write log messages

### DIFF
--- a/main.js
+++ b/main.js
@@ -963,7 +963,7 @@ ipcMain.handle('dialog:write-binary-file', async (event, filePath, byteArray, is
   }
   // Log only on first write (start); suppress per-chunk logs
   if (isFirstWrite) {
-    console.log(`[BBL] Downloading blackbox log to: ${filePath}`);
+    console.log(`[FILE] Writing to: ${filePath}`);
   }
   return buffer.length;
 });
@@ -1000,7 +1000,6 @@ ipcMain.handle('dialog:truncate-file', async (event, filePath, size) => {
         throw err;
       }
     }
-    console.log(`Truncated ${filePath} to ${size} bytes`);
     return size;
   } catch (e) {
     console.error(`Truncate failed for ${filePath}:`, e.message);


### PR DESCRIPTION
AI Generated pull-request

## Summary
- Removed the `Truncated <path> to 0 bytes` log line — it fires whenever a save flow resets the destination file before writing (standard FileWriter `truncate(0)` pattern used by CLI/backup/firmware/OSD saves), but reads like an existing file's contents were wiped.
- Reworded the generic `[BBL] Downloading blackbox log to: <path>` log to `[FILE] Writing to: <path>`, since that handler is shared by CLI dumps, backups, firmware flashing, and OSD saves — not just blackbox log downloads.

## Test plan
- [x] `yarn dev`, trigger CLI "save output to file" and confirm log no longer shows misleading truncate/blackbox messages
- [x] Confirm actual blackbox log download still writes correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated console messaging for file-writing actions to use clearer, more consistent wording.
  * Removed a success log after file truncation to reduce unnecessary console noise.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->