### PR TITLE
fix(linux): strip stale usb build/Release before packaging

### DIFF
--- a/forge.config.js
+++ b/forge.config.js
@@ -57,6 +57,22 @@ module.exports = {
       const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
       packageJson.buildMode = buildMode;
       fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2) + '\n');
+
+      // Defense in depth for the usb/glibc issue documented in rebuildConfig below:
+      // ignoreModules prevents @electron/rebuild from creating a broken build/Release,
+      // but it can't undo one that already exists in a contributor's node_modules
+      // (e.g. left over from before this exclusion was added, or from an interrupted
+      // install). node-gyp-build always prefers a local build/Release over the correct
+      // prebuilt, so a stale one silently ships a binary that crashes with
+      // "undefined symbol: __pthread_cond_timedwait64" during real USB/DFU use.
+      // Strip it from the copied output so packaging is self-healing regardless of
+      // the source tree's node_modules state.
+      if (process.platform === 'linux') {
+        const usbBuildDir = path.join(buildPath, 'node_modules', 'usb', 'build');
+        if (fs.existsSync(usbBuildDir)) {
+          fs.rmSync(usbBuildDir, { recursive: true, force: true });
+        }
+      }
     },
   },
   rebuildConfig: {


### PR DESCRIPTION
AI Generated pull-request

## Summary
- PR #595 added `rebuildConfig.ignoreModules: ['usb']` on Linux to stop `@electron/rebuild` from recompiling `usb` from source, which produces a binary referencing the undefined glibc symbol `__pthread_cond_timedwait64` on glibc 2.34+ (Debian/Ubuntu). That guard only prevents *new* rebuilds — it does not remove a broken `node_modules/usb/build/Release` that already exists in a contributor's `node_modules` (e.g. left over from before the guard was added, or from an interrupted/partial `yarn install`). `node-gyp-build` always prefers a local `build/Release` over the correct prebuilt, so once that stale binary exists it silently ships forever, since `yarn install` never touches an already-satisfied package.
- Reproduced on real hardware: a package built from a `node_modules` that predated the #595 fix crashed the entire app with `symbol lookup error: undefined symbol: __pthread_cond_timedwait64` immediately after a successful `.hex` flash, during DFU error-recovery (`usb-control-transfer: device stalled`). This is a hard `ld.so` abort outside the V8/Node runtime — uncatchable from JS, no crash report, no console output beyond the terminal's stderr.
- A genuinely fresh `yarn install` does not reproduce this (verified: `usb`'s own `node-gyp-build` correctly resolves the `glibc`-tagged prebuild without compiling), and the CI release workflow never caches `node_modules` (only the yarn download cache and the Electron binary download), so official distributed releases are unaffected. This is a local-environment hazard specific to `yarn make:dev` on a contributor machine.
- Adds a `packageAfterCopy` hook step that removes `node_modules/usb/build` from the packaged output on Linux, so packaging is self-healing regardless of the state of the source tree's `node_modules` — no manual `node_modules` repair needed by any contributor, now or in the future.

## Root cause chain
1. Before #595, `@electron/rebuild`'s naive prebuild-matching (unaware of `usb@2.x`'s `node.napi.glibc.node` naming) always triggered a source rebuild of `usb` on Linux, producing a binary linked against the internal glibc symbol `__pthread_cond_timedwait64` (a `_TIME_BITS=64` redirect artifact, not exported by glibc).
2. #595 added `ignoreModules: ['usb']` on Linux to stop this rebuild going forward.
3. `node-gyp-build`'s runtime resolution (`node_modules/node-gyp-build/node-gyp-build.js`) unconditionally checks `build/Release` before `prebuilds/`, with no way to know a given `build/Release` is stale/broken.
4. Any `node_modules/usb/build/Release` created before the #595 fix landed (or by any future interrupted install) is therefore invisible to `ignoreModules` and keeps shadowing the correct prebuilt indefinitely.

## Test plan
- [x] Verified a fully fresh dependency reinstall (removing `node_modules` and reinstalling) never creates `node_modules/usb/build` (falls straight through to `prebuilds/linux-x64/node.napi.glibc.node`, symbol-checked via `nm -D` to reference only the safe versioned `pthread_cond_timedwait@GLIBC_2.3.2`)
- [x] `yarn make:dev` packaging succeeds with the new hook; extracted the resulting `.deb` and confirmed the shipped `usb.node` is the correct prebuilt with no `build/`, `build/Release`, or locally-compiled artifact present
- [x] Deliberately planted a fake `node_modules/usb/build/Release/usb_bindings.node` before packaging and confirmed the resulting `.deb` does **not** contain it (hook strips it from the copied output; source `node_modules` left untouched)
- [x] `yarn lint`: 0 errors on `forge.config.js` (pre-existing warnings elsewhere are unrelated, tracked in bug 618)
- [x] Hardware retest: reinstalled the rebuilt `.deb` and reproduced the exact DFU stall/error-recovery path that crashed before (`usb-control-transfer: device stalled (expected during DFU error recovery)`). App now exits cleanly (`[main.js] Process exiting with code 0`) instead of `symbol lookup error: undefined symbol: __pthread_cond_timedwait64`. Confirmed fixed on real hardware.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Linux packaging reliability by removing stale build artifacts during package preparation, helping ensure the app ships with the correct prebuilt files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
