### PR TITLE
Remove unused short-unique-id dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
     "object-hash": "^3.0.0",
     "request": "^2.88.2",
     "serialport": "^13.0.0",
-    "short-unique-id": "^4.3.3",
     "tslib": "^2.1.0",
     "universal-ga": "^1.2.0",
     "usb": "^2.17.0"

--- a/src/main.html
+++ b/src/main.html
@@ -124,13 +124,6 @@
         }
 
         try {
-            window.ShortUniqueId = require('short-unique-id');
-            console.log('[OK] short-unique-id loaded');
-        } catch(e) {
-            console.error('ERROR: Failed to load short-unique-id:', e.message);
-        }
-
-        try {
             window.objectHash = require('object-hash');
             console.log('[OK] object-hash loaded');
         } catch(e) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4398,11 +4398,6 @@ shebang-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
-short-unique-id@^4.3.3:
-  version "4.4.4"
-  resolved "https://registry.yarnpkg.com/short-unique-id/-/short-unique-id-4.4.4.tgz#a45df68303bbd2dbb5785ed7708e891809c9cb7a"
-  integrity sha512-oLF1NCmtbiTWl2SqdXZQbo5KM1b7axdp0RgQLq8qCBBLoq+o3A5wmLrNM6bZIh54/a8BJ3l69kTXuxwZ+XCYuw==
-
 shortid@^2.1.3:
   version "2.2.17"
   resolved "https://registry.yarnpkg.com/shortid/-/shortid-2.2.17.tgz#ea87297a36b7edd10a57818fbac5be798e0994bb"


### PR DESCRIPTION
AI Generated pull-request

## Summary
- Removes the `short-unique-id` dependency from `package.json`/`yarn.lock`
- Removes the corresponding `require('short-unique-id')` load block in `src/main.html` that exposed it as `window.ShortUniqueId`

The package was loaded and assigned to `window.ShortUniqueId` in `src/main.html` since the Electron/Forge migration, but no code in `src/` ever instantiates it (`new ShortUniqueId(...)` / `ShortUniqueId(...)`). Dead dependency, no functional change.

## Test plan
- [x] `yarn lint` — 0 errors (pre-existing unrelated warnings only)
- [x] `yarn install --check-files` — lockfile regenerates clean, no leftover `short-unique-id` resolution
- [x] Manually tested `yarn dev` build with the removal — configurator functions normally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed an unused package dependency and its associated application initialization.
  * No visible changes to the application’s user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->