### PR TITLE
refactor: extract handleCliModeEntry from cli.js read

### DIFF
--- a/src/js/tabs/cli.js
+++ b/src/js/tabs/cli.js
@@ -462,6 +462,14 @@ TABS.cli.read = function (readInfo) {
 
     }
 
+    this.handleCliModeEntry(validateText);
+
+    if (!CliAutoComplete.isEnabled())
+        // fallback to native autocomplete
+        { setPrompt(removePromptHash(this.cliBuffer)); }
+};
+
+TABS.cli.handleCliModeEntry = function (validateText) {
     if (!CONFIGURATOR.cliValid && validateText.indexOf('CLI') !== -1) {
         GUI.log(i18n.getMessage('cliEnter'));
         CONFIGURATOR.cliValid = true;
@@ -489,10 +497,6 @@ TABS.cli.read = function (readInfo) {
             CliAutoComplete.builderStart();
         }
     }
-
-    if (!CliAutoComplete.isEnabled())
-        // fallback to native autocomplete
-        { setPrompt(removePromptHash(this.cliBuffer)); }
 };
 
 TABS.cli.sendLine = function (line, callback) {


### PR DESCRIPTION
AI Generated pull-request

## Summary
Extracts the CLI-mode-entry/welcome-message block from `TABS.cli.read`
into a new `TABS.cli.handleCliModeEntry(validateText)` method, reducing
`read`'s ESLint `complexity` from 24 to below the threshold (20).
Verbatim code move — no logic change.

## Test plan
- [x] Lint: complexity warning at cli.js:388 resolved, no new warnings
      (repo total 457→453, consistent with sites fixed in #686/#687/#688)
- [x] `yarn dev` boots clean, no console errors
- [x] Hardware-verified (real FC): CLI mode entry banner, prompt line,
      auto-complete on entry, and re-entry after exit all confirmed working

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved CLI input handling when autocomplete is disabled.
  - Ensured the native autocomplete prompt fallback is consistently applied during reads.

- **Refactor**
  - Simplified the CLI-mode entry flow for more consistent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->