### PR TITLE
locales/ru: add missing translation for configurationSensorGyroToUseNotFound

### DIFF
--- a/locales/ru/messages.json
+++ b/locales/ru/messages.json
@@ -779,6 +779,9 @@
     "configurationSensorAlignmentGyro": {
         "message": "Положение Гиро."
     },
+    "configurationSensorGyroToUseNotFound": {
+        "message": "Предупреждение: Гироскоп/Акселерометр не обнаружены"
+    },
     "configurationSensorAlignmentGyro1": {
         "message": "Первый ГИРО"
     },


### PR DESCRIPTION
AI Generated pull-request

## Summary
- Added the missing `configurationSensorGyroToUseNotFound` key to `locales/ru/messages.json`, positioned near the existing `configurationSensorAlignmentGyro*` keys to match the English source ordering.
- Confirmed pre-existing on `upstream/master` — not introduced by PR #608, which only removed dead keys, not translation gaps.

Closes #639

## Test plan
- [x] `node -e` JSON.parse validation of the modified locale file
- [x] `yarn lint`: 0 errors
- [x] Local CodeRabbit review (`coderabbit review --agent --base upstream/master`): 0 findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Russian translation for the warning shown when the gyro or accelerometer is not detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->