### PR TITLE
feat: give firmware flasher its own folder memory

### DIFF
--- a/main.js
+++ b/main.js
@@ -229,7 +229,9 @@ const MAX_ZOOM_LEVEL = 9;
 // Maps a renderer-supplied dialogId to its own remembered-folder config key. An id not listed
 // here (or omitted) falls back to 'lastDialogFolder'. loadConfig/saveConfig derive their
 // whitelist from FOLDER_MEMORY_KEYS below, so adding a bucket here is the only step required.
-const DIALOG_FOLDER_KEYS = { firmware: 'lastFirmwareFolder' };
+// Null-prototype so a dialogId like 'toString' or 'constructor' can't resolve to an inherited
+// Object.prototype member instead of falling through to the shared key.
+const DIALOG_FOLDER_KEYS = { __proto__: null, firmware: 'lastFirmwareFolder' };
 const FOLDER_MEMORY_KEYS = ['lastDialogFolder', ...new Set(Object.values(DIALOG_FOLDER_KEYS))];
 
 // In-memory zoom level — single source of truth; avoids disk reads on resize

--- a/main.js
+++ b/main.js
@@ -226,6 +226,12 @@ const DEFAULT_ZOOM_LEVEL = 0; // Ctrl+0 actual size
 const MIN_ZOOM_LEVEL = -9;
 const MAX_ZOOM_LEVEL = 9;
 
+// Maps a renderer-supplied dialogId to its own remembered-folder config key. An id not listed
+// here (or omitted) falls back to 'lastDialogFolder'. loadConfig/saveConfig derive their
+// whitelist from FOLDER_MEMORY_KEYS below, so adding a bucket here is the only step required.
+const DIALOG_FOLDER_KEYS = { firmware: 'lastFirmwareFolder' };
+const FOLDER_MEMORY_KEYS = ['lastDialogFolder', ...new Set(Object.values(DIALOG_FOLDER_KEYS))];
+
 // In-memory zoom level — single source of truth; avoids disk reads on resize
 // and eliminates races between the F12 handler and devtools-opened/closed handlers.
 let _currentZoom = DEFAULT_ZOOM_LEVEL;
