### PR TITLE
Scope msp.js unhandled-rejection helpers inside an IIFE

### DIFF
--- a/src/js/msp.js
+++ b/src/js/msp.js
@@ -480,7 +480,11 @@ var MSP = {
 // disconnect_cleanup() above (tab switch or real disconnect, not a bug). This hook replaces
 // Bluebird's default reporter app-wide with calmer, explanatory logging for that specific case;
 // anything else still logs normally so a genuine bug is never silently hidden.
-if (window.Promise && typeof window.Promise.onPossiblyUnhandledRejection === 'function') {
+(function () {
+    if (!window.Promise || typeof window.Promise.onPossiblyUnhandledRejection !== 'function') {
+        return;
+    }
+
     var MSP_ABANDONED_REQUEST_PATTERN = /^MSP request (\d+) aborted before a response arrived \(tab switch or disconnect\)$/;
     var mspCodeNamesByValue = {};
     for (var mspCodeName in MSPCodes) {
@@ -496,4 +500,4 @@ if (window.Promise && typeof window.Promise.onPossiblyUnhandledRejection === 'fu
             console.error('Unhandled rejection:', error);
         }
     });
-}
+})();


### PR DESCRIPTION
AI Generated pull-request

Follow-up to #625. Codacy flagged `src/js/msp.js:487` ("avoid using global variables") on that PR after it merged: `MSP_ABANDONED_REQUEST_PATTERN`, `mspCodeNamesByValue`, and the `for...in` loop variable `mspCodeName` in the `onPossiblyUnhandledRejection` setup block were `var`-declared at the top level of `msp.js`, which has no IIFE/module wrapper anywhere, so they became real globals.

Wrapped the whole setup block in an IIFE so those three stay local to it instead. No behavior change — same guard condition (now an early return instead of a wrapping `if`), same logic, same log output for the abandoned-MSP-request case.

Verified: lint clean (0 errors), headless boot clean (`xvfb-run -a yarn dev`), no hardware testing needed since this is a pure scoping change with identical runtime behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved how unhandled promise rejection logging is initialized.
  * Kept the existing handling for “MSP request aborted” messages unchanged, while making the setup more robust when promise support is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->