### PR TITLE
Verify cross-env on CI (throwaway validation for #581)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,6 +88,9 @@ jobs:
       - name: Lint
         run: yarn lint
 
+      - name: Verify cross-env
+        run: yarn verify:cross-env
+
       - name: Make Packages
         env:
           APPLE_SIGNING_ENTITLEMENTS: ./sign/entitlements.plist

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "@electron-forge/plugin-fuses": "7.11.2",
     "@electron/fuses": "^1.0.0",
     "command-exists": "^1.2.9",
-    "cross-env": "^7.0.3",
+    "cross-env": "^10.1.0",
     "del": "^8.0.1",
     "electron": "42.3.3",
     "eslint": "^8.57.0",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "package": "yarn install --check-files && node scripts/build.js && electron-forge package",
     "package:debug": "yarn install --check-files && node scripts/build.js && cross-env EMUCFG_BUILD_MODE=dev-release electron-forge package",
     "build": "node scripts/build.js",
+    "verify:cross-env": "cross-env EMUCFG_VERIFY_CROSS_ENV=cross-env-ok node -e \"if (process.env.EMUCFG_VERIFY_CROSS_ENV !== 'cross-env-ok') { console.error('cross-env failed to propagate environment variable'); process.exit(1); } console.log('cross-env OK:', process.env.EMUCFG_VERIFY_CROSS_ENV);\"",
     "lint": "eslint .",
     "commands": "node .commands.js"
   },

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "package": "yarn install --check-files && node scripts/build.js && electron-forge package",
     "package:debug": "yarn install --check-files && node scripts/build.js && cross-env EMUCFG_BUILD_MODE=dev-release electron-forge package",
     "build": "node scripts/build.js",
-    "verify:cross-env": "cross-env EMUCFG_VERIFY_CROSS_ENV=cross-env-ok node -e \"if (process.env.EMUCFG_VERIFY_CROSS_ENV !== 'cross-env-ok') { console.error('cross-env failed to propagate environment variable'); process.exit(1); } console.log('cross-env OK:', process.env.EMUCFG_VERIFY_CROSS_ENV);\"",
+    "verify:cross-env": "cross-env EMUCFG_VERIFY_CROSS_ENV=cross-env-ok node scripts/verify-cross-env.js",
     "lint": "eslint .",
     "commands": "node .commands.js"
   },

--- a/scripts/verify-cross-env.js
+++ b/scripts/verify-cross-env.js
@@ -1,0 +1,8 @@
+const expected = 'cross-env-ok';
+
+if (process.env.EMUCFG_VERIFY_CROSS_ENV !== expected) {
+  console.error('cross-env failed to propagate environment variable');
+  process.exit(1);
+}
+
+console.log('cross-env OK:', process.env.EMUCFG_VERIFY_CROSS_ENV);

--- a/yarn.lock
+++ b/yarn.lock
@@ -404,6 +404,11 @@
     minimist "^1.2.8"
     postject "^1.0.0-alpha.6"
 
+"@epic-web/invariant@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@epic-web/invariant/-/invariant-1.0.0.tgz#1073e5dee6dd540410784990eb73e4acd25c9813"
+  integrity sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==
+
 "@eslint-community/eslint-utils@^4.2.0":
   version "4.9.1"
   resolved "https://registry.yarnpkg.com/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz#4e90af67bc51ddee6cdef5284edf572ec376b595"
@@ -1716,12 +1721,13 @@ cross-dirname@^0.1.0:
   resolved "https://registry.yarnpkg.com/cross-dirname/-/cross-dirname-0.1.0.tgz#b899599f30a5389f59e78c150e19f957ad16a37c"
   integrity sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==
 
-cross-env@^7.0.3:
-  version "7.0.3"
-  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-7.0.3.tgz#865264b29677dc015ba8418918965dd232fc54cf"
-  integrity sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==
+cross-env@^10.1.0:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-10.1.0.tgz#cfd2a6200df9ed75bfb9cb3d7ce609c13ea21783"
+  integrity sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==
   dependencies:
-    cross-spawn "^7.0.1"
+    "@epic-web/invariant" "^1.0.0"
+    cross-spawn "^7.0.6"
 
 cross-spawn-windows-exe@^1.1.0:
   version "1.2.0"
@@ -1743,7 +1749,7 @@ cross-spawn@^6.0.0:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
-cross-spawn@^7.0.1, cross-spawn@^7.0.2:
+cross-spawn@^7.0.1, cross-spawn@^7.0.2, cross-spawn@^7.0.6:
   version "7.0.6"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.6.tgz#8a58fe78f00dcd70c370451759dfbfaf03e8ee9f"
   integrity sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==


### PR DESCRIPTION
AI Generated pull-request

## Summary
Throwaway validation branch. Includes #581's cross-env 7.0.3->10.1.0 bump plus a new `yarn verify:cross-env` script and CI step to actually exercise cross-env's env-var propagation on real runners.

Confirmed via raw job logs that #581's own CI run never invokes cross-env at all (dev/dev:verbose/make:debug/package:debug are never called by build.yml) on any of linux-x64, windows-x64, or windows-ia32. This PR closes that verification gap.

If the CI step proves useful for catching future cross-env-class regressions, the verify step can be kept permanently; otherwise this branch gets discarded once #581 is confirmed safe.

## Test plan
- [ ] CI green on all platforms, especially both windows-2022 legs (cross-env's actual risk surface is Windows env-var syntax translation)