### PR TITLE
fix: guard throttle curve redraw against missing canvas element

### DIFF
--- a/src/js/tabs/pid_tuning.js
+++ b/src/js/tabs/pid_tuning.js
@@ -2402,8 +2402,13 @@ TABS.pid_tuning.initialize = function(callback) {
                     throttleExpoE = $('.throttle input[name="expo"]'),
                     mid = parseFloat(throttleMidE.val()),
                     expo = parseFloat(throttleExpoE.val()),
-                    throttleCurve = $('.throttle .throttle_curve canvas').get(0),
-                    context = throttleCurve.getContext("2d");
+                    throttleCurve = $('.throttle .throttle_curve canvas').get(0);
+
+                if (!throttleCurve) { // tab may have reinitialized before this deferred callback fired
+                    return;
+                }
+
+                var context = throttleCurve.getContext("2d");
 
                 // local validation to deal with input event
                 if (mid >= parseFloat(throttleMidE.prop('min')) &&


### PR DESCRIPTION
AI Generated pull-request

## Summary
- Added `if (!throttleCurve) { return; }` before `.getContext()` in the deferred `setTimeout(fn, 0)` throttle-curve redraw callback (`pid_tuning.js`, `.throttle input` handler).
- If the PID tuning tab's DOM is replaced (switch away, or a reinit via `initialize()`) before the deferred callback fires, `$('.throttle .throttle_curve canvas').get(0)` returns `undefined` and `.getContext()` throws.
- Confirmed pre-existing since 2019/2020 (`git blame`), not a regression from any recent PR.

Closes #628

## Test plan
- [x] `yarn lint`: 0 errors, 656 warnings (baseline unchanged)
- [x] `node -c` syntax check
- [x] Local CodeRabbit review (`coderabbit review --agent --base upstream/master`): 0 findings