### PR TITLE
Remove unused makensis devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,6 @@
     "eslint": "^8.57.0",
     "follow-redirects": "^1.16.0",
     "fs-extra": "^9.1.0",
-    "makensis": "^0.23.4",
     "os": "^0.1.2",
     "rpm-builder": "^1.2.1",
     "targz": "^1.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -697,11 +697,6 @@
     mkdirp "^1.0.4"
     rimraf "^3.0.2"
 
-"@nsis/language-data@^0.7.4":
-  version "0.7.5"
-  resolved "https://registry.yarnpkg.com/@nsis/language-data/-/language-data-0.7.5.tgz#b847c2265ab797eb66e8f0e8ff5a4ac2071c0597"
-  integrity sha512-t9JVJiFZ3kj66VH+7i4pAyHfYWrxGZr3PVvgi6gywRi/yzM9/zk3JEOazo7DWC5KPAId5bLOAQJLDpfIpcsQ9w==
-
 "@serialport/binding-mock@10.2.2":
   version "10.2.2"
   resolved "https://registry.yarnpkg.com/@serialport/binding-mock/-/binding-mock-10.2.2.tgz#d322a8116a97806addda13c62f50e73d16125874"
@@ -3383,14 +3378,6 @@ make-fetch-happen@^10.2.1:
     socks-proxy-agent "^7.0.0"
     ssri "^9.0.0"
 
-makensis@^0.23.4:
-  version "0.23.4"
-  resolved "https://registry.yarnpkg.com/makensis/-/makensis-0.23.4.tgz#f46d99ec5ed8d3105f379aa3d655812afe8242bf"
-  integrity sha512-1ZQoGkjLdMEy2TAD3CHpMBdOablmjZg4DJgjDA44nD6yxcGP/HdhhNBiuK6j7VXciV4eQ57kbjz3e4oC34E2Iw==
-  dependencies:
-    "@nsis/language-data" "^0.7.4"
-    quoted-string-space-split "^1.0.0"
-
 map-age-cleaner@^0.1.1:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz#7d583a7306434c055fe474b0f45078e6e1b4b92a"
@@ -4044,11 +4031,6 @@ quick-lru@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-5.1.1.tgz#366493e6b3e42a3a6885e2e99d18f80fb7a8c932"
   integrity sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==
-
-quoted-string-space-split@^1.0.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/quoted-string-space-split/-/quoted-string-space-split-1.1.1.tgz#ce4dff182322b2f553ecdb06241cadff31178798"
-  integrity sha512-R/PBCVzU/LxUytMs5FGcIPVpKiqBag7mA5kOP2xw627IpSiqlB1Z5XMTi4ezDu7QHBCBvpJM3gN7Y625BCjxAw==
 
 random-path@^0.1.0:
   version "0.1.2"


### PR DESCRIPTION
AI Generated pull-request

## Summary
- Removes the `makensis` devDependency from `package.json`/`yarn.lock`

Not referenced by any Forge maker (`forge.config.js` only configures `maker-wix`, `maker-zip`, `maker-deb`, `maker-rpm`, `maker-dmg` — Windows packaging uses WiX/MSI, not NSIS), any tracked build script, or any GitHub Actions workflow. Confirmed by independent CodeRabbit analysis on #599 (superseded by this PR).

Legacy NSIS files under `assets/windows/` (`installer.nsi`, `UnInst.nsh`) are unreferenced but out of scope for this PR.

## Test plan
- [x] `yarn lint` — 0 errors (pre-existing unrelated warnings only)
- [x] `yarn install --check-files` — lockfile regenerates clean, no leftover `makensis`/`@nsis/language-data` resolution

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed an unused development dependency from the project configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->