### PR TITLE
fix: settle FONT.openFontFile/LogoManager.openImage Promise on cancel

### DIFF
--- a/src/js/LogoManager.js
+++ b/src/js/LogoManager.js
@@ -213,7 +213,7 @@ LogoManager.openImage = function () {
                 reader.onload = () => { img.src = reader.result; };
                 reader.onerror = error => reject(error);
                 reader.readAsDataURL(file);
-            });
+            }, error => reject(error));
         });
     });
 };

--- a/src/js/LogoManager.js
+++ b/src/js/LogoManager.js
@@ -190,9 +190,11 @@ LogoManager.openImage = function () {
         chrome.fileSystem.chooseEntry(dialogOptions, fileEntry => {
             if (chrome.runtime.lastError) {
                 console.error(chrome.runtime.lastError.message);
+                reject(chrome.runtime.lastError);
                 return;
             }
             if (!fileEntry) {
+                resolve(null);
                 return;
             }
             // load and validate selected image

--- a/src/js/tabs/osd.js
+++ b/src/js/tabs/osd.js
@@ -179,7 +179,12 @@ FONT.openFontFile = function (fontPreviewElement) {
                 var reader = new FileReader();
                 reader.onloadend = function (e) {
                     if (e.total != 0 && e.total == e.loaded) {
-                        FONT.parseMCMFontFile(e.target.result);
+                        try {
+                            FONT.parseMCMFontFile(e.target.result);
+                        } catch (err) {
+                            reject(err);
+                            return;
+                        }
                         resolve(fileEntry);
                     }
                     else {
@@ -187,7 +192,12 @@ FONT.openFontFile = function (fontPreviewElement) {
                         reject(new Error('could not load whole font file'));
                     }
                 };
+                reader.onerror = function (e) {
+                    reject(e.target.error);
+                };
                 reader.readAsText(file);
+            }, function (err) {
+                reject(err);
             });
         });
     });

--- a/src/js/tabs/osd.js
+++ b/src/js/tabs/osd.js
@@ -163,13 +163,15 @@ FONT.parseMCMFontFile = function (data) {
 };
 
 FONT.openFontFile = function (fontPreviewElement) {
-    return new Promise(function (resolve) {
+    return new Promise(function (resolve, reject) {
         chrome.fileSystem.chooseEntry({ type: 'openFile', accepts: [{ description: 'MCM files', extensions: ['mcm'] }] }, function (fileEntry) {
             if (chrome.runtime.lastError) {
                 console.error(chrome.runtime.lastError.message);
+                reject(chrome.runtime.lastError);
                 return;
             }
             if (!fileEntry) {
+                resolve(null);
                 return;
             }
             FONT.data.loaded_font_file = fileEntry.name;
@@ -178,10 +180,11 @@ FONT.openFontFile = function (fontPreviewElement) {
                 reader.onloadend = function (e) {
                     if (e.total != 0 && e.total == e.loaded) {
                         FONT.parseMCMFontFile(e.target.result);
-                        resolve();
+                        resolve(fileEntry);
                     }
                     else {
                         console.error('could not load whole font file');
+                        reject(new Error('could not load whole font file'));
                     }
                 };
                 reader.readAsText(file);
@@ -2849,7 +2852,10 @@ TABS.osd.initialize = function (callback) {
 
 
         $('button.load_font_file').click(function () {
-            FONT.openFontFile().then(function () {
+            FONT.openFontFile().then(function (fileEntry) {
+                if (!fileEntry) {
+                    return;
+                }
                 FONT.preview(fontPreviewElement);
                 LogoManager.drawPreview();
                 updateOsdView();
@@ -2877,6 +2883,9 @@ TABS.osd.initialize = function (callback) {
             }
             LogoManager.openImage()
                 .then(ctx => {
+                    if (!ctx) {
+                        return;
+                    }
                     LogoManager.replaceLogoInFont(ctx);
                     LogoManager.drawPreview();
                     LogoManager.showUploadHint();


### PR DESCRIPTION
AI Generated pull-request

## Summary

Fixes #669. `FONT.openFontFile` (`src/js/tabs/osd.js`) and
`LogoManager.openImage` (`src/js/LogoManager.js`) each wrap
`chrome.fileSystem.chooseEntry` in a `new Promise(...)` but returned from
the callback without calling `resolve()`/`reject()` in several cases:

- dialog cancelled (`fileEntry` null)
- `chrome.runtime.lastError` set
- `fileEntry.file()` reporting an error (Electron shim's `dialog:read-file`
  IPC call rejecting — e.g. the selected file becomes unreadable between
  dialog selection and read)
- `FONT.openFontFile` only: the file-read-failure branch
  (`e.total != e.loaded`), and `FONT.parseMCMFontFile` throwing on malformed
  input inside the `FileReader.onloadend` handler

The Promise stayed pending forever in every case above.

## Fix

- `resolve(null)` on cancel; both callers (`osd.js` `load_font_file` and
  `replace_logo` click handlers) now check for a null resolved value
  before treating it as a loaded font/image.
- `reject()` on `chrome.runtime.lastError`, on the file-read-failure branch,
  on a `fileEntry.file()` error (added the missing `onError` callback
  argument in both functions), and on a `parseMCMFontFile` throw
  (wrapped in `try`/`catch`).

## Verification

No renderer-side test harness exists in this repo. Verified by extracting
the exact patched function bodies from the working tree and driving them
in Node with a mocked `chrome.fileSystem.chooseEntry`/`chrome.runtime`/
`FileReader`, confirming both functions settle (resolve or reject) instead
of hanging, for every branch listed above. Re-ran the same checks against
each prior commit's source to confirm they fail before the corresponding
fix (i.e. the checks detect the real bug, not a tautology).

Not verified: manual exercise in the running app (`yarn dev`) — no display
available in this session.

## Test plan

- [ ] `yarn dev`: OSD tab "load font", click Cancel on the dialog — no
  console errors, button remains usable, no other regression
- [ ] `yarn dev`: OSD tab "replace logo", click Cancel on the dialog —
  same
- [ ] `yarn lint` clean (0 errors; only pre-existing warnings)
