### PR TITLE
fix: CLI autocomplete no longer suggests unsupported resource show

### DIFF
--- a/src/js/CliAutoComplete.js
+++ b/src/js/CliAutoComplete.js
@@ -418,13 +418,13 @@ CliAutoComplete._initTextcomplete = function() {
             match: /^(\s*resource\s+)(\w*)$/i,
             search:  function(term, callback, _match) {
                 sendOnEnter = false;
-                var arr = ['show'].concat(cache.resources);
+                var arr = ['list'].concat(cache.resources);
                 searcher(term, callback, arr, 1);
             },
             replace: function(value) {
                 if (value in cache.resourcesCount) {
                     self.openLater();
-                } else if (value == 'list' || value == 'show') {
+                } else if (value == 'list') {
                     sendOnEnter = true;
                 }
                 return basicReplacer(value);
@@ -524,16 +524,5 @@ CliAutoComplete._initTextcomplete = function() {
                 searcher(term, callback, cache.mixers, 1);
             }
         })
-    ]);
-
-    $textarea.textcomplete('register', [
-        strategy({ // "resource show all", from BF 4.0.0 onwards
-            match: /^(\s*resource\s+show\s+)(\w*)$/i,
-            search:  function(term, callback, _matches) {
-                sendOnEnter = true;
-                searcher(term, callback, ['all'], 1, true);
-            },
-            template: highlighterPrefix
-        }),
     ]);
 };


### PR DESCRIPTION
AI Generated pull-request

## Summary
- EmuFlight firmware's `cliResource()` (`src/main/interface/cli.c:3928`) only recognizes bare `resource`, `resource list`, and a `<owner> <index> <pin>` set command — verified directly in firmware source. `resource show`/`resource show all` were never implemented; they were ported into the configurator's autocomplete from Betaflight 4.0+, which EmuFlight's fork predates.
- The version gate intended to detect BF 4.0+ support (`semver.gte(CONFIG.flightControllerVersion, "0.0.1")`) was always true for EmuFlight's 0.x versioning, so autocomplete always suggested `show`, which firmware then rejects with `Invalid`.
- Collapsed the `"resource"` strategy's suggestion list to `list` only, dropped `show` from the corresponding `replace()` branch, and removed the now-meaningless `"resource show all"` completion strategy entirely.
- No firmware-side issue exists for `resource show`/`resource show all` support — this is a configurator-only fix, not a stopgap pending a firmware feature.

Closes #545

## Test plan
- [x] `yarn lint`: 0 errors, 655 warnings (down 1 from baseline)
- [x] `node -c` syntax check
- [x] Local CodeRabbit review (`coderabbit review --agent --base upstream/master`): 0 findings
- [x] Confirmed `highlighterPrefix` (used by the removed strategy) still has 2 other live call sites, not orphaned

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated resource autocomplete suggestions to use the correct “list” option.
  * Selecting “list” now consistently triggers the expected action.
  * Removed the unsupported “resource show all” autocomplete option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->