### PR TITLE
refactor: extract updateTabList into per-concern helper functions

### DIFF
--- a/src/js/main.js
+++ b/src/js/main.js
@@ -572,7 +572,7 @@ function isExpertModeEnabled() {
     return $('input[name="expertModeCheckbox"]').is(':checked');
 }
 
-function updateTabList(features) {
+function updateExpertModeConnectedTabs() {
     if (isExpertModeEnabled()) {
         $('#tabs ul.mode-connected li.tab_failsafe').show();
         $('#tabs ul.mode-connected li.tab_adjustments').show();
@@ -586,36 +586,42 @@ function updateTabList(features) {
         $('#tabs ul.mode-connected li.tab_sensors').hide();
         $('#tabs ul.mode-connected li.tab_logging').hide();
     }
+}
 
+function updateGpsTabVisibility(features) {
     if (features.isEnabled('GPS') && isExpertModeEnabled()) {
         $('#tabs ul.mode-connected li.tab_gps').show();
     } else {
         $('#tabs ul.mode-connected li.tab_gps').hide();
     }
+}
 
+function updateLedStripTabVisibility(features) {
     if (features.isEnabled('LED_STRIP')) {
         $('#tabs ul.mode-connected li.tab_led_strip').show();
     } else {
         $('#tabs ul.mode-connected li.tab_led_strip').hide();
     }
+}
 
+function updateTransponderTabVisibility(features) {
     if (features.isEnabled('TRANSPONDER')) {
         $('#tabs ul.mode-connected li.tab_transponder').show();
     } else {
         $('#tabs ul.mode-connected li.tab_transponder').hide();
     }
+}
 
+function updateOsdTabVisibility(features) {
     if (features.isEnabled('OSD')) {
         $('#tabs ul.mode-connected li.tab_osd').show();
     } else {
         $('#tabs ul.mode-connected li.tab_osd').hide();
     }
+}
 
-    $('#tabs ul.mode-connected li.tab_power').show();
-
-    $('#tabs ul.mode-connected li.tab_vtx').show();
-
-    //experimental: show/hide with expert-mode
+//experimental: show/hide with expert-mode
+function updateGyroDtermLpfLabels() {
     if (semver.gte(CONFIG.apiVersion, "1.44.0")) {
         if (!isExpertModeEnabled()) {
             $('.LPFPit').hide();
@@ -633,8 +639,10 @@ function updateTabList(features) {
             $('#pid-tuning .dtermLowpass2FrequencyAxis .LPFRol').text(i18n.getMessage("dtermLowpass2FrequencyRoll"));
         }
     }
+}
 
-    //experimental: show/hide with expert-mode
+//experimental: show/hide with expert-mode
+function updateImufQVisibility() {
     if (!isExpertModeEnabled()) {
         $('.IMUFQroll').show();
         $('.IMUFQpitch').hide();
@@ -646,8 +654,10 @@ function updateTabList(features) {
         $('.IMUFQyaw').show();
         $('#pid-tuning .IMUFQroll').text(i18n.getMessage("pidTuningImufRollQ"));
     }
+}
 
-    //experimental: show/hide with expert-mode
+//experimental: show/hide with expert-mode
+function updateImufLpfVisibility() {
     if (CONFIG.boardIdentifier == "HESP" || CONFIG.boardIdentifier == "SX10" || CONFIG.boardIdentifier == "FLUX") {
         if (!isExpertModeEnabled()) {
         $('.IMUFLPFroll').show();
@@ -669,7 +679,9 @@ function updateTabList(features) {
         $('.IMUFLPFyaw').hide();
         console.log("non-Helio hide IMUF LPF");
     }
+}
 
+function updateExpertModeMiscVisibility() {
     //experimental: show/hide with expert-mode
     if (isExpertModeEnabled()) {
         $('.isexpertmode').show(); //show everything but turn off things per MSP below
@@ -718,6 +730,23 @@ function updateTabList(features) {
         }
     }
     //end MSP 1.51
+}
+
+function updateTabList(features) {
+    updateExpertModeConnectedTabs();
+    updateGpsTabVisibility(features);
+    updateLedStripTabVisibility(features);
+    updateTransponderTabVisibility(features);
+    updateOsdTabVisibility(features);
+
+    $('#tabs ul.mode-connected li.tab_power').show();
+
+    $('#tabs ul.mode-connected li.tab_vtx').show();
+
+    updateGyroDtermLpfLabels();
+    updateImufQVisibility();
+    updateImufLpfVisibility();
+    updateExpertModeMiscVisibility();
 } //end updateTabList
 
 function zeroPad(value, width) {


### PR DESCRIPTION
AI Generated pull-request

## Summary
- Extracts `updateTabList` (main.js) into 9 named per-concern helper functions: tab-visibility groups by feature/expert-mode, PID-tuning label/visibility toggles.
- Extract-only refactor: same statements, same execution order, no logic changes. Reduces ESLint `complexity` from 22 to below the max-20 threshold.
- Part of a staged ESLint cleanup: stage 1 (no-case-declarations, PR #684) and stage 2 (no-unreachable, PR #685) merged; this is one function from stage 3 (complexity).

## Test plan
- [x] `yarn lint`: 456 warnings, 0 errors (down from 457) — `main.js` complexity warning resolved, no new warnings introduced anywhere.
- [x] App boots clean under `yarn dev`, no runtime reference errors.
- [x] Hardware-verified (real FC): LED_STRIP feature toggle reflows the sidebar tab correctly.
- [x] Hardware-verified: Expert Mode checkbox toggle reflows Failsafe/Adjustments/Servos/Sensors/Logging tabs correctly.
- [x] Hardware-verified: GPS tab unhides correctly on first Expert Mode toggle (full re-verification after reboot not possible — GPS module not soldered on test board).
- [x] Hardware-verified: all valid Configuration-tab feature toggles reflow the sidebar correctly.
- [x] Hardware-verified: PID Tuning tab's Filter Settings subtab (IMUF Q and IMUF LPF labels/visibility) toggles correctly with Expert Mode.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the organization of settings-tab visibility logic.
  * Preserved existing visibility behavior based on enabled features and firmware versions.
  * Power and VTX tabs continue to remain available at all times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->