### PR TITLE
refactor: remove dead CONFIG.flightControllerVersion >= 0.0.1 gates

### DIFF
--- a/src/js/CliAutoComplete.js
+++ b/src/js/CliAutoComplete.js
@@ -418,12 +418,7 @@ CliAutoComplete._initTextcomplete = function() {
             match: /^(\s*resource\s+)(\w*)$/i,
             search:  function(term, callback, _match) {
                 sendOnEnter = false;
-                var arr = cache.resources;
-                if (semver.gte(CONFIG.flightControllerVersion, "0.0.1")) {
-                    arr = ['show'].concat(arr);
-                } else {
-                    arr = ['list'].concat(arr);
-                }
+                var arr = ['show'].concat(cache.resources);
                 searcher(term, callback, arr, 1);
             },
             replace: function(value) {
@@ -531,16 +526,14 @@ CliAutoComplete._initTextcomplete = function() {
         })
     ]);
 
-    if (semver.gte(CONFIG.flightControllerVersion, "0.0.1")) {
-        $textarea.textcomplete('register', [
-            strategy({ // "resource show all", from BF 4.0.0 onwards
-                match: /^(\s*resource\s+show\s+)(\w*)$/i,
-                search:  function(term, callback, _matches) {
-                    sendOnEnter = true;
-                    searcher(term, callback, ['all'], 1, true);
-                },
-                template: highlighterPrefix
-            }),
-        ]);
-    }
+    $textarea.textcomplete('register', [
+        strategy({ // "resource show all", from BF 4.0.0 onwards
+            match: /^(\s*resource\s+show\s+)(\w*)$/i,
+            search:  function(term, callback, _matches) {
+                sendOnEnter = true;
+                searcher(term, callback, ['all'], 1, true);
+            },
+            template: highlighterPrefix
+        }),
+    ]);
 };

