### PR TITLE
fix: substitute manual port override in firmware flasher

### DIFF
--- a/src/js/port_handler.js
+++ b/src/js/port_handler.js
@@ -132,6 +132,7 @@ PortHandler.check = function () {
             // capture it first so a non-candidate/ambiguous poll can restore it
             // instead of silently falling back to the browser's first-option default.
             var previously_selected_port = $('div#port-picker #port').val();
+            var manual_was_selected = (previously_selected_port === 'manual');
 
             self.update_port_select(current_ports);
 
@@ -140,7 +141,11 @@ PortHandler.check = function () {
 
             // select / highlight new port, if connected -> select connected port
             if (!GUI.connected_to) {
-                if (unambiguous_candidate) {
+                if (manual_was_selected) {
+                    // User explicitly chose manual entry -- a new port enumerating
+                    // must not silently discard that selection.
+                    $('div#port-picker #port').val('manual');
+                } else if (unambiguous_candidate) {
                     $('div#port-picker #port').val(fc_candidates[0]);
                 } else {
                     // No FC-shaped candidate, or more than one -- leave the user's

--- a/src/js/port_handler.js
+++ b/src/js/port_handler.js
@@ -132,16 +132,6 @@ PortHandler.check = function () {
             // capture it first so a non-candidate/ambiguous poll can restore it
             // instead of silently falling back to the browser's first-option default.
             var previously_selected_port = $('div#port-picker #port').val();
-            // 'manual' can be selected two ways: the user deliberately chose it and
-            // typed an override path, or it's simply the only <option> update_port_select()
-            // ever appends when no real port exists yet (incidental, not a real choice).
-            // Only the former should survive a new port enumerating -- otherwise a genuine
-            // single FC candidate could never be offered again once nothing was plugged in
-            // at some earlier poll. Mirrors the same isManual + typed-override check used
-            // for connect-button gating further down in this function.
-            var manual_was_selected = $('div#port-picker #port option:selected').data('isManual')
-                && $('#port-override').val().trim() !== ''
-                && $('#port-override').val().trim() !== '0';
 
             self.update_port_select(current_ports);
 
@@ -150,11 +140,7 @@ PortHandler.check = function () {
 
             // select / highlight new port, if connected -> select connected port
             if (!GUI.connected_to) {
-                if (manual_was_selected) {
-                    // User has a manual override path typed in -- a new port enumerating
-                    // must not silently discard that selection.
-                    $('div#port-picker #port').val('manual');
-                } else if (unambiguous_candidate) {
+                if (unambiguous_candidate) {
                     $('div#port-picker #port').val(fc_candidates[0]);
                 } else {
                     // No FC-shaped candidate, or more than one -- leave the user's

--- a/src/js/port_handler.js
+++ b/src/js/port_handler.js
@@ -132,7 +132,16 @@ PortHandler.check = function () {
             // capture it first so a non-candidate/ambiguous poll can restore it
             // instead of silently falling back to the browser's first-option default.
             var previously_selected_port = $('div#port-picker #port').val();
-            var manual_was_selected = (previously_selected_port === 'manual');
+            // 'manual' can be selected two ways: the user deliberately chose it and
+            // typed an override path, or it's simply the only <option> update_port_select()
+            // ever appends when no real port exists yet (incidental, not a real choice).
+            // Only the former should survive a new port enumerating -- otherwise a genuine
+            // single FC candidate could never be offered again once nothing was plugged in
+            // at some earlier poll. Mirrors the same isManual + typed-override check used
+            // for connect-button gating further down in this function.
+            var manual_was_selected = $('div#port-picker #port option:selected').data('isManual')
+                && $('#port-override').val().trim() !== ''
+                && $('#port-override').val().trim() !== '0';
 
             self.update_port_select(current_ports);
 
@@ -142,7 +151,7 @@ PortHandler.check = function () {
             // select / highlight new port, if connected -> select connected port
             if (!GUI.connected_to) {
                 if (manual_was_selected) {
-                    // User explicitly chose manual entry -- a new port enumerating
+                    // User has a manual override path typed in -- a new port enumerating
                     // must not silently discard that selection.
                     $('div#port-picker #port').val('manual');
                 } else if (unambiguous_candidate) {

--- a/src/js/tabs/firmware_flasher.js
+++ b/src/js/tabs/firmware_flasher.js
@@ -532,7 +532,14 @@ TABS.firmware_flasher.initialize = function (callback) {
                             // '0'/'' sentinel checks below and gets handed to STM32.connect().
                             var port = (rawPort === null || rawPort === undefined) ? '' : String(rawPort).trim();
 
-                            if (port !== '0' && port !== '') {
+                            if (port === 'DFU') {
+                                // A manual override typed as the literal string 'DFU' is not a
+                                // real DFU-mode selection (that's the outer picker-value check
+                                // above) -- treat it the same way the Connect button does instead
+                                // of handing the literal string to STM32.connect() as a port path.
+                                flashComplete();
+                                GUI.log(i18n.getMessage('dfu_connect_message'));
+                            } else if (port !== '0' && port !== '') {
                                 var baud;
                                 baud = 115200;
 

--- a/src/js/tabs/firmware_flasher.js
+++ b/src/js/tabs/firmware_flasher.js
@@ -533,12 +533,11 @@ TABS.firmware_flasher.initialize = function (callback) {
                             const port = (rawPort === null || rawPort === undefined) ? '' : String(rawPort).trim();
 
                             if (port === 'DFU') {
-                                // A manual override typed as the literal string 'DFU' is not a
-                                // real DFU-mode selection (that's the outer picker-value check
-                                // above) -- treat it the same way the Connect button does instead
-                                // of handing the literal string to STM32.connect() as a port path.
-                                flashComplete();
-                                GUI.log(i18n.getMessage('dfu_connect_message'));
+                                // A manual override typed as the literal string 'DFU' means the
+                                // same thing as picking the real DFU option -- attempt the same
+                                // USB DFU handshake instead of handing the literal string to
+                                // STM32.connect() as a serial port path.
+                                STM32DFU.connect(usbDevices, parsed_hex, options, flashComplete);
                             } else if (port !== '0' && port !== '') {
                                 var baud;
                                 baud = 115200;

--- a/src/js/tabs/firmware_flasher.js
+++ b/src/js/tabs/firmware_flasher.js
@@ -526,9 +526,13 @@ TABS.firmware_flasher.initialize = function (callback) {
                             // substitute the typed override path, matching the same
                             // isManual handling serial_backend.js uses for the Connect button.
                             var isManualPortSelected = $('div#port-picker #port option:selected').data('isManual');
-                            var port = isManualPortSelected ? $('#port-override').val().trim() : String($('div#port-picker #port').val());
+                            var rawPort = isManualPortSelected ? $('#port-override').val() : $('div#port-picker #port').val();
+                            // .val() can return null (no option selected); String(null) would
+                            // otherwise become the literal string "null", which passes the
+                            // '0'/'' sentinel checks below and gets handed to STM32.connect().
+                            var port = (rawPort === null || rawPort === undefined) ? '' : String(rawPort).trim();
 
-                            if (port != '0' && port != '') {
+                            if (port !== '0' && port !== '') {
                                 var baud;
                                 baud = 115200;
 

--- a/src/js/tabs/firmware_flasher.js
+++ b/src/js/tabs/firmware_flasher.js
@@ -522,8 +522,14 @@ TABS.firmware_flasher.initialize = function (callback) {
                         };
 
                         if (String($('div#port-picker #port').val()) != 'DFU') {
-                            if (String($('div#port-picker #port').val()) != '0') {
-                                var port = String($('div#port-picker #port').val()), baud;
+                            // Manual entry's picker value is the literal string 'manual' --
+                            // substitute the typed override path, matching the same
+                            // isManual handling serial_backend.js uses for the Connect button.
+                            var isManualPortSelected = $('div#port-picker #port option:selected').data('isManual');
+                            var port = isManualPortSelected ? $('#port-override').val().trim() : String($('div#port-picker #port').val());
+
+                            if (port != '0' && port != '') {
+                                var baud;
                                 baud = 115200;
 
                                 if ($('input.updating').is(':checked')) {

--- a/src/js/tabs/firmware_flasher.js
+++ b/src/js/tabs/firmware_flasher.js
@@ -525,12 +525,12 @@ TABS.firmware_flasher.initialize = function (callback) {
                             // Manual entry's picker value is the literal string 'manual' --
                             // substitute the typed override path, matching the same
                             // isManual handling serial_backend.js uses for the Connect button.
-                            var isManualPortSelected = $('div#port-picker #port option:selected').data('isManual');
-                            var rawPort = isManualPortSelected ? $('#port-override').val() : $('div#port-picker #port').val();
+                            const isManualPortSelected = $('div#port-picker #port option:selected').data('isManual');
+                            const rawPort = isManualPortSelected ? $('#port-override').val() : $('div#port-picker #port').val();
                             // .val() can return null (no option selected); String(null) would
                             // otherwise become the literal string "null", which passes the
                             // '0'/'' sentinel checks below and gets handed to STM32.connect().
-                            var port = (rawPort === null || rawPort === undefined) ? '' : String(rawPort).trim();
+                            const port = (rawPort === null || rawPort === undefined) ? '' : String(rawPort).trim();
 
                             if (port === 'DFU') {
                                 // A manual override typed as the literal string 'DFU' is not a


### PR DESCRIPTION
AI Generated pull-request

## Summary

`firmware_flasher.js`'s Flash button read the port-picker's raw `.val()`, which is the literal string `"manual"` when manual entry is selected -- not the typed override path. `STM32.connect()` then tried to open a serial device literally named `manual` and failed (`SERIAL: Failed to open serial port`).

The normal Connect button (`serial_backend.js`) already substitutes `#port-override` via the option's `isManual` data flag; the Flash button now does the same substitution, with an explicit null-guard since `.val()` returning `null` would otherwise coerce to the string `"null"` and pass the validity check.

A CodeRabbit follow-up analysis on this PR (since the bot's incremental reviewer had already reviewed the earlier commits and couldn't re-run) caught one more divergence: the outer DFU-mode check tested the raw picker value, so a manual override typed as the literal string `DFU` fell through to `STM32.connect('DFU', ...)`. First fix made this show the same `dfu_connect_message` the Connect button shows -- but that message tells the user to switch to the Firmware Flasher tab, which doesn't make sense when already on that tab. Corrected to instead route this case to the same `STM32DFU.connect()` call the real DFU picker option already uses -- a manual override of `"DFU"` now behaves identically to selecting the real DFU entry, which is a legitimate, separate, auto-detected dropdown entry that this change does not touch.

## Background

This PR originally also attempted to fix #673 (auto-detected port overwriting a manual selection) in `port_handler.js`. That change was reverted after hardware testing showed it broke the primary bench-test workflow: sequential FC swaps rely on an unambiguous FC candidate always taking over the port picker, including over a stale manual selection. `port_handler.js` is unchanged from `upstream/master` in the final state of this PR. See comment on #673 for detail.

## Test plan
- [x] `yarn lint` — 0 errors, no new warning categories
- [x] `port_handler.js` confirmed byte-identical to `upstream/master` after revert
- [x] Manual hardware verification: Flash with manual entry (typed override path) now succeeds -- previously failed with `SERIAL: Failed to open serial port`
- [x] Manual hardware verification: with two boards connected (`/dev/ttyACM0` MSP-connected, `/dev/ttyACM1` selected in the port picker), flashing `/dev/ttyACM1` succeeds and does not affect `/dev/ttyACM0` -- confirms the app's single-connection architecture (`main.js` generation-tracked `_serialPort`) cleanly scopes the reboot-to-DFU handshake to the selected port only
- [x] Manual hardware verification: manual override typed as `DFU` now correctly triggers the USB DFU flash path
- [x] Reviewed: local CodeRabbit CLI (0 findings), opencode independent LLM review (correct, no blocking issues), CodeRabbit GitHub bot free-form analysis (2 rounds, both findings fixed)