### PR TITLE
feat(pid-tuning): add frame-size tuning guidance banner for angle mode

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -2933,7 +2933,7 @@
         "message": "Maximum angle allowed in Angle Mode."
     },
     "stableAngleNote": {
-        "message": "<b>Angle / Horizon mode — frame size guidance</b><br />Default values (Roll/Pitch Low P = 100, Angle Feed-Forward = 70) are sized for 1–2 inch whoops. On larger frames these can cause motor saturation during aggressive inputs, producing unintended climb. Suggested starting points:<br />• 1–2\" whoop: P 100, FF 70<br />• 3–4\": P 70–80, FF 40–50<br />• 5–6\": P 55–65, FF 25–35<br />• 7–10\"+: P 50–60, FF 20–30<br />• GPS Rescue: P 60–80, FF 40–50 (prioritise stability)<br />Reducing Roll/Pitch Low P softens the self-levelling snap; tune to taste."
+        "message": "<b>Angle / Horizon mode — frame size guidance</b><br />Default values (Roll/Pitch Low P = 100, Angle Feed-Forward = 70) are sized for 1–2 inch whoops. On larger frames these can cause motor saturation during aggressive inputs, producing unintended climb. Suggested starting points:<br />• 1–2\" whoop: P 100, FF 70<br />• 3–4\": P 70–80, FF 40–50<br />• 5–6\": P 55–65, FF 25–35<br />• 7–10\"+: P 50–60, FF 20–30<br />Reducing Roll/Pitch Low P softens the self-levelling snap; tune to taste."
     },
     "pidTuningAngleHigh": {
         "message": "Roll/Pitch High"

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -2932,6 +2932,9 @@
     "pidTuningLevelAngleLimitHelp": {
         "message": "Maximum angle allowed in Angle Mode."
     },
+    "stableAngleNote": {
+        "message": "<b>Angle / Horizon mode — frame size guidance</b><br />Default values (Roll/Pitch Low P = 100, Angle Feed-Forward = 70) are sized for 1–2 inch whoops. On larger frames these can cause motor saturation during aggressive inputs, producing unintended climb. Suggested starting points:<br />• 1–2\" whoop: P 100, FF 70<br />• 3–4\": P 70–80, FF 40–50<br />• 5–6\": P 55–65, FF 25–35<br />• 7–10\"+: P 50–60, FF 20–30<br />• GPS Rescue: P 60–80, FF 40–50 (prioritise stability)<br />Reducing Roll/Pitch Low P softens the self-levelling snap; tune to taste."
+    },
     "pidTuningAngleHigh": {
         "message": "Roll/Pitch High"
     },

--- a/src/js/tabs/pid_tuning.js
+++ b/src/js/tabs/pid_tuning.js
@@ -243,6 +243,7 @@ TABS.pid_tuning.initialize = function(callback) {
 
         $('.NEWANGLEUI').hide();
         $('.OLDANGLEUI').hide();
+        $('.stableAngleNote').hide();
         $('.pid_tuning input[name="angleLimit"]').val(ADVANCED_TUNING.levelAngleLimit);
             $('.angleLimit').show();
             console.log('show angle limit');
@@ -264,6 +265,7 @@ TABS.pid_tuning.initialize = function(callback) {
                     $('.pid_tuning input[name="horizon_transition"]').val(ADVANCED_TUNING.horizonTransition);
                     $('.OLDANGLEUI').hide();
                     $('.NEWANGLEUI').show();
+                    $('.stableAngleNote').show();
                     $('.pid_optional').show();
                     //removes 5th column which is Feedforward
                     //$('#pid_main .pid_titlebar2 th').attr('colspan', 4);

--- a/src/tabs/pid_tuning.html
+++ b/src/tabs/pid_tuning.html
@@ -487,6 +487,11 @@
                 <div class="subtab-stable" style="display: none;">
                     <div class="clear-both"></div>
 
+                    <!-- Frame-class tuning guidance banner: NEWANGLEUI only, toggled in pid_tuning.js -->
+                    <div class="note stableAngleNote">
+                        <p i18n="stableAngleNote"></p>
+                    </div>
+
                     <!-- Left cf_column: Angle Mode PIDs -->
                     <div class="cf_column pid_optional needed_by_LEVEL">
 


### PR DESCRIPTION
AI Generated pull-request

## Summary

Adds an in-UI banner to the Stable PIDs sub-tab showing suggested Roll/Pitch Low P and Angle Feed-Forward starting points by frame size, so users don't have to guess when moving off the 1-2" whoop defaults.

Firmware issue: emuflight/EmuFlight#1184
Firmware fix (root-cause analysis, hardware test data, tuning values): emuflight/EmuFlight#1257

## Changes

- `src/tabs/pid_tuning.html` — new `.note stableAngleNote` banner inside `.subtab-stable`, following the existing `tuningHelp`/`filterWarning` pattern on the Filter sub-tab (no new CSS; `.note` is already generically styled).
- `src/js/tabs/pid_tuning.js` — banner visibility gated to `NEWANGLEUI` only (`semver.gte(CONFIG.apiVersion, "1.46.0")`), the same check that already gates `p_angle_low`/`d_angle_low`/`f_angle` population. Firmware below that (including old 0.x builds using `OLDANGLEUI`) never shows it, since those builds don't expose these settings at all.
- `locales/en/messages.json` — one new `stableAngleNote` key with the per-frame-size table. Existing `pidTuningAngleLowHelp` / `pidTuningAngleFeedForwardHelp` tooltips are untouched.

## Tuning values

| Frame size | Roll/Pitch Low P (`p_angle_low`) | Angle Feed-Forward (`df_angle_low`) | Notes |
|---|---|---|---|
| 1-2" whoop | 100 (default) | 70 (default) | Motor headroom large relative to PID demand |
| 3-4" | 70-80 | 40-50 | |
| 5-6" | 55-65 | 25-35 | |
| 7-10"+ | 50-60 | 20-30 | |

Values sourced from HELIOSPRING (F405) hardware blackbox testing documented in emuflight/EmuFlight#1257. GPS Rescue is intentionally not covered: it calls the same `pidLevel()` and shares `p_angle_low`/`df_angle_low`, but the #1257 pure-P directFF fix only activates on the `ANGLE_MODE`/`HORIZON_MODE` flags (`pid.c`, master), not `GPS_RESCUE_MODE` — a distinct GPS Rescue tuning recommendation isn't supported by the validated data (flagged by CodeRabbitAI review, see PR comments).

Closes #605

## Test plan

- [x] JSON validated (`messages.json` parses)
- [x] JS syntax validated (`node -c src/js/tabs/pid_tuning.js`)
- [ ] `eslint` / full build — not run; `node_modules` not installed in this environment
- [ ] Manual UI check — banner renders only on Stable PIDs sub-tab, only for NEWANGLEUI firmware (needs a running app + FC connection, not verified here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added guidance for recommended starting PID and feed-forward values based on frame size.
  * Included GPS Rescue guidance and an explanation of how lowering Roll/Pitch Low P affects self-leveling.
  * Guidance is displayed only when the newer Angle tuning interface is active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