@@ -250,9 +256,13 @@ function loadConfig() {
       const data = fs.readFileSync(APP_CONFIG_FILE, 'utf8');
       const config = JSON.parse(data);
       const wb = config.windowBounds;
+      const folders = {};
+      for (const key of FOLDER_MEMORY_KEYS) {
+        folders[key] = typeof config[key] === 'string' ? config[key] : '';
+      }
       return {
         zoomLevel: typeof config.zoomLevel === 'number' ? config.zoomLevel : DEFAULT_ZOOM_LEVEL,
-        lastDialogFolder: typeof config.lastDialogFolder === 'string' ? config.lastDialogFolder : '',
+        ...folders,
         windowBounds: (wb && typeof wb.x === 'number' && typeof wb.y === 'number' &&
                        typeof wb.width === 'number' && typeof wb.height === 'number') ? wb : null,
         isMaximized: typeof config.isMaximized === 'boolean' ? config.isMaximized : false,
@@ -261,7 +271,12 @@ function loadConfig() {
   } catch (e) {
     console.error('Failed to load app config:', e);
   }
-  return { zoomLevel: DEFAULT_ZOOM_LEVEL, lastDialogFolder: '', windowBounds: null, isMaximized: false };
+  return {
+    zoomLevel: DEFAULT_ZOOM_LEVEL,
+    ...Object.fromEntries(FOLDER_MEMORY_KEYS.map(key => [key, ''])),
+    windowBounds: null,
+    isMaximized: false,
+  };
 }
 
 // Save unified app config (sanitizes known fields, merges with existing config)
@@ -272,8 +287,10 @@ function saveConfig(patch) {
     if ('zoomLevel' in patch) {
       sanitizedPatch.zoomLevel = clampZoom(patch.zoomLevel);
     }
-    if ('lastDialogFolder' in patch) {
-      sanitizedPatch.lastDialogFolder = typeof patch.lastDialogFolder === 'string' ? patch.lastDialogFolder : '';
+    for (const key of FOLDER_MEMORY_KEYS) {
+      if (key in patch) {
+        sanitizedPatch[key] = typeof patch[key] === 'string' ? patch[key] : '';
+      }
     }
     if ('windowBounds' in patch) {
       const b = patch.windowBounds;
@@ -935,21 +952,24 @@ ipcMain.handle('dialog:choose-entry', async (event, options) => {
   }
   dialogChooseEntryInProgress = true;
   try {
-    const { type, suggestedName, accepts } = options;
-    const { lastDialogFolder } = loadConfig();
+    const { type, suggestedName, accepts, dialogId } = options;
+    const folderKey = DIALOG_FOLDER_KEYS[dialogId] || 'lastDialogFolder';
+    const config = loadConfig();
+    // Fall back to the shared folder until this bucket has its own stored value.
+    const lastFolder = config[folderKey] || config.lastDialogFolder;
 
     if (type === 'saveFile') {
       const filters = accepts ? accepts.map(a => ({ name: a.description, extensions: a.extensions })) : [];
       // Prefer last-used folder; fall back to suggestedName (which may itself be a filename only)
-      const defaultPath = lastDialogFolder
-        ? path.join(lastDialogFolder, suggestedName || '')
+      const defaultPath = lastFolder
+        ? path.join(lastFolder, suggestedName || '')
         : suggestedName;
       const result = await dialog.showSaveDialog({
         defaultPath,
         filters: filters.length > 0 ? filters : undefined,
       });
       if (!result.canceled && result.filePath) {
-        saveConfig({ lastDialogFolder: path.dirname(result.filePath) });
+        saveConfig({ [folderKey]: path.dirname(result.filePath) });
       }
       return result;
     } else if (type === 'openFile') {
@@ -958,14 +978,14 @@ ipcMain.handle('dialog:choose-entry', async (event, options) => {
                  .map(a => ({ name: a.description, extensions: a.extensions }))
         : [];
       // Use last-used folder as defaultPath; suggestedName is rarely set for openFile
-      const defaultPath = lastDialogFolder || suggestedName;
+      const defaultPath = lastFolder || suggestedName;
       const result = await dialog.showOpenDialog({
         defaultPath,
         filters: openFilters,
         properties: ['openFile'],
       });
       if (!result.canceled && result.filePaths && result.filePaths[0]) {
-        saveConfig({ lastDialogFolder: path.dirname(result.filePaths[0]) });
+        saveConfig({ [folderKey]: path.dirname(result.filePaths[0]) });
       }
       return result;
     }

--- a/src/js/tabs/firmware_flasher.js
+++ b/src/js/tabs/firmware_flasher.js
@@ -365,7 +365,7 @@ TABS.firmware_flasher.initialize = function (callback) {
         $('a.load_file').click(function () {
             self.enableFlashing(false);
             self.localFileLoaded = true;
-            chrome.fileSystem.chooseEntry({type: 'openFile', accepts: [{description: 'HEX files', extensions: ['hex']}]}, function (fileEntry) {
+            chrome.fileSystem.chooseEntry({type: 'openFile', dialogId: 'firmware', accepts: [{description: 'HEX files', extensions: ['hex']}]}, function (fileEntry) {
                 if (chrome.runtime.lastError) {
                     console.error(chrome.runtime.lastError.message);
 
@@ -571,7 +571,7 @@ TABS.firmware_flasher.initialize = function (callback) {
 
         $(document).on('click', 'span.progressLabel a.save_firmware', function () {
             var summary = $('select[name="firmware_version"] option:selected').data('summary');
-            chrome.fileSystem.chooseEntry({type: 'saveFile', suggestedName: summary.file, accepts: [{description: 'HEX files', extensions: ['hex']}]}, function (fileEntry) {
+            chrome.fileSystem.chooseEntry({type: 'saveFile', suggestedName: summary.file, dialogId: 'firmware', accepts: [{description: 'HEX files', extensions: ['hex']}]}, function (fileEntry) {
                 if (chrome.runtime.lastError) {
                     console.error(chrome.runtime.lastError.message);
                     return;


### PR DESCRIPTION
AI Generated pull-request

## Summary
- Every EFC file dialog shared one config field, `lastDialogFolder`, via the IPC bridge at `main.js` (`dialog:choose-entry`). Saving a firmware `.hex` re-pointed the CLI dump, blackbox `.BBL`, OSD font, backup/restore, and sensor-log dialogs at the firmware folder, and vice versa.
- Adds a second bucket, `lastFirmwareFolder`, used only by the two firmware-flasher dialog call sites (open/save `.hex`), tagged via a `dialogId` option field. `main.js` maps `dialogId` to a config key through a `DIALOG_FOLDER_KEYS` allow-list rather than trusting a renderer-supplied key directly. An unrecognized/absent `dialogId` falls back to the original shared `lastDialogFolder` key, so the other 10 dialog call sites need no change.
- First use of the new bucket falls back to the pre-existing shared folder, so upgrading users don't get a cold `$HOME` default.
- `loadConfig`/`saveConfig` derive their persisted-field whitelist from `FOLDER_MEMORY_KEYS` (built from `DIALOG_FOLDER_KEYS`) instead of hardcoding each bucket in three places, so a future bucket can't be silently dropped by one missed spot.
- Scope, confirmed with the requester: exactly two buckets — `.hex` (firmware) on its own, everything else (CLI `.txt`, blackbox `.BBL`, backup `.json`, OSD `.mcm`, sensor-log `.csv`, boot-logo image) staying on the original shared bucket.

## Test plan
- [x] `yarn lint` — 0 errors, no new warnings
- [x] App boots cleanly under Xvfb (`yarn dev`) before and after the final refactor
- [x] Standalone re-execution of the exact persisted-config logic (`loadConfig`/`saveConfig`/folder-key resolution) against a throwaway config file — 10/10 assertions covering bucket isolation both directions, the upgrade fallback, and a simulated third-bucket addition round-tripping with no other code changes
- [ ] Manual click-through of the firmware/CLI/backup/OSD dialogs on a real display
- [ ] Manual blackbox `.BBL` save with a connected flight controller (unchanged shared-bucket behavior, not modified by this PR)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * File selection dialogs now remember the last folder separately for each dialog type.
  * Firmware file open and save dialogs reopen in their previously used folders.

* **Bug Fixes**
  * Improved folder handling for save and open dialogs, including safer configuration loading and storage.
  * Preserved folder preferences across sessions while providing a shared fallback when no dialog-specific folder is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->