### PR TITLE
refactor: remove dead SUPEREXPO_RATES feature-flag read

### DIFF
--- a/src/js/tabs/pid_tuning.js
+++ b/src/js/tabs/pid_tuning.js
@@ -1458,15 +1458,13 @@ TABS.pid_tuning.initialize = function(callback) {
             rc_yaw_expo: RC_tuning.RC_YAW_EXPO,
             rc_rate_pitch: RC_tuning.rcPitchRate,
             rc_pitch_expo: RC_tuning.RC_PITCH_EXPO,
-            superexpo: FEATURE_CONFIG.features.isEnabled('SUPEREXPO_RATES'),
+            superexpo: true, // Betaflight-style rate handler always applies the superexpo curve; no live FEATURE_CONFIG bit exists to gate it
             deadband: RC_DEADBAND_CONFIG.deadband,
             yawDeadband: RC_DEADBAND_CONFIG.yaw_deadband,
             roll_rate_limit: RC_tuning.roll_rate_limit,
             pitch_rate_limit: RC_tuning.pitch_rate_limit,
             yaw_rate_limit: RC_tuning.yaw_rate_limit
         };
-
-        self.currentRates.superexpo = true;
 
         $('.pid_tuning input[name="sensitivity"]').hide();
         $('.pid_tuning .levelSensitivityHeader').empty();


### PR DESCRIPTION
AI Generated pull-request

## Summary
- Removed `FEATURE_CONFIG.features.isEnabled('SUPEREXPO_RATES')` read in `pid_tuning.js`'s rate-curve preview init, which always returned `false` (no `SUPEREXPO_RATES` entry exists in `Features.js`'s feature list, nor in current EmuFlight firmware — vestigial name from an old Cleanflight-era `FEATURE_SUPEREXPO_RATES` bit) and was immediately discarded by the next line's unconditional `= true` override.
- Confirmed this is not a masking bug (contrary to the original CodeRabbit framing on PR #608): `RateCurve.js`'s Betaflight-style rate handler (`getBetaflightRates`) always applies the superexpo formula, and no live UI element ever sets this value to anything other than `true` — `pid_tuning.html` has no `SUPEREXPO_RATES` input, so the checkbox-change handler that would toggle it (`pid_tuning.js:2346`) is itself unreachable.
- Collapsed to the single value (`true`) that was ever actually in effect, no behavior change.

Closes #640

## Test plan
- [x] `yarn lint`: 0 errors, 656 warnings (baseline unchanged)
- [x] `node -c` syntax check
- [x] Manual source audit: confirmed no `SUPEREXPO_RATES` feature bit in `Features.js` or firmware, confirmed `RateCurve.js:99` branches meaningfully on this value, confirmed no live checkbox in `pid_tuning.html`