--- a/src/js/tabs/configuration.js
+++ b/src/js/tabs/configuration.js
@@ -94,21 +94,11 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
     }
 
     function load_battery() {
-        var next_callback = load_current;
-        if (semver.gte(CONFIG.flightControllerVersion, "0.0.1")) {
-            MSP.send_message(MSPCodes.MSP_VOLTAGE_METER_CONFIG, false, false, next_callback);
-        } else {
-            next_callback();
-        }
+        MSP.send_message(MSPCodes.MSP_VOLTAGE_METER_CONFIG, false, false, load_current);
     }
 
     function load_current() {
-        var next_callback = load_rx_config;
-        if (semver.gte(CONFIG.flightControllerVersion, "0.0.1")) {
-            MSP.send_message(MSPCodes.MSP_CURRENT_METER_CONFIG, false, false, next_callback);
-        } else {
-            next_callback();
-        }
+        MSP.send_message(MSPCodes.MSP_CURRENT_METER_CONFIG, false, false, load_rx_config);
     }
 
     function load_rx_config() {
@@ -491,7 +481,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
 
         serialRXtypes.push('IBUS');
 
-        if ((CONFIG.flightControllerIdentifier === 'EMUF' && semver.gte(CONFIG.flightControllerVersion, "0.0.1"))) {
+        if (CONFIG.flightControllerIdentifier === 'EMUF') {
             serialRXtypes.push('JETIEXBUS');
         }
 
@@ -616,25 +606,21 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
 
         // fill battery
         if (self.SHOW_OLD_BATTERY_CONFIG) {
-            if (semver.gte(CONFIG.flightControllerVersion, "0.0.1")) {
-                var batteryMeterTypes = [
-                    'Onboard ADC',
-                    'ESC Sensor'
-                ];
+            var batteryMeterTypes = [
+                'Onboard ADC',
+                'ESC Sensor'
+            ];
 
-                var batteryMeterType_e = $('select.batterymetertype');
-                for (i = 0; i < batteryMeterTypes.length; i++) {
-                    batteryMeterType_e.append('<option value="' + i + '">' + batteryMeterTypes[i] + '</option>');
-                }
-
-                batteryMeterType_e.change(function () {
-                    MISC.batterymetertype = parseInt($(this).val());
-                    checkUpdateVbatControls();
-                });
-                batteryMeterType_e.val(MISC.batterymetertype).change();
-            } else {
-                $('div.batterymetertype').hide();
+            var batteryMeterType_e = $('select.batterymetertype');
+            for (i = 0; i < batteryMeterTypes.length; i++) {
+                batteryMeterType_e.append('<option value="' + i + '">' + batteryMeterTypes[i] + '</option>');
             }
+
+            batteryMeterType_e.change(function () {
+                MISC.batterymetertype = parseInt($(this).val());
+                checkUpdateVbatControls();
+            });
+            batteryMeterType_e.val(MISC.batterymetertype).change();
 
             $('input[name="mincellvoltage"]').val(MISC.vbatmincellvoltage);
             $('input[name="maxcellvoltage"]').val(MISC.vbatmaxcellvoltage);
@@ -648,9 +634,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
                 'Virtual'
             ];
 
-            if (semver.gte(CONFIG.flightControllerVersion, "0.0.1")) {
-                currentMeterTypes.push('ESC Sensor');
-            }
+            currentMeterTypes.push('ESC Sensor');
 
             var currentMeterType_e = $('select.currentmetertype');
             for (i = 0; i < currentMeterTypes.length; i++) {
@@ -674,14 +658,10 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
             if (FEATURE_CONFIG.features.isEnabled('VBAT')) {
                 $('.vbatmonitoring').show();
 
-                if (semver.gte(CONFIG.flightControllerVersion, "0.0.1")) {
-                     $('select.batterymetertype').show();
+                $('select.batterymetertype').show();
 
-                    if (MISC.batterymetertype !== 0) {
-                        $('.vbatCalibration').hide();
-                     }
-                } else {
-                    $('select.batterymetertype').hide();
+                if (MISC.batterymetertype !== 0) {
+                    $('.vbatCalibration').hide();
                 }
             } else {
                 $('.vbatmonitoring').hide();
@@ -996,21 +976,11 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
             }
 
             function save_battery() {
-                var next_callback = save_current;
-                if (semver.gte(CONFIG.flightControllerVersion, "0.0.1")) {
-                    MSP.send_message(MSPCodes.MSP_SET_VOLTAGE_METER_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_VOLTAGE_METER_CONFIG), false, next_callback);
-                } else {
-                    next_callback();
-                }
+                MSP.send_message(MSPCodes.MSP_SET_VOLTAGE_METER_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_VOLTAGE_METER_CONFIG), false, save_current);
             }
 
             function save_current() {
-                var next_callback = save_rx_config;
-                if (semver.gte(CONFIG.flightControllerVersion, "0.0.1")) {
-                    MSP.send_message(MSPCodes.MSP_SET_CURRENT_METER_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_CURRENT_METER_CONFIG), false, next_callback);
-                } else {
-                    next_callback();
-                }
+                MSP.send_message(MSPCodes.MSP_SET_CURRENT_METER_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_CURRENT_METER_CONFIG), false, save_rx_config);
             }
 
             function save_rx_config() {


### PR DESCRIPTION
AI Generated pull-request

## Summary
- Removed 10 dead `semver.gte(CONFIG.flightControllerVersion, "0.0.1")` gates: 8 in `configuration.js`, 2 in `CliAutoComplete.js`.
- `CONFIG.flightControllerVersion` is only ever populated (non-empty) after a full MSP connection completes (`MSP_FC_VERSION` response); at that point it always holds a real firmware semver string, always `>= "0.0.1"`. Verified `semver.gte('', "0.0.1")` throws rather than returning `false`, confirming the else branch could never execute.
- Each site collapsed to its always-taken branch, no other behavior change. `configuration.js`'s one compound condition (`flightControllerIdentifier === 'EMUF' && ...`) kept the identifier check, dropped only the version-gate half.
- Split out of #586/PR #608 (dead semver-gate removal) since these gates check firmware version rather than MSP API version, and needed independent CLI-safety verification (autocomplete suggestions only, unrelated to CLI tab connectivity).

Closes #637

## Test plan
- [x] `yarn lint`: 0 errors, 656 warnings (baseline unchanged)
- [x] `node -c` syntax check on both modified files
- [x] Local CodeRabbit review (`coderabbit review --agent --base upstream/master`): 1 finding, confirmed out of scope — flagged `SHOW_OLD_BATTERY_CONFIG` (a separate, unrelated flag hardcoded `false` since the initial commit) as further dead code; not touched by this PR