### PR TITLE
fix: guard serial connect/disconnect race and wrong-port auto-select during flashing

### DIFF
--- a/main.js
+++ b/main.js
@@ -425,7 +425,7 @@ ipcMain.handle('serial-connect', async (event, portPath, options) => {
     });
     if (myGen !== _serialGen) {
       // A later serial-connect/serial-disconnect superseded this call while open() was pending.
-      port.close(() => {});
+      try { port.close(() => {}); } catch (closeErr) { console.warn('main.js: error closing superseded port:', closeErr.message); }
       return null;
     }
 
@@ -455,7 +455,9 @@ ipcMain.handle('serial-connect', async (event, portPath, options) => {
     return { connectionId: 1, bitrate: options.bitrate || 115200 };
   } catch (e) {
     console.error('main.js: serial-connect failed:', e.message);
-    if (port && port.isOpen) port.close(() => {});
+    if (port && port.isOpen) {
+      try { port.close(() => {}); } catch (closeErr) { console.warn('main.js: error closing port after connect failure:', closeErr.message); }
+    }
     return null;
   }
 });
@@ -1371,6 +1373,7 @@ async function cleanupConnectionsBeforeQuit() {
   _usbOpenDevices.clear();
 
   if (_serialPort && _serialPort.isOpen) {
+    ++_serialGen; // invalidate any serial-connect still in flight during shutdown
     try {
       const currentPort = _serialPort;
       await withTimeout(new Promise((resolve) => {

--- a/main.js
+++ b/main.js
@@ -376,6 +376,11 @@ function resetWindowToPreferredBounds(win) {
 
 // --- Serial port IPC bridge ---
 let _serialPort = null; // active serialport instance
+// Bumped by every serial-connect/serial-disconnect call. A connect in flight across an
+// `await` re-checks its captured generation before touching `_serialPort` or attaching
+// listeners, so a concurrent disconnect/reconnect (e.g. a flash's reboot-and-reenumerate
+// handshake) can't race it into using a stale/nulled port instance.
+let _serialGen = 0;
 
 // IPC: list serial ports from main process
 ipcMain.handle('serial-list-ports', async () => {
@@ -398,6 +403,8 @@ ipcMain.handle('serial-list-ports', async () => {
 
 // IPC: open serial port
 ipcMain.handle('serial-connect', async (event, portPath, options) => {
+  const myGen = ++_serialGen;
+  let port;
   try {
     const { SerialPort } = require('serialport');
     if (_serialPort && _serialPort.isOpen) {
@@ -406,43 +413,57 @@ ipcMain.handle('serial-connect', async (event, portPath, options) => {
         resolve();
       }));
     }
-    _serialPort = new SerialPort({
+    if (myGen !== _serialGen) return null; // superseded while closing the previous port
+
+    port = new SerialPort({
       path: portPath,
       baudRate: options.bitrate || 115200,
       autoOpen: false,
     });
     await new Promise((resolve, reject) => {
-      _serialPort.open((err) => err ? reject(err) : resolve());
+      port.open((err) => err ? reject(err) : resolve());
     });
+    if (myGen !== _serialGen) {
+      // A later serial-connect/serial-disconnect superseded this call while open() was pending.
+      port.close(() => {});
+      return null;
+    }
+
+    _serialPort = port;
     // Forward incoming data to renderer
-    _serialPort.on('data', (data) => {
+    port.on('data', (data) => {
+      if (myGen !== _serialGen) return; // listener from a superseded connect
       safeSendToRenderer(event.sender, 'serial-data', data.buffer.slice(data.byteOffset, data.byteOffset + data.byteLength));
     });
     // Enhanced error handler to prevent uncaught exceptions
-    _serialPort.on('error', (err) => {
+    port.on('error', (err) => {
+      if (myGen !== _serialGen) return;
       console.error('main.js serialport error:', err.message);
       safeSendToRenderer(event.sender, 'serial-error', err.message);
       // Attempt graceful recovery
-      if (_serialPort && _serialPort.isOpen) {
-        _serialPort.close((err) => {
+      if (_serialPort === port && port.isOpen) {
+        port.close((err) => {
           if (err) console.error('main.js: error closing serial port after error:', err.message);
           else console.log('main.js: closed serial port after error');
         });
       }
     });
-    _serialPort.on('close', () => {
+    port.on('close', () => {
+      if (myGen !== _serialGen) return;
       safeSendToRenderer(event.sender, 'serial-close');
     });
     return { connectionId: 1, bitrate: options.bitrate || 115200 };
   } catch (e) {
     console.error('main.js: serial-connect failed:', e.message);
+    if (port && port.isOpen) port.close(() => {});
     return null;
   }
 });
 
 // IPC: send data over serial port
 ipcMain.handle('serial-send', async (event, bufferData) => {
-  if (!_serialPort || !_serialPort.isOpen) return { bytesSent: 0, error: 'not_connected' };
+  const port = _serialPort; // capture: a concurrent disconnect/reconnect must not redirect this write
+  if (!port || !port.isOpen) return { bytesSent: 0, error: 'not_connected' };
   const buf = Buffer.from(bufferData);
   return new Promise((resolve) => {
     let settled = false;
@@ -456,7 +477,7 @@ ipcMain.handle('serial-send', async (event, bufferData) => {
     }, 10000);
 
     try {
-      _serialPort.write(buf, (err) => {
+      port.write(buf, (err) => {
         if (settled) return;
         if (err) {
           settled = true;
@@ -483,27 +504,26 @@ ipcMain.handle('serial-send', async (event, bufferData) => {
 
 // IPC: close serial port
 ipcMain.handle('serial-disconnect', async () => {
-  if (!_serialPort || !_serialPort.isOpen) {
-    _serialPort = null;
+  ++_serialGen; // invalidate any serial-connect currently in flight
+  const port = _serialPort;
+  _serialPort = null;
+  if (!port || !port.isOpen) {
     return true;
   }
   return new Promise((resolve) => {
     const timeoutId = setTimeout(() => {
       console.error('main.js: serial-disconnect timeout, forcing cleanup');
-      _serialPort = null;
       resolve(false);
     }, 5000);
 
     try {
-      _serialPort.close((err) => {
+      port.close((err) => {
         clearTimeout(timeoutId);
-        _serialPort = null;
         resolve(!err);
       });
     } catch (e) {
       clearTimeout(timeoutId);
       console.error('main.js: serial-disconnect exception:', e.message);
-      _serialPort = null;
       resolve(false);
     }
   });

--- a/main.js
+++ b/main.js
@@ -1372,8 +1372,8 @@ async function cleanupConnectionsBeforeQuit() {
   await Promise.allSettled(usbCleanupPromises);
   _usbOpenDevices.clear();
 
+  ++_serialGen; // invalidate any serial-connect still in flight during shutdown, even if _serialPort isn't assigned yet
   if (_serialPort && _serialPort.isOpen) {
-    ++_serialGen; // invalidate any serial-connect still in flight during shutdown
     try {
       const currentPort = _serialPort;
       await withTimeout(new Promise((resolve) => {

--- a/src/js/port_handler.js
+++ b/src/js/port_handler.js
@@ -155,8 +155,13 @@ PortHandler.check = function () {
             if (unambiguous_candidate && GUI.auto_connect && !GUI.connecting_to && !GUI.connected_to) {
                 // we need firmware flasher protection over here
                 if (GUI.active_tab != 'firmware_flasher') {
+                    var detected_candidate = fc_candidates[0];
                     GUI.timeout_add('auto-connect_timeout', function () {
                         // Re-validate state: 1s may have passed and conditions can change.
+                        // Also require the port picker to still show the exact candidate
+                        // this timeout was scheduled for -- otherwise the user changed the
+                        // selection (e.g. to manual entry) or a later poll cycle updated it,
+                        // and this stale timeout must not connect to a different port.
                         var connectBtn = $('div#port-picker a.connect');
                         var selectedPort = $('div#port-picker #port').val();
                         var stateValid = GUI.auto_connect
@@ -164,7 +169,7 @@ PortHandler.check = function () {
                             && !GUI.connecting_to
                             && GUI.active_tab != 'firmware_flasher'
                             && connectBtn.length > 0
-                            && selectedPort && selectedPort !== '0';
+                            && selectedPort === detected_candidate;
                         if (stateValid) {
                             connectBtn.click();
                         }

--- a/src/js/port_handler.js
+++ b/src/js/port_handler.js
@@ -182,7 +182,7 @@ PortHandler.check = function () {
                 }
             }
 
-            self.initial_ports = current_ports;
+            self.absorb_resolved_ports(new_ports, fc_candidates, unambiguous_candidate, current_ports);
         }
 
         self.check_usb_devices();
@@ -210,6 +210,25 @@ PortHandler.check = function () {
             self.check();
         }, TIMEOUT_CHECK);
     });
+};
+
+// Folds resolved new ports into initial_ports so they stop being re-flagged as
+// "new". An unambiguous candidate (already handled above) or pure noise (no FC
+// candidates at all) is fully adopted. An ambiguous FC-candidate set is only
+// partially adopted -- the candidates themselves are kept OUT of initial_ports
+// so array_difference() re-surfaces them on the next poll and the ambiguity is
+// re-evaluated instead of being silently adopted and never resolved.
+PortHandler.absorb_resolved_ports = function (new_ports, fc_candidates, unambiguous_candidate, current_ports) {
+    if (unambiguous_candidate || fc_candidates.length === 0) {
+        this.initial_ports = current_ports;
+        return;
+    }
+
+    for (var i = 0; i < new_ports.length; i++) {
+        if (fc_candidates.indexOf(new_ports[i]) === -1) {
+            this.initial_ports.push(new_ports[i]);
+        }
+    }
 };
 
 // Excludes device paths that can't be the FC (see NON_FC_PORT_PATTERN) from a

--- a/src/js/port_handler.js
+++ b/src/js/port_handler.js
@@ -136,7 +136,7 @@ PortHandler.check = function () {
             self.update_port_select(current_ports);
 
             var fc_candidates = self.resolve_fc_candidates(new_ports);
-            var unambiguous_candidate = (fc_candidates.length == 1);
+            var unambiguous_candidate = (fc_candidates.length === 1);
 
             // select / highlight new port, if connected -> select connected port
             if (!GUI.connected_to) {

--- a/src/js/port_handler.js
+++ b/src/js/port_handler.js
@@ -127,6 +127,12 @@ PortHandler.check = function () {
                 console.log('PortHandler - Found: ' + new_ports[0]);
             }
 
+            // update_port_select() rebuilds the <option> list from scratch, which
+            // drops the current selection unless something re-sets it below --
+            // capture it first so a non-candidate/ambiguous poll can restore it
+            // instead of silently falling back to the browser's first-option default.
+            var previously_selected_port = $('div#port-picker #port').val();
+
             self.update_port_select(current_ports);
 
             var fc_candidates = self.resolve_fc_candidates(new_ports);
@@ -136,9 +142,11 @@ PortHandler.check = function () {
             if (!GUI.connected_to) {
                 if (unambiguous_candidate) {
                     $('div#port-picker #port').val(fc_candidates[0]);
+                } else {
+                    // No FC-shaped candidate, or more than one -- leave the user's
+                    // prior selection alone instead of guessing which device is the FC.
+                    $('div#port-picker #port').val(previously_selected_port);
                 }
-                // else: no FC-shaped candidate, or more than one -- leave the port
-                // picker as-is instead of guessing which device is the FC.
             } else {
                 $('div#port-picker #port').val(GUI.connected_to);
             }

--- a/src/js/port_handler.js
+++ b/src/js/port_handler.js
@@ -8,6 +8,11 @@ var usbDevices = { filters: [
     {'vendorId': 12619, 'productId': 262} // APM32 DFU Bootloader
 ] };
 
+// Device paths that can never be a flight controller's USB-serial re-enumeration --
+// excluded from auto-connect/auto-select candidates so an unrelated device (e.g. a
+// Bluetooth RFCOMM service registering mid-reboot) never gets picked over the FC.
+var NON_FC_PORT_PATTERN = /^\/dev\/rfcomm\d+$/i;
+
 var PortHandler = new function () {
     this.initial_ports = false;
     this.port_detected_callbacks = [];
@@ -122,15 +127,22 @@ PortHandler.check = function () {
 
             self.update_port_select(current_ports);
 
+            var fc_candidates = self.resolve_fc_candidates(new_ports);
+            var unambiguous_candidate = (fc_candidates.length == 1);
+
             // select / highlight new port, if connected -> select connected port
             if (!GUI.connected_to) {
-                $('div#port-picker #port').val(new_ports[0]);
+                if (unambiguous_candidate) {
+                    $('div#port-picker #port').val(fc_candidates[0]);
+                }
+                // else: no FC-shaped candidate, or more than one -- leave the port
+                // picker as-is instead of guessing which device is the FC.
             } else {
                 $('div#port-picker #port').val(GUI.connected_to);
             }
 
             // start connect procedure (if statement is valid)
-            if (GUI.auto_connect && !GUI.connecting_to && !GUI.connected_to) {
+            if (unambiguous_candidate && GUI.auto_connect && !GUI.connecting_to && !GUI.connected_to) {
                 // we need firmware flasher protection over here
                 if (GUI.active_tab != 'firmware_flasher') {
                     GUI.timeout_add('auto-connect_timeout', function () {
@@ -150,19 +162,24 @@ PortHandler.check = function () {
                 }
             }
 
-            // trigger callbacks
-            for (var i = (self.port_detected_callbacks.length - 1); i >= 0; i--) {
-                var obj = self.port_detected_callbacks[i];
+            // trigger callbacks only once the new-port set resolves to exactly one
+            // FC-shaped candidate; leave them registered otherwise so a later poll
+            // (once the ambiguity clears) can still resolve them (see port_detected's
+            // ignore_timeout usage in firmware_flasher.js's flash_on_connect).
+            if (unambiguous_candidate) {
+                for (var i = (self.port_detected_callbacks.length - 1); i >= 0; i--) {
+                    var obj = self.port_detected_callbacks[i];
 
-                // remove timeout
-                clearTimeout(obj.timer);
+                    // remove timeout
+                    clearTimeout(obj.timer);
 
-                // trigger callback
-                obj.code(new_ports);
+                    // trigger callback
+                    obj.code(fc_candidates);
 
-                // remove object from array
-                var index = self.port_detected_callbacks.indexOf(obj);
-                if (index > -1) self.port_detected_callbacks.splice(index, 1);
+                    // remove object from array
+                    var index = self.port_detected_callbacks.indexOf(obj);
+                    if (index > -1) self.port_detected_callbacks.splice(index, 1);
+                }
             }
 
             self.initial_ports = current_ports;
@@ -193,6 +210,21 @@ PortHandler.check = function () {
             self.check();
         }, TIMEOUT_CHECK);
     });
+};
+
+// Excludes device paths that can't be the FC (see NON_FC_PORT_PATTERN) from a
+// newly-appeared port list, so an unrelated device never gets auto-selected in
+// place of the FC re-enumerating after a reboot.
+PortHandler.resolve_fc_candidates = function (new_ports) {
+    var fc_candidates = new_ports.filter(function (port) {
+        return !NON_FC_PORT_PATTERN.test(port);
+    });
+
+    if (fc_candidates.length > 1) {
+        console.log('PortHandler - ambiguous new ports, skipping auto-select: ' + fc_candidates);
+    }
+
+    return fc_candidates;
 };
 
 PortHandler.check_usb_devices = function (callback) {

--- a/src/js/port_handler.js
+++ b/src/js/port_handler.js
@@ -8,9 +8,11 @@ var usbDevices = { filters: [
     {'vendorId': 12619, 'productId': 262} // APM32 DFU Bootloader
 ] };
 
-// Device paths that can never be a flight controller's USB-serial re-enumeration --
-// excluded from auto-connect/auto-select candidates so an unrelated device (e.g. a
-// Bluetooth RFCOMM service registering mid-reboot) never gets picked over the FC.
+// Linux Bluetooth RFCOMM device paths -- excluded from auto-connect/auto-select
+// candidates so a Bluetooth service registering mid-reboot (the confirmed repro
+// in emuflight/EmuConfigurator#638, e.g. /dev/rfcomm0) never gets picked over
+// the FC. Linux-specific: does not cover macOS/Windows Bluetooth SPP device
+// naming, which isn't distinguishable from a real FC port by path alone.
 var NON_FC_PORT_PATTERN = /^\/dev\/rfcomm\d+$/i;
 
 var PortHandler = new function () {
@@ -231,9 +233,9 @@ PortHandler.absorb_resolved_ports = function (new_ports, fc_candidates, unambigu
     }
 };
 
-// Excludes device paths that can't be the FC (see NON_FC_PORT_PATTERN) from a
-// newly-appeared port list, so an unrelated device never gets auto-selected in
-// place of the FC re-enumerating after a reboot.
+// Excludes known non-FC device paths (see NON_FC_PORT_PATTERN) from a
+// newly-appeared port list, so a Bluetooth RFCOMM device never gets
+// auto-selected in place of the FC re-enumerating after a reboot.
 PortHandler.resolve_fc_candidates = function (new_ports) {
     var fc_candidates = new_ports.filter(function (port) {
         return !NON_FC_PORT_PATTERN.test(port);

--- a/src/js/serial_backend.js
+++ b/src/js/serial_backend.js
@@ -292,6 +292,10 @@ function onOpen(openInfo) {
         console.log('Failed to open serial port');
         GUI.log(i18n.getMessage('serialPortOpenFail'));
 
+        // Without this, a failed/superseded open leaves connecting_to set forever,
+        // permanently blocking PortHandler's auto-connect gate (!GUI.connecting_to).
+        GUI.connecting_to = false;
+
         $('div#connectbutton a.connect_state').text(i18n.getMessage('connect'));
         $('div#connectbutton a.connect').removeClass('active');
 


### PR DESCRIPTION
AI Generated pull-request

## Summary

Firmware flashing could sometimes stop after the "Flashing" progress label appears, or fail to find the serial port after a reboot, with no consistent trigger. Root cause is the same class of defect as emuflight/EmuConfigurator#638 Findings 2 and 3 (originally filed against save-and-reboot tabs only), generalized to the firmware flasher's own reboot/reconnect path:

- `main.js`'s shared `_serialPort` handle had no generation tracking. A `serial-connect`/`serial-disconnect` racing across an `await` (the exact churn produced by `stm32.js`'s reboot-to-DFU handshake) could throw `Cannot read properties of null (reading 'on')` or attach listeners to a stale port instance. Fixed with a generation-token guard: each connect captures a token and re-checks it after every `await` before touching shared state.
- `port_handler.js`'s new-port auto-select picked `new_ports[0]` with no identity check, so an unrelated serial device (e.g. Bluetooth RFCOMM) enumerating in the same ~500ms poll window could be auto-selected ahead of the flight controller. Fixed by filtering known non-FC device paths and only acting on an unambiguous single candidate, re-evaluating on later polls otherwise.

Reviewed with local CodeRabbit CLI (3 rounds, 0 findings on final code -- round 1 caught a real ambiguous-candidate bug, fixed), and opencode (4 additional real issues found via full call-graph trace and fixed: `GUI.connecting_to` left stuck on a superseded connect, an unguarded double-close edge case, app-quit not invalidating an in-flight connect's generation, and the port-picker dropdown silently losing the user's manual selection during an ambiguous poll).

## Test plan
- [x] `node --check` on all modified files
- [x] `yarn lint` -- 0 errors (unchanged from baseline)
- [x] Headless `yarn dev` launch smoke-test (Xvfb) -- no JS-level crash
- [x] Hardware: PYRODRONEF7 flashed successfully 3x on `/dev/ttyACM1` with a phone connected as `/dev/ttyACM0` throughout (confirms normal flashing and the candidate-filtering fix both work correctly with another serial device present)
- [x] Hardware: confirmed operation-in-progress gating (`GUI.connect_lock`) correctly blocks interleaving actions during an active erase/flash
- [ ] Not tested: the exact concurrent-connect race requires switching away from the firmware_flasher tab mid-flash, which is gated off during normal single-tab use -- no test harness exists in this repo (see AGENTS.md) to verify this synthetically

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection handling during port opening, closing, and shutdown to prevent stale operations from affecting active connections.
  * Prevented failed or cancelled connection attempts from blocking future automatic connections.
  * Excluded Bluetooth RFCOMM ports from flight-controller detection.
  * Improved port selection when multiple possible flight-controller ports are detected.
  * Prevented stale data and error events from disconnected ports from being forwarded.
  * Preserved the current port selection when no unique flight-controller candidate is available.
  * Ensured delayed connections target the originally selected port.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->