### PR TITLE
fix: repair OSD Font Manager boot-logo preview and custom-image loading

### DIFF
--- a/src/js/LogoManager.js
+++ b/src/js/LogoManager.js
@@ -192,7 +192,15 @@ LogoManager.openImage = function () {
                     .catch(error => reject(error));
             };
             img.onerror = error => reject(error);
-            fileEntry.file(file => img.src = "file://" + file.path);
+            // fileEntry.file() resolves to a Blob (Electron dialog shim), not a
+            // filesystem-backed File with a .path — read it via FileReader instead
+            // of constructing a file:// URL.
+            fileEntry.file(file => {
+                var reader = new FileReader();
+                reader.onload = () => { img.src = reader.result; };
+                reader.onerror = error => reject(error);
+                reader.readAsDataURL(file);
+            });
         });
     });
 };
@@ -270,11 +278,33 @@ LogoManager.replaceLogoInFont = function (img) {
 
 /**
  * Draw the logo using the loaded font data.
+ *
+ * Composites every tile onto one canvas and displays a single image, rather
+ * than appending one <img> per tile and relying on inline-wrap to reconstruct
+ * the grid — 96 separately laid-out/composited elements only need a single
+ * sub-pixel rounding difference between two of them to visibly misalign.
  */
 LogoManager.drawPreview = function () {
-    var $el = this.elements.$preview.empty();
-    for (var i = this.logoStartIndex, I = this.font.constants.MAX_CHAR_COUNT; i < I; i++) {
-        var url = this.font.data.character_image_urls[i];
-        $el.append('<img src="' + url + '" title="0x' + i.toString(16) + '"></img>');
+    var charWidth = this.font.constants.SIZES.CHAR_WIDTH,
+        charHeight = this.font.constants.SIZES.CHAR_HEIGHT,
+        horiz = this.constants.TILES_NUM_HORIZ,
+        vert = this.constants.TILES_NUM_VERT,
+        canvas = document.createElement('canvas'),
+        ctx = canvas.getContext('2d');
+    canvas.width = this.constraints.imageSize.expectedWidth;
+    canvas.height = this.constraints.imageSize.expectedHeight;
+    for (var row = 0; row < vert; row++) {
+        for (var col = 0; col < horiz; col++) {
+            var charAddr = this.logoStartIndex + (row * horiz) + col,
+                bits = this.font.data.characters[charAddr];
+            for (var y = 0; y < charHeight; y++) {
+                for (var x = 0; x < charWidth; x++) {
+                    var v = bits ? bits[(y * charWidth) + x] : 1;
+                    ctx.fillStyle = this.font.constants.COLORS[v];
+                    ctx.fillRect((col * charWidth) + x, (row * charHeight) + y, 1, 1);
+                }
+            }
+        }
     }
+    this.elements.$preview.empty().append($('<img>', { src: canvas.toDataURL('image/png') }));
 };

--- a/src/js/LogoManager.js
+++ b/src/js/LogoManager.js
@@ -111,10 +111,18 @@ LogoManager.init = function (font, logoStartIndex) {
     Object.keys(this.constraints).forEach(key => {
         this.constraints[key].$el = $(this.constraints[key].el);
     });
-    // resize logo preview area to match tile size
+    // Resize logo preview area to match tile size and pin tiles to an explicit
+    // grid: with plain inline <img> tags, wrapping to the next row depends on
+    // 24 tiles happening to add up to exactly one row width, so a single
+    // sub-pixel rounding difference between tiles shifts the wrap point and
+    // shears the reconstructed image into diagonal stripes.
     this.elements.$preview
         .width(this.constraints.imageSize.expectedWidth)
-        .height(this.constraints.imageSize.expectedHeight);
+        .height(this.constraints.imageSize.expectedHeight)
+        .css({
+            display: "grid",
+            gridTemplateColumns: "repeat(" + this.constants.TILES_NUM_HORIZ + ", " + font.constants.SIZES.CHAR_WIDTH + "px)",
+        });
     this.resetImageInfo();
 };
 
@@ -278,33 +286,11 @@ LogoManager.replaceLogoInFont = function (img) {
 
 /**
  * Draw the logo using the loaded font data.
- *
- * Composites every tile onto one canvas and displays a single image, rather
- * than appending one <img> per tile and relying on inline-wrap to reconstruct
- * the grid — 96 separately laid-out/composited elements only need a single
- * sub-pixel rounding difference between two of them to visibly misalign.
  */
 LogoManager.drawPreview = function () {
-    var charWidth = this.font.constants.SIZES.CHAR_WIDTH,
-        charHeight = this.font.constants.SIZES.CHAR_HEIGHT,
-        horiz = this.constants.TILES_NUM_HORIZ,
-        vert = this.constants.TILES_NUM_VERT,
-        canvas = document.createElement('canvas'),
-        ctx = canvas.getContext('2d');
-    canvas.width = this.constraints.imageSize.expectedWidth;
-    canvas.height = this.constraints.imageSize.expectedHeight;
-    for (var row = 0; row < vert; row++) {
-        for (var col = 0; col < horiz; col++) {
-            var charAddr = this.logoStartIndex + (row * horiz) + col,
-                bits = this.font.data.characters[charAddr];
-            for (var y = 0; y < charHeight; y++) {
-                for (var x = 0; x < charWidth; x++) {
-                    var v = bits ? bits[(y * charWidth) + x] : 1;
-                    ctx.fillStyle = this.font.constants.COLORS[v];
-                    ctx.fillRect((col * charWidth) + x, (row * charHeight) + y, 1, 1);
-                }
-            }
-        }
+    var $el = this.elements.$preview.empty();
+    for (var i = this.logoStartIndex, I = this.font.constants.MAX_CHAR_COUNT; i < I; i++) {
+        var url = this.font.data.character_image_urls[i];
+        $el.append('<img src="' + url + '" title="0x' + i.toString(16) + '"></img>');
     }
-    this.elements.$preview.empty().append($('<img>', { src: canvas.toDataURL('image/png') }));
 };


### PR DESCRIPTION
AI Generated pull-request

## Summary
- `LogoManager.openImage()` built `img.src` from a `.path` property that the picked-file object doesn't have — the Electron `chrome.fileSystem` dialog shim (`src/support/preload.js`) resolves `fileEntry.file(callback)` with a `Blob`, not a filesystem-backed `File`. `img.src` became the literal string `"file://undefined"`, so every custom boot-logo image failed to load regardless of size or color content. Fixed by reading the `Blob` via `FileReader.readAsDataURL`, matching the pattern `FONT.openFontFile()` already uses correctly for the custom font-file picker.
- `LogoManager.drawPreview()` rendered the tiled boot-logo preview by appending 96 separate `<img>` tags and relying on the browser's inline text-wrap to break them into a 24x4 grid — this only reconstructs the grid correctly if 24 tiles happen to sum to exactly one row width with zero rounding slack, and any sub-pixel layout difference between tiles shifts the wrap point and shears the image into diagonal stripes. Fixed by pinning tiles to an explicit CSS grid (`grid-template-columns`) in `LogoManager.init()`, so each tile's row/column is set by grid position rather than by whether inline images happen to wrap at the right point.
- Verified the `.mcm` boot-logo data and the character-tiling algorithm are correct (not corrupted) via an independent re-implementation before concluding the bug was in the preview's DOM/CSS layer, not the font data.

Closes #627

## Test plan
- [x] `yarn lint` — 0 errors, no new warnings introduced
- [x] User-verified in a real `yarn dev` build: custom `.bmp` boot logo now loads and previews correctly; upload progresses; the default (`clarity.mcm`) boot-logo preview renders unstaggered
- [ ] Actual on-FC analog OSD/MAX7456 video output of an uploaded custom logo — not verifiable without a connected FC + capture; out of scope for this fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved logo preview rendering with consistent sizing and alignment.
  * Fixed image loading for selected files, including clearer handling of read errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->