### PR TITLE
build(deps): migrate DFU/USB code to usb@3.0.1 WebUSB API

### DIFF
--- a/main.js
+++ b/main.js
@@ -593,47 +593,40 @@ ipcMain.handle('tcp-allocate', async () => {
 const _usbOpenDevices = new Map();
 
 function usbKeyFromDevice(device) {
-  return `${device.busNumber}:${device.deviceAddress}`;
+  return device.handle;
 }
 
-function findUsbDeviceByKey(key) {
+async function findUsbDeviceByKey(key) {
   const { usb } = require('usb');
-  return usb.getDeviceList().find((d) => usbKeyFromDevice(d) === key) || null;
+  const devices = await usb.getDevices();
+  return devices.find((d) => usbKeyFromDevice(d) === key) || null;
 }
 
-function ensureUsbDeviceOpen(key) {
-  let device = _usbOpenDevices.get(key) || findUsbDeviceByKey(key);
+async function ensureUsbDeviceOpen(key) {
+  let device = _usbOpenDevices.get(key);
+  if (!device) {
+    device = await findUsbDeviceByKey(key);
+  }
   if (!device) {
     throw new Error(`USB device not found: ${key}`);
   }
-  if (!device.interfaces) {
-    device.open();
+  if (!device.opened) {
+    await device.open();
   }
   _usbOpenDevices.set(key, device);
   return device;
 }
 
-function toBmRequestType(direction, requestType, recipient) {
-  let bm = 0;
-  if (direction === 'in') {
-    bm |= 0x80;
-  }
+// usb@3.x defaults every native transfer to a 1000ms timeout unless an
+// explicit timeout is passed — far too short for a large-sector flash erase,
+// which can leave the device silent past that window while genuinely busy.
+const USB_NATIVE_TRANSFER_TIMEOUT_MS = 10000;
 
-  if (requestType === 'class') {
-    bm |= 0x20;
-  } else if (requestType === 'vendor') {
-    bm |= 0x40;
+function usbTransferBuffer(result) {
+  if (!result.data) {
+    return Buffer.alloc(0);
   }
-
-  if (recipient === 'interface') {
-    bm |= 0x01;
-  } else if (recipient === 'endpoint') {
-    bm |= 0x02;
-  } else if (recipient === 'other') {
-    bm |= 0x03;
-  }
-
-  return bm;
+  return Buffer.from(result.data.buffer, result.data.byteOffset, result.data.byteLength);
 }
 
 ipcMain.handle('usb-list-dfu', async () => {
@@ -644,15 +637,13 @@ ipcMain.handle('usb-list-dfu', async () => {
       { vendorId: 0x2DAE, productId: 0x0003 },
     ];
 
-    return usb.getDeviceList()
-      .filter((d) => {
-        const desc = d.deviceDescriptor || {};
-        return DFU_IDS.some((id) => id.vendorId === desc.idVendor && id.productId === desc.idProduct);
-      })
+    const devices = await usb.getDevices();
+    return devices
+      .filter((d) => DFU_IDS.some((id) => id.vendorId === d.vendorId && id.productId === d.productId))
       .map((d) => ({
         device: usbKeyFromDevice(d),
-        vendorId: d.deviceDescriptor.idVendor,
-        productId: d.deviceDescriptor.idProduct,
+        vendorId: d.vendorId,
+        productId: d.productId,
         serialNumber: '',
         manufacturer: '',
         product: '',
@@ -665,7 +656,7 @@ ipcMain.handle('usb-list-dfu', async () => {
 
 ipcMain.handle('usb-open-device', async (event, deviceKey) => {
   try {
-    ensureUsbDeviceOpen(deviceKey);
+    await ensureUsbDeviceOpen(deviceKey);
     return { success: true };
   } catch (e) {
     console.error('usb-open-device error:', e.message);
@@ -676,8 +667,8 @@ ipcMain.handle('usb-open-device', async (event, deviceKey) => {
 ipcMain.handle('usb-close-device', async (event, deviceKey) => {
   try {
     const device = _usbOpenDevices.get(deviceKey);
-    if (device && device.interfaces) {
-      device.close();
+    if (device && device.opened) {
+      await device.close();
     }
     _usbOpenDevices.delete(deviceKey);
     return { success: true };
@@ -689,9 +680,8 @@ ipcMain.handle('usb-close-device', async (event, deviceKey) => {
 
 ipcMain.handle('usb-claim-interface', async (event, deviceKey, interfaceNumber) => {
   try {
-    const device = ensureUsbDeviceOpen(deviceKey);
-    const iface = device.interface(interfaceNumber);
-    iface.claim();
+    const device = await ensureUsbDeviceOpen(deviceKey);
+    await device.claimInterface(interfaceNumber);
     return { success: true };
   } catch (e) {
     console.error('usb-claim-interface error:', e.message);
@@ -701,11 +691,8 @@ ipcMain.handle('usb-claim-interface', async (event, deviceKey, interfaceNumber) 
 
 ipcMain.handle('usb-release-interface', async (event, deviceKey, interfaceNumber) => {
   try {
-    const device = ensureUsbDeviceOpen(deviceKey);
-    const iface = device.interface(interfaceNumber);
-    await new Promise((resolve, reject) => {
-      iface.release(true, (err) => (err ? reject(err) : resolve()));
-    });
+    const device = await ensureUsbDeviceOpen(deviceKey);
+    await device.releaseInterface(interfaceNumber);
     return { success: true };
   } catch (e) {
     console.error('usb-release-interface error:', e.message);
@@ -715,17 +702,19 @@ ipcMain.handle('usb-release-interface', async (event, deviceKey, interfaceNumber
 
 ipcMain.handle('usb-get-configuration', async (event, deviceKey) => {
   try {
-    const device = ensureUsbDeviceOpen(deviceKey);
-    const configDescriptor = device.configDescriptor || {};
+    const device = await ensureUsbDeviceOpen(deviceKey);
+    const configuration = device.configuration || {};
     // Flatten ALL interface alternate settings — mirrors Chrome USB API config.interfaces
     // e.g. STM32 DFU has interface 0 with 4 alt settings (Internal Flash, Option Bytes, OTP, Device Info)
     const interfaces = [];
-    ((configDescriptor.interfaces) || []).forEach((altSettings) => {
-      altSettings.forEach((altSetting) => {
+    (configuration.interfaces || []).forEach((iface) => {
+      (iface.alternates || []).forEach((alt) => {
         interfaces.push({
-          interfaceNumber: altSetting.bInterfaceNumber,
-          alternateSetting: altSetting.bAlternateSetting,
-          endpoints: (altSetting.endpoints || []).map((ep) => ({ address: ep.bEndpointAddress })),
+          interfaceNumber: iface.interfaceNumber,
+          alternateSetting: alt.alternateSetting,
+          endpoints: (alt.endpoints || []).map((ep) => ({
+            address: ep.endpointNumber | (ep.direction === 'in' ? 0x80 : 0),
+          })),
         });
       });
     });
@@ -733,7 +722,7 @@ ipcMain.handle('usb-get-configuration', async (event, deviceKey) => {
     console.log('usb-get-configuration: found', interfaces.length, 'interface alt settings');
     return {
       resultCode: 0,
-      configurationValue: configDescriptor.bConfigurationValue || 1,
+      configurationValue: configuration.configurationValue || 1,
       interfaces,
     };
   } catch (e) {
@@ -744,53 +733,50 @@ ipcMain.handle('usb-get-configuration', async (event, deviceKey) => {
 
 ipcMain.handle('usb-control-transfer', async (event, deviceKey, options) => {
   try {
-    const device = ensureUsbDeviceOpen(deviceKey);
-    const bmRequestType = toBmRequestType(options.direction, options.requestType, options.recipient);
-    const bRequest = options.request;
-    const wValue = options.value || 0;
-    const wIndex = options.index || 0;
+    const device = await ensureUsbDeviceOpen(deviceKey);
+    const setup = {
+      requestType: options.requestType || 'standard',
+      recipient: options.recipient || 'device',
+      request: options.request,
+      value: options.value || 0,
+      index: options.index || 0,
+    };
 
     if (options.direction === 'in') {
       const length = options.length || 0;
-      const data = await new Promise((resolve, reject) => {
-        const timeoutId = setTimeout(() => {
-          reject(new Error('USB control transfer timeout'));
-        }, 10000);
-
-        device.controlTransfer(bmRequestType, bRequest, wValue, wIndex, length, (err, inData) => {
-          clearTimeout(timeoutId);
-          if (err) {
-            reject(err);
-            return;
-          }
-          resolve(inData || Buffer.alloc(0));
-        });
-      });
-
+      const result = await withTimeout(
+        device.controlTransferIn(setup, length, USB_NATIVE_TRANSFER_TIMEOUT_MS),
+        12000, 'USB control transfer timeout',
+      );
+      if (result.status === 'stall') {
+        console.warn('usb-control-transfer: device stalled (expected during DFU error recovery)');
+        return { resultCode: 1, bytesTransferred: 0, data: [] };
+      }
+      if (result.status !== 'ok') {
+        throw new Error(`USB control transfer failed: ${result.status}`);
+      }
+      const data = usbTransferBuffer(result);
       return { resultCode: 0, bytesTransferred: data.length, data: Array.from(data) };
     }
 
     const outData = options.data ? Buffer.from(options.data) : Buffer.alloc(0);
-    await new Promise((resolve, reject) => {
-      const timeoutId = setTimeout(() => {
-        reject(new Error('USB control transfer timeout'));
-      }, 10000);
-
-      device.controlTransfer(bmRequestType, bRequest, wValue, wIndex, outData, (err) => {
-        clearTimeout(timeoutId);
-        if (err) {
-          reject(err);
-          return;
-        }
-        resolve();
-      });
-    });
-
-    return { resultCode: 0, bytesTransferred: outData.length };
+    const result = await withTimeout(
+      device.controlTransferOut(setup, outData, USB_NATIVE_TRANSFER_TIMEOUT_MS),
+      12000, 'USB control transfer timeout',
+    );
+    if (result.status === 'stall') {
+      console.warn('usb-control-transfer: device stalled (expected during DFU error recovery)');
+      return { resultCode: 1, bytesTransferred: 0, data: [] };
+    }
+    if (result.status !== 'ok') {
+      throw new Error(`USB control transfer failed: ${result.status}`);
+    }
+    return { resultCode: 0, bytesTransferred: result.bytesWritten };
   } catch (e) {
-    if (e.message && e.message.includes('LIBUSB_TRANSFER_STALL')) {
+    if (e.message && e.message.toLowerCase().includes('stall')) {
       // STALL is a valid DFU device response (device in dfuERROR, protocol
-      // clears it via DFU_CLRSTATUS). Not a fatal error — demote to warn.
+      // clears it via DFU_CLRSTATUS). usb@3.x rejects on stall rather than
+      // resolving {status: 'stall'} as its own type contract documents.
       console.warn('usb-control-transfer: device stalled (expected during DFU error recovery)');
     } else {
       console.error('usb-control-transfer error:', e.message);
@@ -801,84 +787,38 @@ ipcMain.handle('usb-control-transfer', async (event, deviceKey, options) => {
 
 ipcMain.handle('usb-bulk-transfer', async (event, deviceKey, options) => {
   try {
-    const device = ensureUsbDeviceOpen(deviceKey);
-    const interfaceNumber = options.interfaceNumber !== undefined ? options.interfaceNumber : 0;
-    const iface = device.interfaces[interfaceNumber];
-    if (!iface) {
-      throw new Error(`Interface ${interfaceNumber} not found on device`);
-    }
+    const device = await ensureUsbDeviceOpen(deviceKey);
     const endpointNumber = options.endpoint || 1;
-    const endpointAddress = options.direction === 'in' ? (endpointNumber | 0x80) : endpointNumber;
-    const endpoint = (iface.endpoints || []).find((ep) => ep.address === endpointAddress);
+    const direction = options.direction === 'in' ? 'in' : 'out';
 
-    if (!endpoint) {
-      return { resultCode: 1, bytesTransferred: 0, data: [] };
-    }
-
-    const withTransferTimeout = (transferPromiseFactory, timeoutMessage) => {
-      return new Promise((resolve, reject) => {
-        const timeoutId = setTimeout(() => {
-          try {
-            if (typeof endpoint.stopPoll === 'function') {
-              endpoint.stopPoll(() => {});
-            }
-          } catch {
-            // ignore endpoint stopPoll errors during timeout recovery
-          }
-
-          try {
-            if (typeof endpoint.clearHalt === 'function') {
-              endpoint.clearHalt(() => {});
-            }
-          } catch {
-            // ignore endpoint clearHalt errors during timeout recovery
-          }
-
-          reject(new Error(timeoutMessage));
-        }, 10000);
-
-        transferPromiseFactory()
-          .then((result) => {
-            clearTimeout(timeoutId);
-            resolve(result);
-          })
-          .catch((err) => {
-            clearTimeout(timeoutId);
-            reject(err);
-          });
+    const clearHaltOnTimeout = () => {
+      device.clearHalt(direction, endpointNumber).catch(() => {
+        // best-effort recovery only — original error already propagates
       });
     };
 
-    if (options.direction === 'in') {
-      const data = await withTransferTimeout(() => {
-        return new Promise((resolve, reject) => {
-          endpoint.transfer(options.length || 64, (err, inData) => {
-            if (err) {
-              reject(err);
-              return;
-            }
-            resolve(inData || Buffer.alloc(0));
-          });
-        });
-      }, 'USB bulk IN transfer timeout');
-
+    if (direction === 'in') {
+      const length = options.length || 64;
+      const result = await withTimeout(
+        device.transferIn(endpointNumber, length, USB_NATIVE_TRANSFER_TIMEOUT_MS),
+        12000, 'USB bulk IN transfer timeout',
+      ).catch((err) => { clearHaltOnTimeout(); throw err; });
+      if (result.status !== 'ok') {
+        throw new Error(`USB bulk transfer failed: ${result.status}`);
+      }
+      const data = usbTransferBuffer(result);
       return { resultCode: 0, bytesTransferred: data.length, data: Array.from(data) };
     }
 
     const outData = options.data ? Buffer.from(options.data) : Buffer.alloc(0);
-    await withTransferTimeout(() => {
-      return new Promise((resolve, reject) => {
-        endpoint.transfer(outData, (err) => {
-          if (err) {
-            reject(err);
-            return;
-          }
-          resolve();
-        });
-      });
-    }, 'USB bulk OUT transfer timeout');
-
-    return { resultCode: 0, bytesTransferred: outData.length };
+    const result = await withTimeout(
+      device.transferOut(endpointNumber, outData, USB_NATIVE_TRANSFER_TIMEOUT_MS),
+      12000, 'USB bulk OUT transfer timeout',
+    ).catch((err) => { clearHaltOnTimeout(); throw err; });
+    if (result.status !== 'ok') {
+      throw new Error(`USB bulk transfer failed: ${result.status}`);
+    }
+    return { resultCode: 0, bytesTransferred: result.bytesWritten };
   } catch (e) {
     console.error('usb-bulk-transfer error:', e.message);
     return { resultCode: 1, bytesTransferred: 0, data: [] };
@@ -887,10 +827,8 @@ ipcMain.handle('usb-bulk-transfer', async (event, deviceKey, options) => {
 
 ipcMain.handle('usb-reset-device', async (event, deviceKey) => {
   try {
-    const device = ensureUsbDeviceOpen(deviceKey);
-    await new Promise((resolve, reject) => {
-      device.reset((err) => (err ? reject(err) : resolve()));
-    });
+    const device = await ensureUsbDeviceOpen(deviceKey);
+    await device.reset();
     return { success: true, resultCode: 0 };
   } catch (e) {
     console.error('usb-reset-device error:', e.message);
@@ -1295,39 +1233,23 @@ async function cleanupConnectionsBeforeQuit() {
   const usbCleanupPromises = [];
 
   for (const [, device] of _usbOpenDevices) {
-    const cleanupOneDevice = withTimeout(new Promise((resolve) => {
-      let completed = false;
-      const finish = () => {
-        if (!completed) {
-          completed = true;
-          resolve();
-        }
-      };
-
-      const closeDevice = () => {
-        try {
-          device.close(() => finish());
-        } catch {
-          try {
-            device.close();
-          } catch {
-            // ignore close errors
-          }
-          finish();
-        }
-      };
-
+    const cleanupOneDevice = withTimeout((async () => {
       try {
         // DFU_CLRSTATUS (USB class request): bmRequestType=0x21, bRequest=0x00,
         // wValue=0, wIndex=0, wLength=0 — clears DFU status bits and returns
         // the device to dfuIDLE so it can be safely closed.
-        device.controlTransfer(0x21, 0x00, 0, 0, 0, () => {
-          closeDevice();
+        await device.controlTransferOut({
+          requestType: 'class', recipient: 'interface', request: 0x00, value: 0, index: 0,
         });
       } catch {
-        closeDevice();
+        // device may already be detached or in a state that rejects this — still attempt close
       }
-    }), 2000, 'USB cleanup timeout').catch((error) => {
+      try {
+        await device.close();
+      } catch {
+        // ignore close errors
+      }
+    })(), 2000, 'USB cleanup timeout').catch((error) => {
       console.error('USB cleanup error:', error.message);
     });
 

--- a/main.js
+++ b/main.js
@@ -1292,11 +1292,11 @@ async function cleanupConnectionsBeforeQuit() {
   for (const [, device] of _usbOpenDevices) {
     const cleanupOneDevice = withTimeout((async () => {
       try {
-        // DFU_CLRSTATUS (USB class request): bmRequestType=0x21, bRequest=0x00,
+        // DFU_CLRSTATUS (USB class request): bmRequestType=0x21, bRequest=0x04,
         // wValue=0, wIndex=0, wLength=0 — clears DFU status bits and returns
         // the device to dfuIDLE so it can be safely closed.
         await device.controlTransferOut({
-          requestType: 'class', recipient: 'interface', request: 0x00, value: 0, index: 0,
+          requestType: 'class', recipient: 'interface', request: 0x04, value: 0, index: 0,
         });
       } catch {
         // device may already be detached or in a state that rejects this — still attempt close

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "marked": "^18.0.9",
     "object-hash": "^3.0.0",
     "serialport": "^13.0.0",
-    "usb": "^2.17.0"
+    "usb": "^3.0.1"
   },
   "devDependencies": {
     "@electron-forge/cli": "7.11.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -665,6 +665,56 @@
   dependencies:
     cross-spawn "^7.0.1"
 
+"@node-usb/usb-darwin-arm64@3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@node-usb/usb-darwin-arm64/-/usb-darwin-arm64-3.0.1.tgz#de278cdb026c0691ddbc52cf9356dc2296d8d0b1"
+  integrity sha512-GB+MGKaXvEtaDOWng7nCPxWvnXWhZtbFL0FW9ncDmGYtFl3OW+xfLZGhd5Y9VKG6GXXIYS3x1FsBI+zkcxVMhA==
+
+"@node-usb/usb-darwin-x64@3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@node-usb/usb-darwin-x64/-/usb-darwin-x64-3.0.1.tgz#8c9fc14ce76cc5df9184f6c62f364afcbf92c0fa"
+  integrity sha512-oTY8vLoigjYFwNft1nZNNje0zAXjSQy9u3swe+pcCfZp6qQbEoSLegLEBr94arEgQloQabaq4VA2JZVA8cUQqQ==
+
+"@node-usb/usb-linux-arm-gnueabihf@3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@node-usb/usb-linux-arm-gnueabihf/-/usb-linux-arm-gnueabihf-3.0.1.tgz#38b85e62b9df7ab76195f4e5a91f04f523c97b2a"
+  integrity sha512-GN5dTxc/FhjmC9NP7Xx1esGAhpIhnNvAf02kk/0i7Cz0w1VaJ/I0XbIVAYIJ5zhDg/oSYkhdILHbOS9+mlWCRQ==
+
+"@node-usb/usb-linux-arm64-gnu@3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@node-usb/usb-linux-arm64-gnu/-/usb-linux-arm64-gnu-3.0.1.tgz#0ae08a0170cba3e3157ee4168297c5534753cb90"
+  integrity sha512-7cL85qb/yrBXvssZwL3k62duBxT/LaCY/Vcfv/Du9MLFdHhqU0zdYX5fLch/zaW5euYXQE0gmCoTfimfAjlxGQ==
+
+"@node-usb/usb-linux-arm64-musl@3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@node-usb/usb-linux-arm64-musl/-/usb-linux-arm64-musl-3.0.1.tgz#ee90a0dd93e171c8e849a08d71c052c9bf5c2ea9"
+  integrity sha512-EweA4HeTwzLiRHsU2DRFflJ3vx0shB5Z9Lt5/P/bkoUtSNt8uGjFCmsCjqoO068ul9oejsBMJg22rNLD3+iFqQ==
+
+"@node-usb/usb-linux-x64-gnu@3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@node-usb/usb-linux-x64-gnu/-/usb-linux-x64-gnu-3.0.1.tgz#0ef65148967fe351f4b1636cf3dab105ccb987ec"
+  integrity sha512-cEE7GyMhtfq5OM/MXZn3RmYBqPvId0CMuoBx7biazPvlnf0iEWYjpma0WvVMWad/f1QIcC45WgrazHaVv6gAPw==
+
+"@node-usb/usb-linux-x64-musl@3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@node-usb/usb-linux-x64-musl/-/usb-linux-x64-musl-3.0.1.tgz#122a11005ecbe4550b8ded5fb956e88a5e0e4aeb"
+  integrity sha512-zGWlk1mzElTPO4wxlRcd1C7xd7xDxzgpOXbQfE+NbClOUJ71NkbnahWN2ef2LcJvFESYg/CV9Dv/ULKSpJWEEw==
+
+"@node-usb/usb-win32-arm64-msvc@3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@node-usb/usb-win32-arm64-msvc/-/usb-win32-arm64-msvc-3.0.1.tgz#248b6ec97430d199adbd0c770402cc2107088dd8"
+  integrity sha512-ayXNeb+KvdkZLXzTWyttNONUPG8/x9PwuP+GvUeiYCQuyLMqmbGeMsO7IiuBWTnxLFtCdep+UBpcL8XMcYdTiA==
+
+"@node-usb/usb-win32-ia32-msvc@3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@node-usb/usb-win32-ia32-msvc/-/usb-win32-ia32-msvc-3.0.1.tgz#c8f90e5b6acfd27e2ea10b87ae3751997064577d"
+  integrity sha512-U5281i6yY7gtoTwLom8nLF2o+ILI/g4OFpbAJBr4GbVPOTu+CSNF2Ea+dLEAG30148mp8v79NEsIiAbWXS/1aw==
+
+"@node-usb/usb-win32-x64-msvc@3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@node-usb/usb-win32-x64-msvc/-/usb-win32-x64-msvc-3.0.1.tgz#8af801b4ebdd5c9a88a4e1ddd2fb62cc1b0ec234"
+  integrity sha512-T1jzCBwgnA6E5otxJS/j44b//6fGzHSDmLQtNN1fX6JvdQIisgtbf2+iKD/YI7E247j6Yi9Ixt+MKjHt64hugA==
+
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"
@@ -912,7 +962,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/w3c-web-usb@^1.0.6":
+"@types/w3c-web-usb@^1.0.14":
   version "1.0.14"
   resolved "https://registry.yarnpkg.com/@types/w3c-web-usb/-/w3c-web-usb-1.0.14.tgz#9b2c8e723045e7bf8018d47efe1b736815b23b38"
   integrity sha512-Qu3Nn6JFuF4+sHKYl+IcX9vYiI40ogleXzFFSxoE1W94rG98o/kXs8uJ0QSfFzuwBCZWlGfUGpPkgwuuX4PchA==
@@ -3088,11 +3138,6 @@ node-addon-api@8.3.0:
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-8.3.0.tgz#ec3763f18befc1cdf66d11e157ce44d5eddc0603"
   integrity sha512-8VOpLHFrOQlAH+qA0ZzuGRlALRA6/LVh8QJldbrC4DY0hXoMP0l4Acq8TzFC018HztWiRqyCEj2aTWY2UvnJUg==
 
-node-addon-api@^8.0.0:
-  version "8.7.0"
-  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-8.7.0.tgz#f64f8413456ecbe900221305a3f883c37666473f"
-  integrity sha512-9MdFxmkKaOYVTV+XVRG8ArDwwQ77XIgIPyKASB1k3JPq3M8fGQQQE3YpMOrKm6g//Ktx8ivZr8xo1Qmtqub+GA==
-
 node-api-version@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/node-api-version/-/node-api-version-0.2.1.tgz#19bad54f6d65628cbee4e607a325e4488ace2de9"
@@ -3107,7 +3152,7 @@ node-fetch@^2.6.7:
   dependencies:
     whatwg-url "^5.0.0"
 
-node-gyp-build@4.8.4, node-gyp-build@^4.5.0:
+node-gyp-build@4.8.4:
   version "4.8.4"
   resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.8.4.tgz#8a70ee85464ae52327772a90d66c6077a900cfc8"
   integrity sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==
@@ -4061,14 +4106,23 @@ uri-js@^4.2.2:
   dependencies:
     punycode "^2.1.0"
 
-usb@^2.17.0:
-  version "2.17.0"
-  resolved "https://registry.yarnpkg.com/usb/-/usb-2.17.0.tgz#ab4662aee723f0ed7c2a70ee622ff8d59491f018"
-  integrity sha512-UuFgrlglgDn5ll6d5l7kl3nDb2Yx43qLUGcDq+7UNLZLtbNug0HZBb2Xodhgx2JZB1LqvU+dOGqLEeYUeZqsHg==
+usb@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/usb/-/usb-3.0.1.tgz#d6c0ca3ba260c07a8ac1453092e474321e77615b"
+  integrity sha512-IQIi5EraqmKssMNcXe7afKhriHFAE5WdfykhvgkOschJyHBkJXtk/PDx/DzVNyfI7qdr+BUbmLziXA+I3z02lw==
   dependencies:
-    "@types/w3c-web-usb" "^1.0.6"
-    node-addon-api "^8.0.0"
-    node-gyp-build "^4.5.0"
+    "@types/w3c-web-usb" "^1.0.14"
+  optionalDependencies:
+    "@node-usb/usb-darwin-arm64" "3.0.1"
+    "@node-usb/usb-darwin-x64" "3.0.1"
+    "@node-usb/usb-linux-arm-gnueabihf" "3.0.1"
+    "@node-usb/usb-linux-arm64-gnu" "3.0.1"
+    "@node-usb/usb-linux-arm64-musl" "3.0.1"
+    "@node-usb/usb-linux-x64-gnu" "3.0.1"
+    "@node-usb/usb-linux-x64-musl" "3.0.1"
+    "@node-usb/usb-win32-arm64-msvc" "3.0.1"
+    "@node-usb/usb-win32-ia32-msvc" "3.0.1"
+    "@node-usb/usb-win32-x64-msvc" "3.0.1"
 
 username@^5.1.0:
   version "5.1.0"


### PR DESCRIPTION
AI Generated pull-request

## Summary

usb 2.17.0 -> 3.0.1 is a breaking major bump. The package was rewritten in Rust and dropped the classic synchronous node-usb API (`getDeviceList`, `device.interface()`, raw `controlTransfer`, callback-based `open`/`close`/`reset`) in favor of an async WebUSB-style surface (`getDevices`, `claimInterface`, `controlTransferIn`/`Out`, `transferIn`/`Out`).

`main.js`'s DFU device listing, open/close, claim/release interface, get-configuration, control-transfer, bulk-transfer, and reset IPC handlers are rewritten against the new API. Device identity keying switches from `busNumber:deviceAddress` to the native `device.handle`.

Upstream dependabot PR #664 (usb 2.17.0 -> 3.0.1) was closed as incompatible without this migration -- it only bumped the dependency and did not adapt `main.js`, which breaks DFU entirely (`usb.getDeviceList is not a function`).

Two issues were found and fixed via real-hardware testing during development, not caught by static analysis alone:
- usb@3.x rejects a control transfer on a STALL (`Error('endpoint stalled')`) rather than resolving `{status: 'stall'}` as its own type declarations claim. STALL is a normal, recoverable DFU protocol response and is now demoted to a warning, matching the old code's behavior.
- usb@3.x defaults every native transfer to a 1000ms timeout unless one is passed explicitly. An explicit 10s native timeout is now passed on every control/bulk transfer call, since environment-dependent USB stack/scheduling overhead can push a real transfer past the library default.

`usb@2.x` is not formally deprecated but its own README states development has moved to `node-usb-rs` (the 3.x line) since v3.0.0; no further 2.x releases are expected.

CodeRabbit review flagged a pre-existing bug in `cleanupConnectionsBeforeQuit`'s shutdown control transfer: it sent `bRequest=0x00` (DFU_DETACH) while intending DFU_CLRSTATUS (`bRequest=0x04`, per this codebase's own DFU request constants in `stm32usbdfu.js`). Confirmed this predates the migration (present on `upstream/master` under the classic API too) and was never caught because the real flash/erase driver already used the correct value elsewhere, and this call's result was always discarded. Fixed in a follow-up commit.

## Test plan

- [x] `node --check main.js` / `eslint main.js` -- 0 errors
- [x] Real hardware: DFU device listing (STM32 DFU device detected and enumerated)
- [x] Real hardware: full chip erase completed across multiple sector sizes
- [x] Real hardware: firmware flash + verification completed successfully
- [x] Real hardware: multiple hardware targets flashed and configured successfully
- [x] Windows x86_64: DFU/USB tested and working on real hardware. Author needed the ImpulseRC Driver Fixer to install a WinUSB driver for DFU mode -- a known, independent Windows driver requirement unrelated to this PR's code.
- [ ] macOS: not independently tested (author has no macOS hardware). CI's macOS build matrix (ARM64 + Intel) passes -- confirms the platform-specific native module installs and packages correctly. Functional DFU behavior is assumed to work given the identical WebUSB API is used across all platforms, but is not hardware-verified.

## Notes

macOS functional testing was not performed. Passing CI on macOS confirms packaging only, not DFU device behavior. If a macOS-specific issue surfaces post-merge, it will need to be filed and addressed separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved USB device discovery, connection, communication, and shutdown reliability.
  * Added stronger transfer timeout and status handling.
  * Improved recovery from interrupted USB transfers.

* **Chores**
  * Updated USB support to the latest API version for more reliable device operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->