### PR TITLE
fix: prevent duplicate open/save dialogs on rapid trigger

### DIFF
--- a/main.js
+++ b/main.js
@@ -901,43 +901,56 @@ ipcMain.handle('usb-reset-device', async (event, deviceKey) => {
 // --- File system dialog IPC bridge ---
 const { dialog } = require('electron');
 
+// Native dialogs opened without a parent window are non-modal, so a second
+// IPC call before the first resolves (double-click, double-triggered handler)
+// spawns a second OS dialog instead of focusing the existing one.
+let dialogChooseEntryInProgress = false;
+
 // IPC: show open/save file dialog; persists last-used folder across sessions
 ipcMain.handle('dialog:choose-entry', async (event, options) => {
-  const { type, suggestedName, accepts } = options;
-  const { lastDialogFolder } = loadConfig();
-
-  if (type === 'saveFile') {
-    const filters = accepts ? accepts.map(a => ({ name: a.description, extensions: a.extensions })) : [];
-    // Prefer last-used folder; fall back to suggestedName (which may itself be a filename only)
-    const defaultPath = lastDialogFolder
-      ? path.join(lastDialogFolder, suggestedName || '')
-      : suggestedName;
-    const result = await dialog.showSaveDialog({
-      defaultPath,
-      filters: filters.length > 0 ? filters : undefined,
-    });
-    if (!result.canceled && result.filePath) {
-      saveConfig({ lastDialogFolder: path.dirname(result.filePath) });
-    }
-    return result;
-  } else if (type === 'openFile') {
-    const openFilters = accepts
-      ? accepts.filter(a => Array.isArray(a.extensions) && a.extensions.length > 0)
-               .map(a => ({ name: a.description, extensions: a.extensions }))
-      : [];
-    // Use last-used folder as defaultPath; suggestedName is rarely set for openFile
-    const defaultPath = lastDialogFolder || suggestedName;
-    const result = await dialog.showOpenDialog({
-      defaultPath,
-      filters: openFilters,
-      properties: ['openFile'],
-    });
-    if (!result.canceled && result.filePaths && result.filePaths[0]) {
-      saveConfig({ lastDialogFolder: path.dirname(result.filePaths[0]) });
-    }
-    return result;
+  if (dialogChooseEntryInProgress) {
+    return { canceled: true };
   }
-  return { canceled: true };
+  dialogChooseEntryInProgress = true;
+  try {
+    const { type, suggestedName, accepts } = options;
+    const { lastDialogFolder } = loadConfig();
+
+    if (type === 'saveFile') {
+      const filters = accepts ? accepts.map(a => ({ name: a.description, extensions: a.extensions })) : [];
+      // Prefer last-used folder; fall back to suggestedName (which may itself be a filename only)
+      const defaultPath = lastDialogFolder
+        ? path.join(lastDialogFolder, suggestedName || '')
+        : suggestedName;
+      const result = await dialog.showSaveDialog({
+        defaultPath,
+        filters: filters.length > 0 ? filters : undefined,
+      });
+      if (!result.canceled && result.filePath) {
+        saveConfig({ lastDialogFolder: path.dirname(result.filePath) });
+      }
+      return result;
+    } else if (type === 'openFile') {
+      const openFilters = accepts
+        ? accepts.filter(a => Array.isArray(a.extensions) && a.extensions.length > 0)
+                 .map(a => ({ name: a.description, extensions: a.extensions }))
+        : [];
+      // Use last-used folder as defaultPath; suggestedName is rarely set for openFile
+      const defaultPath = lastDialogFolder || suggestedName;
+      const result = await dialog.showOpenDialog({
+        defaultPath,
+        filters: openFilters,
+        properties: ['openFile'],
+      });
+      if (!result.canceled && result.filePaths && result.filePaths[0]) {
+        saveConfig({ lastDialogFolder: path.dirname(result.filePaths[0]) });
+      }
+      return result;
+    }
+    return { canceled: true };
+  } finally {
+    dialogChooseEntryInProgress = false;
+  }
 });
 
 // IPC: write binary content to file (preserves binary data)

--- a/src/js/LogoManager.js
+++ b/src/js/LogoManager.js
@@ -192,6 +192,9 @@ LogoManager.openImage = function () {
                 console.error(chrome.runtime.lastError.message);
                 return;
             }
+            if (!fileEntry) {
+                return;
+            }
             // load and validate selected image
             var img = new Image();
             img.onload = () => {

--- a/src/js/tabs/firmware_flasher.js
+++ b/src/js/tabs/firmware_flasher.js
@@ -560,6 +560,9 @@ TABS.firmware_flasher.initialize = function (callback) {
                     console.error(chrome.runtime.lastError.message);
                     return;
                 }
+                if (!fileEntry) {
+                    return;
+                }
 
                 chrome.fileSystem.getDisplayPath(fileEntry, function (path) {
                     console.log('Saving firmware to: ' + path);

--- a/src/js/tabs/osd.js
+++ b/src/js/tabs/osd.js
@@ -165,11 +165,14 @@ FONT.parseMCMFontFile = function (data) {
 FONT.openFontFile = function (fontPreviewElement) {
     return new Promise(function (resolve) {
         chrome.fileSystem.chooseEntry({ type: 'openFile', accepts: [{ description: 'MCM files', extensions: ['mcm'] }] }, function (fileEntry) {
-            FONT.data.loaded_font_file = fileEntry.name;
             if (chrome.runtime.lastError) {
                 console.error(chrome.runtime.lastError.message);
                 return;
             }
+            if (!fileEntry) {
+                return;
+            }
+            FONT.data.loaded_font_file = fileEntry.name;
             fileEntry.file(function (file) {
                 var reader = new FileReader();
                 reader.onloadend = function (e) {
@@ -2885,6 +2888,9 @@ TABS.osd.initialize = function (callback) {
             chrome.fileSystem.chooseEntry({ type: 'saveFile', suggestedName: 'baseflight', accepts: [{ description: 'MCM files', extensions: ['mcm'] }] }, function (fileEntry) {
                 if (chrome.runtime.lastError) {
                     console.error(chrome.runtime.lastError.message);
+                    return;
+                }
+                if (!fileEntry) {
                     return;
                 }
 


### PR DESCRIPTION
AI Generated pull-request

## Summary
- Clicking Open or Save could spawn a second (or more) native file dialog if one was already open, since `dialog.showSaveDialog`/`dialog.showOpenDialog` are called without a parent window and are therefore non-modal — a second IPC call before the first resolves opens a new dialog instead of focusing the existing one.
- Add a module-level in-progress guard around the `dialog:choose-entry` IPC handler in `main.js`. A concurrent call while a dialog is already open now resolves immediately with `{ canceled: true }` instead of opening another dialog.
- Manual testing of the guard surfaced a related bug: `chrome.fileSystem.chooseEntry` resolves `fileEntry` to `null` on a cancelled or suppressed dialog, and `FONT.openFontFile`/`LogoManager.openImage`/the OSD and firmware-flasher save-file handlers dereferenced `fileEntry` before checking for `null`. Added the same `if (!fileEntry) return;` guard already used by the other call sites (`cli.js`, `backup_restore.js`, `onboard_logging.js`, `logging.js`).

## Test plan
- [x] `yarn lint` — 0 errors (pre-existing warnings only, none introduced)
- [x] Host-native harness: faked the `electron` module and drove the actual `dialog:choose-entry` handler directly — confirmed the pre-fix handler opens 2 dialogs on concurrent calls, and the fix reduces this to 1 dialog call with the second resolving `{ canceled: true }` immediately; a subsequent call after the first settles opens normally
- [x] Manual verification in the built app (`yarn dev`) — double-dialog no longer reproduces; testing surfaced the null-`fileEntry` crash on the OSD font-load dialog, fixed in the second commit
- [ ] Manual re-verification of the null-guard fix in the built app (OSD load/save font, firmware save, logo replace) after the second commit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented errors when canceling image, firmware, font, and file save dialogs.
  * Blocked overlapping file dialogs from opening simultaneously.
  * Improved handling of unavailable or canceled file selections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->