### PR TITLE
fix: remove unreachable break statements in led_strip.js

### DIFF
--- a/src/js/tabs/led_strip.js
+++ b/src/js/tabs/led_strip.js
@@ -706,7 +706,6 @@ TABS.led_strip.initialize = function (callback, scrollPosition) {
             case "function-a":
             case "function-f":
                 return true;
-            break;
         }
         return false;
     }
@@ -723,7 +722,6 @@ TABS.led_strip.initialize = function (callback, scrollPosition) {
             case "function-o":
             case "function-g":
                 return true;
-            break;
         }
         return false;
     }
@@ -734,7 +732,6 @@ TABS.led_strip.initialize = function (callback, scrollPosition) {
             case "function-a":
             case "function-f":
                 return true;
-            break;
         }
         return false;
     }
@@ -745,13 +742,11 @@ TABS.led_strip.initialize = function (callback, scrollPosition) {
             case "function-s":
             case "function-g":
                 return false;
-                break;
             case "function-r":
             case "function-b":
                 return true;
             default:
                 return true;
-            break;
         }
     }
 
@@ -762,10 +757,8 @@ TABS.led_strip.initialize = function (callback, scrollPosition) {
             case "function-a":
             case "function-f":
                 return true;
-            break;
             default:
                 return false;
-            break;
         }
     }
 


### PR DESCRIPTION
AI Generated pull-request

## Summary
Stage 2 of the ESLint cleanup batch (stage 1: #684, no-case-declarations, merged).

Removes all 7 `no-unreachable` warnings in `src/js/tabs/led_strip.js`. Each was a stray `break;` sitting directly after a `return`, still inside the enclosing `switch` — unreachable by JS control flow (the `return` already exits before `break` is reached). Sites: `areModifiersActive`, `areOverlaysActive`, `areBlinkersActive`, `isWarningActive`, `isVtxActive`.

`yarn lint`: 464 → 457 warnings, 0 errors, 0 `no-unreachable` remaining.

## Test plan
- [x] `yarn lint`: 457 warnings, 0 errors, 0 no-unreachable
- [ ] LED Strip tab function-select dropdown, real hardware: modifier/overlay/blinker/warning/VTX toggle sections behave identically before/after

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed unreachable code from LED-strip status handling.
  * No user-visible behavior or functionality has changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->