### PR TITLE
refactor: extract setupEscProtocol from configuration.js process_html

### DIFF
--- a/src/js/tabs/configuration.js
+++ b/src/js/tabs/configuration.js
@@ -212,80 +212,86 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
         orientation_acc_e.val(SENSOR_ALIGNMENT.align_acc);
         orientation_mag_e.val(SENSOR_ALIGNMENT.align_mag);
 
-        // ESC protocols
-        var escprotocols = [
-            'PWM',
-            'ONESHOT125',
-            'ONESHOT42',
-            'MULTISHOT'
-        ];
+        function setupEscProtocol() {
+            // ESC protocols
+            var escprotocols = [
+                'PWM',
+                'ONESHOT125',
+                'ONESHOT42',
+                'MULTISHOT'
+            ];
 
-        escprotocols.push('BRUSHED');
-        escprotocols.push('DSHOT150');
-        escprotocols.push('DSHOT300');
-        escprotocols.push('DSHOT600');
-        escprotocols.push('DSHOT1200');
-        if (semver.gte(CONFIG.apiVersion, "1.48.0")) {
-            escprotocols.push('DSHOT2400');
-            escprotocols.push('DSHOT4800');
-        }
-        escprotocols.push('PROSHOT1000');
+            escprotocols.push('BRUSHED');
+            escprotocols.push('DSHOT150');
+            escprotocols.push('DSHOT300');
+            escprotocols.push('DSHOT600');
+            escprotocols.push('DSHOT1200');
+            if (semver.gte(CONFIG.apiVersion, "1.48.0")) {
+                escprotocols.push('DSHOT2400');
+                escprotocols.push('DSHOT4800');
+            }
+            escprotocols.push('PROSHOT1000');
 
-        var esc_protocol_e = $('select.escprotocol');
+            var esc_protocol_e = $('select.escprotocol');
 
-        for (var i = 0; i < escprotocols.length; i++) {
-            esc_protocol_e.append('<option value="' + (i + 1) + '">'+ escprotocols[i] + '</option>');
-        }
+            for (var i = 0; i < escprotocols.length; i++) {
+                esc_protocol_e.append('<option value="' + (i + 1) + '">'+ escprotocols[i] + '</option>');
+            }
 
-        $("input[id='unsyncedPWMSwitch']").change(function() {
-            if ($(this).is(':checked')) {
-                $('div.unsyncedpwmfreq').show();
+            $("input[id='unsyncedPWMSwitch']").change(function() {
+                if ($(this).is(':checked')) {
+                    $('div.unsyncedpwmfreq').show();
+                } else {
+                    $('div.unsyncedpwmfreq').hide();
+                }
+            });
+
+            $('input[id="unsyncedPWMSwitch"]').prop('checked', PID_ADVANCED_CONFIG.use_unsyncedPwm !== 0).change();
+            $('input[name="unsyncedpwmfreq"]').val(PID_ADVANCED_CONFIG.motor_pwm_rate);
+            $('input[name="digitalIdlePercent"]').val(PID_ADVANCED_CONFIG.digitalIdlePercent);
+
+            //MSP 1.54
+            if (semver.gte(CONFIG.apiVersion, "1.54.0")) {
+                $('input[name="motorPoleCount"]').val(PID_ADVANCED_CONFIG.motorPoleCount);
+                $('div.motorPoleCount').show();
             } else {
-                $('div.unsyncedpwmfreq').hide();
+                $('div.motorPoleCount').hide();
             }
-        });
+            //End MSP 1.54
 
-        $('input[id="unsyncedPWMSwitch"]').prop('checked', PID_ADVANCED_CONFIG.use_unsyncedPwm !== 0).change();
-        $('input[name="unsyncedpwmfreq"]').val(PID_ADVANCED_CONFIG.motor_pwm_rate);
-        $('input[name="digitalIdlePercent"]').val(PID_ADVANCED_CONFIG.digitalIdlePercent);
+            esc_protocol_e.val(PID_ADVANCED_CONFIG.fast_pwm_protocol + 1);
+            esc_protocol_e.change(function () {
+                var escProtocolValue = parseInt($(this).val()) - 1;
 
-        //MSP 1.54
-        if (semver.gte(CONFIG.apiVersion, "1.54.0")) {
-            $('input[name="motorPoleCount"]').val(PID_ADVANCED_CONFIG.motorPoleCount);
-            $('div.motorPoleCount').show();
-        } else {
-            $('div.motorPoleCount').hide();
+                var newValue;
+                if (escProtocolValue !== PID_ADVANCED_CONFIG.fast_pwm_protocol) {
+                    newValue = $(this).find('option:selected').text();
+                }
+                //hide not used setting for DSHOT protocol
+                if (escProtocolValue >= self.DSHOT_PROTOCOL_MIN_VALUE) {
+                    $('div.minthrottle').hide();
+                    $('div.maxthrottle').hide();
+                    $('div.mincommand').hide();
+                    $('div.checkboxPwm').hide();
+                    $('div.unsyncedpwmfreq').hide();
+
+                    $('div.digitalIdlePercent').show();
+                } else {
+                    $('div.minthrottle').show();
+                    $('div.maxthrottle').show();
+                    $('div.mincommand').show();
+                    $('div.checkboxPwm').show();
+                    //trigger change unsyncedPWMSwitch to show/hide Motor PWM freq input
+                    $("input[id='unsyncedPWMSwitch']").change();
+
+                    $('div.digitalIdlePercent').hide();
+                }
+            }).change();
+
+            return esc_protocol_e;
         }
-        //End MSP 1.54
 
-        esc_protocol_e.val(PID_ADVANCED_CONFIG.fast_pwm_protocol + 1);
-        esc_protocol_e.change(function () {
-            var escProtocolValue = parseInt($(this).val()) - 1;
-
-            var newValue;
-            if (escProtocolValue !== PID_ADVANCED_CONFIG.fast_pwm_protocol) {
-                newValue = $(this).find('option:selected').text();
-            }
-            //hide not used setting for DSHOT protocol
-            if (escProtocolValue >= self.DSHOT_PROTOCOL_MIN_VALUE) {
-                $('div.minthrottle').hide();
-                $('div.maxthrottle').hide();
-                $('div.mincommand').hide();
-                $('div.checkboxPwm').hide();
-                $('div.unsyncedpwmfreq').hide();
-
-                $('div.digitalIdlePercent').show();
-            } else {
-                $('div.minthrottle').show();
-                $('div.maxthrottle').show();
-                $('div.mincommand').show();
-                $('div.checkboxPwm').show();
-                //trigger change unsyncedPWMSwitch to show/hide Motor PWM freq input
-                $("input[id='unsyncedPWMSwitch']").change();
-
-                $('div.digitalIdlePercent').hide();
-            }
-        }).change();
+        var esc_protocol_e = setupEscProtocol();
 
 
         // Gyro and PID update


### PR DESCRIPTION
AI Generated pull-request

## Summary
`process_html` in `src/js/tabs/configuration.js` had ESLint `complexity` 21 (max 20). Moves ESC/motor protocol dropdown population and its change handler into a nested named helper `setupEscProtocol()`, matching the extraction pattern used for `main.js` `updateTabList` (#686). Extract-only — no logic reordered; the outer scope now captures the helper's return value for the one read in the save handler.

Stage 3 of the ESLint cleanup batch (see #682, #684, #685, #686).

## Test plan
- [x] `yarn lint`: `complexity` warning for `configuration.js` gone, no new warnings, total warning count 456 -> 455
- [x] `node -c` syntax check passes
- [x] Manual boot test on Configuration tab, connected to FC:
  - [x] ESC/Motor Protocol dropdown populates with current FC selection
  - [x] Switching to a DSHOT protocol hides throttle/PWM fields, shows Digital Idle %
  - [x] Switching to a non-DSHOT protocol restores those fields
  - [x] Save persists the protocol choice

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the internal organization of ESC protocol configuration setup.
  * Preserved existing ESC protocol selection, PWM synchronization, DSHOT throttle visibility, and motor pole count behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->