### PR TITLE
fix: eqeqeq cleanup for tab batch A

### DIFF
--- a/src/js/CliAutoComplete.js
+++ b/src/js/CliAutoComplete.js
@@ -17,11 +17,11 @@ CliAutoComplete.isEnabled = function() {
     // state='done':  cache built, suggestions available
     // state='fail':  gave up — disable entirely
     // isBuilding():  currently fetching help/dump — suppress raw output
-    return this.isBuilding() || (this.configEnabled && CONFIG.flightControllerIdentifier == "EMUF" && this.builder.state != 'fail');
+    return this.isBuilding() || (this.configEnabled && CONFIG.flightControllerIdentifier === "EMUF" && this.builder.state !== 'fail');
 };
 
 CliAutoComplete.isBuilding = function() {
-    return this.builder.state != 'reset' && this.builder.state != 'done' && this.builder.state != 'fail';
+    return this.builder.state !== 'reset' && this.builder.state !== 'done' && this.builder.state !== 'fail';
 };
 
 CliAutoComplete.isOpen = function() {
@@ -41,7 +41,7 @@ CliAutoComplete.openLater = function(force) {
 };
 
 CliAutoComplete.setEnabled = function(enable) {
-    if (this.configEnabled != enable) {
+    if (this.configEnabled !== enable) {
         this.configEnabled = enable;
 
         if (CONFIGURATOR.cliActive && CONFIGURATOR.cliValid) {
@@ -111,7 +111,7 @@ CliAutoComplete.builderStart = function() {
     if (!CONFIGURATOR.cliActive || !CONFIGURATOR.cliValid) {
         return;
     }
-    if (this.builder.state == 'reset') {
+    if (this.builder.state === 'reset') {
         this.cache = {
             commands: [],
             resources: [],
@@ -246,7 +246,7 @@ CliAutoComplete._initTextcomplete = function() {
 
         callback(res);
 
-        if (self.forceOpen && res.length == 1) {
+        if (self.forceOpen && res.length === 1) {
             // hacky: if we came here because of Tab and there's only one match
             // trigger Tab again, so that textcomplete should immediately select the only result
             // instead of showing the menu
@@ -256,7 +256,7 @@ CliAutoComplete._initTextcomplete = function() {
 
     var contexter = function(text) {
         var val = $textarea.val();
-        if (val.length == text.length || val[text.length].match(/\s/)) {
+        if (val.length === text.length || val[text.length].match(/\s/)) {
             return true;
         }
         return false; // do not show autocomplete if in the middle of a word
@@ -277,7 +277,7 @@ CliAutoComplete._initTextcomplete = function() {
             onKeydown: function(e) {
                 // some strategies may set sendOnEnter only at the replace stage, thus we call with timeout
                 // since this handler [onKeydown] is triggered before replace()
-                if (e.which == 13) {
+                if (e.which === 13) {
                     setTimeout(function() {
                         if (sendOnEnter) {
                             // fake "enter" to run the textarea's handler
@@ -424,7 +424,7 @@ CliAutoComplete._initTextcomplete = function() {
             replace: function(value) {
                 if (value in cache.resourcesCount) {
                     self.openLater();
-                } else if (value == 'list') {
+                } else if (value === 'list') {
                     sendOnEnter = true;
                 }
                 return basicReplacer(value);
@@ -471,13 +471,13 @@ CliAutoComplete._initTextcomplete = function() {
                 }
             },
             template: function(value, term) {
-                if (value == 'none') {
+                if (value === 'none') {
                     return highlighterPrefix(value, term);
                 }
                 return value;
             },
             replace: function(value) {
-                if (value == 'none') {
+                if (value === 'none') {
                     sendOnEnter = true;
                     return '$1none ';
                 }
@@ -508,7 +508,7 @@ CliAutoComplete._initTextcomplete = function() {
                 searcher(term, callback, arr, 1);
             },
             replace: function(value) {
-                if (value == '-') {
+                if (value === '-') {
                     self.openLater(true);
                     return '$1-';
                 }

--- a/src/js/backup_restore.js
+++ b/src/js/backup_restore.js
@@ -482,7 +482,7 @@ function configuration_restore(callback) {
 
         if (compareVersions(migratedVersion, '0.63.0')) {
             // backups created with 0.63.0 for firmwares with api < 1.8 were saved with incorrect looptime
-            if (configuration.FC_CONFIG.loopTime === 0) {
+            if (Number(configuration.FC_CONFIG.loopTime) === 0) {
                 //reset it to the default
                 configuration.FC_CONFIG.loopTime = 3500;
             }

--- a/src/js/backup_restore.js
+++ b/src/js/backup_restore.js
@@ -286,7 +286,7 @@ function configuration_restore(callback) {
             };
 
             reader.onloadend = function (e) {
-                if (e.total != 0 && e.total == e.loaded) {
+                if (e.total !== 0 && e.total === e.loaded) {
                     console.log('Read SUCCESSFUL');
 
                     try { // check if string provided is a valid JSON
@@ -323,7 +323,7 @@ function configuration_restore(callback) {
     });
 
     function compareVersions(generated, required) {
-        if (generated == undefined) {
+        if (generated == null) {
             return false;
         }
         return semver.gte(generated, required);
@@ -404,7 +404,7 @@ function configuration_restore(callback) {
             appliedMigrationsCount++;
         }
 
-        if (configuration.apiVersion == undefined) {
+        if (configuration.apiVersion == null) {
             configuration.apiVersion = "1.0.0" // a guess that will satisfy the rest of the code
         }
         // apiVersion previously stored without patchlevel
@@ -463,13 +463,13 @@ function configuration_restore(callback) {
         if (compareVersions(migratedVersion, '0.63.0') && !compareVersions(configuration.apiVersion, '1.8.0')) {
             // api 1.8 exposes looptime and arming config
 
-            if (configuration.FC_CONFIG == undefined) {
+            if (configuration.FC_CONFIG == null) {
                 configuration.FC_CONFIG = {
                     loopTime: 3500
                 };
             }
 
-            if (configuration.ARMING_CONFIG == undefined) {
+            if (configuration.ARMING_CONFIG == null) {
                 configuration.ARMING_CONFIG = {
                     auto_disarm_delay:      5,
                     disarm_kill_switch:     1
@@ -482,7 +482,7 @@ function configuration_restore(callback) {
 
         if (compareVersions(migratedVersion, '0.63.0')) {
             // backups created with 0.63.0 for firmwares with api < 1.8 were saved with incorrect looptime
-            if (configuration.FC_CONFIG.loopTime == 0) {
+            if (configuration.FC_CONFIG.loopTime === 0) {
                 //reset it to the default
                 configuration.FC_CONFIG.loopTime = 3500;
             }
@@ -543,7 +543,7 @@ function configuration_restore(callback) {
         if (compareVersions(migratedVersion, '0.66.0') && !compareVersions(configuration.apiVersion, '1.14.0')) {
             // api 1.14 exposes 3D configuration
 
-            if (configuration.MOTOR_3D_CONFIG == undefined) {
+            if (configuration.MOTOR_3D_CONFIG == null) {
                 configuration.MOTOR_3D_CONFIG = {
                     deadband3d_low:         1406,
                     deadband3d_high:        1514,
@@ -562,7 +562,7 @@ function configuration_restore(callback) {
 
 
             for (var profileIndex = 0; profileIndex < configuration.profiles.length; profileIndex++) {
-                 if (configuration.profiles[profileIndex].RCdeadband == undefined) {
+                 if (configuration.profiles[profileIndex].RCdeadband == null) {
                     configuration.profiles[profileIndex].RCdeadband = {
                     deadband:                0,
                     yaw_deadband:            0,
@@ -570,7 +570,7 @@ function configuration_restore(callback) {
                     };
                 }
             }
-            if (configuration.SENSOR_ALIGNMENT == undefined) {
+            if (configuration.SENSOR_ALIGNMENT == null) {
                     configuration.SENSOR_ALIGNMENT = {
                     align_gyro:              0,
                     align_acc:               0,
@@ -580,7 +580,7 @@ function configuration_restore(callback) {
 
             // api 1.15 exposes RX_CONFIG, FAILSAFE_CONFIG and RXFAIL_CONFIG configuration
 
-            if (configuration.RX_CONFIG == undefined) {
+            if (configuration.RX_CONFIG == null) {
                 configuration.RX_CONFIG = {
                     serialrx_provider:      0,
                     spektrum_sat_bind:      0,
@@ -592,7 +592,7 @@ function configuration_restore(callback) {
                 };
             }
 
-            if (configuration.FAILSAFE_CONFIG == undefined) {
+            if (configuration.FAILSAFE_CONFIG == null) {
                 configuration.FAILSAFE_CONFIG = {
                     failsafe_delay:                 10,
                     failsafe_off_delay:             200,
@@ -603,7 +603,7 @@ function configuration_restore(callback) {
                 };
             }
 
-            if (configuration.RXFAIL_CONFIG == undefined) {
+            if (configuration.RXFAIL_CONFIG == null) {
                 configuration.RXFAIL_CONFIG = [
                     {mode: 0, value: 1500},
                     {mode: 0, value: 1500},

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -30,7 +30,7 @@ var HttpClient = function() {
     this.get = function(aUrl, aCallback) {
         var anHttpRequest = new XMLHttpRequest();
         anHttpRequest.onreadystatechange = function() {
-            if (anHttpRequest.readyState == 4 && anHttpRequest.status == 200)
+            if (anHttpRequest.readyState === 4 && anHttpRequest.status === 200)
                 { aCallback(anHttpRequest.responseText); }
         }
 
@@ -164,7 +164,7 @@ function startProcess() {
 
     var ui_tabs = $('#tabs > ul');
     $('a', ui_tabs).click(function () {
-        if ($(this).parent().hasClass('active') == false && !GUI.tab_switch_in_progress) { // only initialize when the tab isn't already active
+        if ($(this).parent().hasClass('active') === false && !GUI.tab_switch_in_progress) { // only initialize when the tab isn't already active
             var self = this,
                 tabClass = $(self).parent().prop('class');
 
@@ -183,7 +183,7 @@ function startProcess() {
                 return;
             }
 
-            if (GUI.allowedTabs.indexOf(tab) < 0 && tabName == "Firmware Flasher") {
+            if (GUI.allowedTabs.indexOf(tab) < 0 && tabName === "Firmware Flasher") {
                 if (GUI.connected_to || GUI.connecting_to) {
                     $('a.connect').click();
                 } else {
@@ -331,7 +331,7 @@ function startProcess() {
                     }).change();
 
                 function close_and_cleanup(e) {
-                    if (e.type == 'click' && !$.contains($('div#options-window')[0], e.target) || e.type == 'keyup' && e.keyCode == 27) {
+                    if (e.type === 'click' && !$.contains($('div#options-window')[0], e.target) || e.type === 'keyup' && e.keyCode === 27) {
                         $(document).unbind('click keyup', close_and_cleanup);
 
                         $('div#options-window').slideUp(250, function () {
@@ -368,7 +368,7 @@ function startProcess() {
             37, 38, 39, 40, 13 // arrows and enter
         ];
 
-        if (whitelist.indexOf(e.keyCode) == -1) {
+        if (whitelist.indexOf(e.keyCode) === -1) {
             e.preventDefault();
         }
     });
@@ -417,7 +417,7 @@ function startProcess() {
 
             if (val % 1 === 0) {
                 element.val(val.toFixed(decimal_places));
-            } else if (String(val).split('.')[1].length != decimal_places) {
+            } else if (String(val).split('.')[1].length !== decimal_places) {
                 element.val(val.toFixed(decimal_places));
             }
         }
@@ -658,7 +658,7 @@ function updateImufQVisibility() {
 
 //experimental: show/hide with expert-mode
 function updateImufLpfVisibility() {
-    if (CONFIG.boardIdentifier == "HESP" || CONFIG.boardIdentifier == "SX10" || CONFIG.boardIdentifier == "FLUX") {
+    if (CONFIG.boardIdentifier === "HESP" || CONFIG.boardIdentifier === "SX10" || CONFIG.boardIdentifier === "FLUX") {
         if (!isExpertModeEnabled()) {
         $('.IMUFLPFroll').show();
         $('.IMUFLPFpitch').hide();

--- a/src/js/tabs/firmware_flasher.js
+++ b/src/js/tabs/firmware_flasher.js
@@ -10,7 +10,7 @@ TABS.firmware_flasher = {
 TABS.firmware_flasher.initialize = function (callback) {
     var self = this;
 
-    if (GUI.active_tab != 'firmware_flasher') {
+    if (GUI.active_tab !== 'firmware_flasher') {
         GUI.active_tab = 'firmware_flasher';
     }
 
@@ -110,7 +110,7 @@ TABS.firmware_flasher.initialize = function (callback) {
                 .forEach(function(target, i) {
                     var descriptors = builds[target];
                     descriptors.forEach(function(descriptor){
-                        if($.inArray(target, selectTargets) == -1) {
+                        if($.inArray(target, selectTargets) === -1) {
                             selectTargets.push(target);
                             var select_e =
                                     $("<option value='{0}'>{0}</option>".format(
@@ -151,7 +151,7 @@ TABS.firmware_flasher.initialize = function (callback) {
                             return;
                         }
                         var target = match[2].replace(/_Build_\d+_\w+$/i, '');
-                        if($.inArray(target, unsortedTargets) == -1) {
+                        if($.inArray(target, unsortedTargets) === -1) {
                             unsortedTargets.push(target);
                         }
                     });
@@ -177,7 +177,7 @@ TABS.firmware_flasher.initialize = function (callback) {
                         var target = match[2].replace(/_Build_\d+_\w+$/i, '');
                         var format = match[4];
 
-                        if (format != 'hex') {
+                        if (format !== 'hex') {
                             return;
                         }
 
@@ -213,7 +213,7 @@ TABS.firmware_flasher.initialize = function (callback) {
                     .forEach(function(target, i) {
                         var descriptors = releases[target];
                         descriptors.forEach(function(descriptor){
-                            if($.inArray(target, selectTargets) == -1) {
+                            if($.inArray(target, selectTargets) === -1) {
                                 selectTargets.push(target);
                                 var select_e =
                                         $("<option value='{0}'>{0}</option>".format(
@@ -331,7 +331,7 @@ TABS.firmware_flasher.initialize = function (callback) {
                 }
 
                 var versions_e = $('select[name="firmware_version"]').empty();
-                if(target == 0) {
+                if(target === "0") {
                     versions_e.append($("<option value='0'>{0}</option>".format(i18n.getMessage('firmwareFlasherOptionLabelSelectFirmwareVersion'))));
                 } else {
                     versions_e.append($("<option value='0'>{0} {1}</option>".format(i18n.getMessage('firmwareFlasherOptionLabelSelectFirmwareVersionFor'), target)));
@@ -356,7 +356,7 @@ TABS.firmware_flasher.initialize = function (callback) {
                 }
 
                 // Default to first real version for a valid target; keep placeholder (index 0) when no target selected.
-                versions_e.prop("selectedIndex", target == 0 ? 0 : 1).change();
+                versions_e.prop("selectedIndex", target === "0" ? 0 : 1).change();
             }
             chrome.storage.local.set({'selected_board': target});
         });
@@ -401,7 +401,7 @@ TABS.firmware_flasher.initialize = function (callback) {
 
                         reader.onloadend = function(e) {
 
-                            if (e.total != 0 && e.total == e.loaded) {
+                            if (e.total !== 0 && e.total === e.loaded) {
 
                                 console.log('File loaded (' + e.loaded + ')');
 
@@ -438,7 +438,7 @@ TABS.firmware_flasher.initialize = function (callback) {
 
             let release = $("option:selected", evt.target).data("summary");
             let isCached = FirmwareCache.has(release);
-            if (evt.target.value == "0") {
+            if (evt.target.value === "0") {
                 $("a.load_remote_file").addClass('disabled');
             } else if (isCached) {
                 FirmwareCache.get(release, cached => {
@@ -455,7 +455,7 @@ TABS.firmware_flasher.initialize = function (callback) {
         $('a.load_remote_file').click(function (evt) {
             self.enableFlashing(false);
             self.localFileLoaded = false;
-            if ($('select[name="firmware_version"]').val() == "0") {
+            if ($('select[name="firmware_version"]').val() === "0") {
                 GUI.log(i18n.getMessage('firmwareFlasherNoFirmwareSelected'));
                 return;
             }
@@ -481,7 +481,7 @@ TABS.firmware_flasher.initialize = function (callback) {
         $('a.flash_firmware').click(function () {
             if (!$(this).hasClass('disabled')) {
                 if (!GUI.connect_lock) { // button disabled while flashing is in progress
-                    if (parsed_hex != false) {
+                    if (parsed_hex !== false) {
                         var options = {};
 
                         var eraseAll = false;
@@ -521,7 +521,7 @@ TABS.firmware_flasher.initialize = function (callback) {
                             console.log('[flashComplete] controls re-enabled');
                         };
 
-                        if (String($('div#port-picker #port').val()) != 'DFU') {
+                        if (String($('div#port-picker #port').val()) !== 'DFU') {
                             // Manual entry's picker value is the literal string 'manual' --
                             // substitute the typed override path, matching the same
                             // isManual handling serial_backend.js uses for the Connect button.
@@ -730,7 +730,7 @@ TABS.firmware_flasher.initialize = function (callback) {
         });
 
         $(document).keypress(function (e) {
-            if (e.which == 13) { // enter
+            if (e.which === 13) { // enter
                 // Trigger regular Flashing sequence
                 $('a.flash_firmware').click();
             }


### PR DESCRIPTION
AI Generated pull-request

## Summary
- Converts 53 `==`/`!=` sites to `===`/`!==` across `CliAutoComplete.js` (14), `backup_restore.js` (13), `main.js` (12), `firmware_flasher.js` (14). Lint 390->337, 0 new warnings.
- Stage 4 of the `eslint-non-curly-cleanup` batch plan (see #695, #696 for prior stages of this `eqeqeq` cleanup).
- Every site verified per-comparison for operand type, not auto-fixed:
  - 10 `backup_restore.js` null-or-undefined checks converted to `== null`/`!= null` (smart-mode exempt) instead of `===`/`!==` against `undefined`, to avoid narrowing behavior (a real bug caught by CodeRabbit in a prior batch, #696).
  - 2 `firmware_flasher.js` board-select comparisons (`target == 0`) cast to `target === "0"`, since `.val()` always returns a string.
  - `parsed_hex != false` converted to strict `!==` since `parsed_hex` is always boolean `false` or a parse-result object, never loose-coercible to a matching type.

## Follow-up fix (commit 641ee3a3)
CodeRabbit's formal review caught that `backup_restore.js:485`'s `loopTime == 0` -> direct `=== 0` would stop matching a legacy backup where `loopTime` was serialized as the string `"0"` instead of the number `0`, silently skipping the reset to `3500`. Fixed with `Number(configuration.FC_CONFIG.loopTime) === 0`, normalizing both representations before the strict comparison.

## Manual UI/hardware testing found 3 pre-existing, unrelated issues (not in scope for this PR, filed separately)
- #697 — Firmware Flasher build-type switch may show a stale version list from an unguarded async race (needs reproduction).
- #698 — Backup/Restore buttons and code have been dead/hidden since 2020; propose full removal.
- #699 — Motor idle throttle field (and 23 other decimal-step numeric fields, not yet individually checked) loses decimal padding display after save + tab re-entry; cosmetic only.

## Test plan
- [x] `yarn lint`: 390 -> 337 warnings, 0 errors, 0 new warnings, all 4 files clean of `eqeqeq`.
- [x] `node -c` syntax check on all 4 files.
- [x] `yarn dev` boots cleanly.
- [x] Hardware/UI smoke test: Firmware Flasher (board/version select, local file load, remote file load), CLI tab autocomplete, main.js UI (options window, dark theme, tab switching, numeric inputs, IMUF LPF visibility) — all pass, no regressions from this diff.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability across autocomplete, configuration restore, navigation, input validation, and firmware flashing workflows.
  - Prevented unexpected behavior caused by automatic value conversion during comparisons.
  - Improved handling of board selection, firmware versions, ports, file loading, migration states, and completion checks.
  - Ensured configuration restore and firmware flashing respond more consistently to valid and invalid state values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->