### PR TITLE
fix: scope let declarations to case blocks (no-case-declarations)

### DIFF
--- a/src/js/msp/MSPHelper.js
+++ b/src/js/msp/MSPHelper.js
@@ -612,7 +612,7 @@ MspHelper.prototype.process_data = function(dataHandler) {
                 CONFIG.buildInfo = String.fromCharCode.apply(null, buff);
                 break;
 
-            case MSPCodes.MSP_BOARD_INFO:
+            case MSPCodes.MSP_BOARD_INFO: {
                 var identifier = '';
                 for (var i = 0; i < 4; i++) {
                     identifier += String.fromCharCode(data.readU8());
@@ -651,6 +651,7 @@ MspHelper.prototype.process_data = function(dataHandler) {
                 }
                 //End MSP 1.54
                 break;
+            }
 
             case MSPCodes.MSP_NAME:
                 CONFIG.name = '';
@@ -800,7 +801,7 @@ MspHelper.prototype.process_data = function(dataHandler) {
                 }
                 break;
 
-            case MSPCodes.MSP_ADVANCED_CONFIG:
+            case MSPCodes.MSP_ADVANCED_CONFIG: {
                 PID_ADVANCED_CONFIG.gyro_sync_denom = data.readU8();
                 PID_ADVANCED_CONFIG.pid_process_denom = data.readU8();
                 PID_ADVANCED_CONFIG.use_unsyncedPwm = data.readU8();
@@ -815,6 +816,7 @@ MspHelper.prototype.process_data = function(dataHandler) {
                 }
                 //End MSP 1.54
                 break;
+            }
 
             case MSPCodes.MSP_FILTER_CONFIG:
                 if (semver.lt(CONFIG.apiVersion, "1.44.0")) {
@@ -1649,7 +1651,7 @@ MspHelper.prototype.crunch = function(code) {
                   .push8(SENSOR_ALIGNMENT.align_mag);
             break;
 
-        case MSPCodes.MSP_SET_ADVANCED_CONFIG:
+        case MSPCodes.MSP_SET_ADVANCED_CONFIG: {
             buffer.push8(PID_ADVANCED_CONFIG.gyro_sync_denom)
                   .push8(PID_ADVANCED_CONFIG.pid_process_denom)
                   .push8(PID_ADVANCED_CONFIG.use_unsyncedPwm)
@@ -1664,6 +1666,7 @@ MspHelper.prototype.crunch = function(code) {
             }
             //End MSP 1.54
             break;
+        }
 
         case MSPCodes.MSP_SET_FILTER_CONFIG:
             if (semver.lt(CONFIG.apiVersion, "1.44.0")) {


### PR DESCRIPTION
AI Generated pull-request

## Summary
Wraps the `MSP_BOARD_INFO`, `MSP_ADVANCED_CONFIG`, and `MSP_SET_ADVANCED_CONFIG` case bodies in `src/js/msp/MSPHelper.js` in blocks so their `let` declarations don't leak into the enclosing `switch` scope. No logic change. Follows PR #682 (curly braces), picking up the `no-case-declarations` rule from the remaining lint backlog.

Clears all 5 `no-case-declarations` ESLint warnings. `yarn lint`: 469 -> 464 total warnings, 0 errors, no other rule's count changed.

## Test plan
- [x] `yarn lint`: 0 errors, `no-case-declarations` count 5 -> 0
- [ ] Hardware verified: n/a — pure block-scoping change, no logic altered

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue that could prevent configuration data from being processed due to duplicate variable declarations.
  * Improved reliability when handling board information and advanced configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->