### PR TITLE
fix: eqeqeq cleanup for serial/protocol core

### DIFF
--- a/src/js/gui.js
+++ b/src/js/gui.js
@@ -54,11 +54,11 @@ var GUI_control = function () {
     this.allowedTabs = this.defaultAllowedTabsWhenDisconnected;
 
     // check which operating system is user running
-    if (navigator.appVersion.indexOf("Win") != -1)          { this.operating_system = "Windows"; }
-    else if (navigator.appVersion.indexOf("Mac") != -1)     { this.operating_system = "MacOS"; }
-    else if (navigator.appVersion.indexOf("CrOS") != -1)    { this.operating_system = "ChromeOS"; }
-    else if (navigator.appVersion.indexOf("Linux") != -1)   { this.operating_system = "Linux"; }
-    else if (navigator.appVersion.indexOf("X11") != -1)     { this.operating_system = "UNIX"; }
+    if (navigator.appVersion.indexOf("Win") !== -1)          { this.operating_system = "Windows"; }
+    else if (navigator.appVersion.indexOf("Mac") !== -1)     { this.operating_system = "MacOS"; }
+    else if (navigator.appVersion.indexOf("CrOS") !== -1)    { this.operating_system = "ChromeOS"; }
+    else if (navigator.appVersion.indexOf("Linux") !== -1)   { this.operating_system = "Linux"; }
+    else if (navigator.appVersion.indexOf("X11") !== -1)     { this.operating_system = "UNIX"; }
     else { this.operating_system = "Unknown"; }
 
     // Check the method of execution
@@ -95,7 +95,7 @@ const GUI_Modes = {
 GUI_control.prototype.interval_add = function (name, code, interval, first) {
     var data = {'name': name, 'timer': null, 'code': code, 'interval': interval, 'fired': 0, 'paused': false};
 
-    if (first == true) {
+    if (first === true) {
         code(); // execute code
 
         data.fired++; // increment counter
@@ -115,7 +115,7 @@ GUI_control.prototype.interval_add = function (name, code, interval, first) {
 // name = string
 GUI_control.prototype.interval_remove = function (name) {
     for (var i = 0; i < this.interval_array.length; i++) {
-        if (this.interval_array[i].name == name) {
+        if (this.interval_array[i].name === name) {
             clearInterval(this.interval_array[i].timer); // stop timer
 
             this.interval_array.splice(i, 1); // remove element/object from array
@@ -130,7 +130,7 @@ GUI_control.prototype.interval_remove = function (name) {
 // name = string
 GUI_control.prototype.interval_pause = function (name) {
     for (var i = 0; i < this.interval_array.length; i++) {
-        if (this.interval_array[i].name == name) {
+        if (this.interval_array[i].name === name) {
             clearInterval(this.interval_array[i].timer);
             this.interval_array[i].paused = true;
 
@@ -144,7 +144,7 @@ GUI_control.prototype.interval_pause = function (name) {
 // name = string
 GUI_control.prototype.interval_resume = function (name) {
     for (var i = 0; i < this.interval_array.length; i++) {
-        if (this.interval_array[i].name == name && this.interval_array[i].paused) {
+        if (this.interval_array[i].name === name && this.interval_array[i].paused) {
             var obj = this.interval_array[i];
 
             obj.timer = setInterval(function() {
@@ -172,7 +172,7 @@ GUI_control.prototype.interval_kill_all = function (keep_array) {
         var keep = false;
         if (keep_array) { // only run through the array if it exists
             keep_array.forEach(function (name) {
-                if (self.interval_array[i].name == name) {
+                if (self.interval_array[i].name === name) {
                     keep = true;
                 }
             });
@@ -214,7 +214,7 @@ GUI_control.prototype.timeout_add = function (name, code, timeout) {
 // name = string
 GUI_control.prototype.timeout_remove = function (name) {
     for (var i = 0; i < this.timeout_array.length; i++) {
-        if (this.timeout_array[i].name == name) {
+        if (this.timeout_array[i].name === name) {
             clearTimeout(this.timeout_array[i].timer); // stop timer
 
             this.timeout_array.splice(i, 1); // remove element/object from array
@@ -379,7 +379,7 @@ GUI_control.prototype.selectDefaultTabWhenConnected = function() {
     ConfigStorage.get(['rememberLastTab', 'lastTab'], function (result) {
         if (!(result.rememberLastTab
                 && !!result.lastTab
-                && result.lastTab.substring(4) != "cli")) {
+                && result.lastTab.substring(4) !== "cli")) {
             $('#tabs ul.mode-connected .tab_setup a').click();
             return;
         }
@@ -388,16 +388,16 @@ GUI_control.prototype.selectDefaultTabWhenConnected = function() {
 };
 
 GUI_control.prototype.isChromeApp = function () {
-  return this.Mode == GUI_Modes.ChromeApp;
+  return this.Mode === GUI_Modes.ChromeApp;
 }
 GUI_control.prototype.isNWJS = function () {
-  return this.Mode == GUI_Modes.NWJS;
+  return this.Mode === GUI_Modes.NWJS;
 }
 GUI_control.prototype.isElectron = function () {
-  return this.Mode == GUI_Modes.Electron;
+  return this.Mode === GUI_Modes.Electron;
 }
 GUI_control.prototype.isOther = function () {
-  return this.Mode == GUI_Modes.Other;
+  return this.Mode === GUI_Modes.Other;
 }
 
 

--- a/src/js/msp.js
+++ b/src/js/msp.js
@@ -242,7 +242,7 @@ var MSP = {
         });
     },
     listen: function(listener) {
-        if (this.listeners.indexOf(listener) == -1) {
+        if (this.listeners.indexOf(listener) === -1) {
             this.listeners.push(listener);
         }
     },
@@ -340,7 +340,7 @@ var MSP = {
 
         var requestExists = false;
         for (var i = 0; i < MSP.callbacks.length; i++) {
-            if (MSP.callbacks[i].code == code) {
+            if (MSP.callbacks[i].code === code) {
                 // request already exist, we will just attach
                 requestExists = true;
                 break;
@@ -360,7 +360,7 @@ var MSP = {
         // always send messages with data payload (even when there is a message already in the queue)
         if (data || !requestExists) {
             serial.send(bufferOut, function (sendInfo) {
-                if (sendInfo.bytesSent == bufferOut.byteLength) {
+                if (sendInfo.bytesSent === bufferOut.byteLength) {
                     if (callback_sent) {
                         callback_sent();
                     }

--- a/src/js/port_handler.js
+++ b/src/js/port_handler.js
@@ -40,7 +40,7 @@ PortHandler.check = function () {
         if (self.array_difference(self.initial_ports, current_ports).length > 0 || !self.initial_ports) {
             var removed_ports = self.array_difference(self.initial_ports, current_ports);
 
-            if (self.initial_ports != false) {
+            if (self.initial_ports !== false) {
                 if (removed_ports.length > 1) {
                     console.log('PortHandler - Removed: ' + removed_ports);
                 } else {
@@ -52,7 +52,7 @@ PortHandler.check = function () {
             // Keep in mind that this routine can not fire during atmega32u4 reboot procedure !!!
             if (GUI.connected_to) {
                 for (var i = 0; i < removed_ports.length; i++) {
-                    if (removed_ports[i] == GUI.connected_to) {
+                    if (removed_ports[i] === GUI.connected_to) {
                         $('div#port-picker a.connect').click();
                     }
                 }
@@ -87,7 +87,7 @@ PortHandler.check = function () {
                         // if last_used_port was set, we try to select it
                         if (result.last_used_port) {
                             current_ports.forEach(function(port) {
-                                if (port == result.last_used_port) {
+                                if (port === result.last_used_port) {
                                     console.log('Selecting last used port: ' + result.last_used_port);
 
                                     $('div#port-picker #port').val(result.last_used_port);
@@ -154,7 +154,7 @@ PortHandler.check = function () {
             // start connect procedure (if statement is valid)
             if (unambiguous_candidate && GUI.auto_connect && !GUI.connecting_to && !GUI.connected_to) {
                 // we need firmware flasher protection over here
-                if (GUI.active_tab != 'firmware_flasher') {
+                if (GUI.active_tab !== 'firmware_flasher') {
                     var detected_candidate = fc_candidates[0];
                     GUI.timeout_add('auto-connect_timeout', function () {
                         // Re-validate state: 1s may have passed and conditions can change.
@@ -167,7 +167,7 @@ PortHandler.check = function () {
                         var stateValid = GUI.auto_connect
                             && !GUI.connected_to
                             && !GUI.connecting_to
-                            && GUI.active_tab != 'firmware_flasher'
+                            && GUI.active_tab !== 'firmware_flasher'
                             && connectBtn.length > 0
                             && selectedPort === detected_candidate;
                         if (stateValid) {
@@ -367,7 +367,7 @@ PortHandler.array_difference = function (firstArray, secondArray) {
     }
 
     for (var i = 0; i < secondArray.length; i++) {
-        if (cloneArray.indexOf(secondArray[i]) != -1) {
+        if (cloneArray.indexOf(secondArray[i]) !== -1) {
             cloneArray.splice(cloneArray.indexOf(secondArray[i]), 1);
         }
     }

--- a/src/js/protocols/stm32.js
+++ b/src/js/protocols/stm32.js
@@ -201,7 +201,7 @@ STM32_protocol.prototype.read = function (readInfo) {
     }
 
     // routine that fetches data from buffer if statement is true
-    if (this.receive_buffer.length >= this.bytes_to_read && this.bytes_to_read != 0) {
+    if (this.receive_buffer.length >= this.bytes_to_read && this.bytes_to_read !== 0) {
         var data = this.receive_buffer.slice(0, this.bytes_to_read); // bytes requested
         this.receive_buffer.splice(0, this.bytes_to_read); // remove read bytes
 
@@ -256,7 +256,7 @@ STM32_protocol.prototype.send = function (Array, bytes_to_read, callback) {
 STM32_protocol.prototype.verify_response = function (val, data) {
     var self = this;
     
-    if (val != data[0]) {
+    if (val !== data[0]) {
         var message = 'STM32 Communication failed, wrong response, expected: ' + val + ' (0x' + val.toString(16) + ') received: ' + data[0] + ' (0x' + data[0].toString(16) + ')';
         console.error(message);
         TABS.firmware_flasher.flashingMessage(i18n.getMessage('stm32WrongResponse',[val, val.toString(16), data[0], data[0].toString(16)]), TABS.firmware_flasher.FLASH_MESSAGE_TYPES.INVALID);
@@ -353,7 +353,7 @@ STM32_protocol.prototype.verify_chip_signature = function (signature) {
 // result = true/false
 STM32_protocol.prototype.verify_flash = function (first_array, second_array) {
     for (var i = 0; i < first_array.length; i++) {
-        if (first_array[i] != second_array[i]) {
+        if (first_array[i] !== second_array[i]) {
             console.log('Verification failed on byte: ' + i + ' expected: 0x' + first_array[i].toString(16) + ' received: 0x' + second_array[i].toString(16));
             return false;
         }
@@ -376,7 +376,7 @@ STM32_protocol.prototype.upload_procedure = function (step) {
             var send_counter = 0;
             GUI.interval_add('stm32_initialize_mcu', function () { // 200 ms interval (just in case mcu was already initialized), we need to break the 2 bytes command requirement
                 self.send([0x7F], 1, function (reply) {
-                    if (reply[0] == 0x7F || reply[0] == self.status.ACK || reply[0] == self.status.NACK) {
+                    if (reply[0] === 0x7F || reply[0] === self.status.ACK || reply[0] === self.status.NACK) {
                         GUI.interval_remove('stm32_initialize_mcu');
                         console.log('STM32 - Serial interface initialized on the MCU side');
 
@@ -413,7 +413,7 @@ STM32_protocol.prototype.upload_procedure = function (step) {
                     self.retrieve(data[1] + 1 + 1, function (data) { // data[1] = number of bytes that will follow [– 1 except current and ACKs]
                         console.log('STM32 - Bootloader version: ' + (parseInt(data[0].toString(16)) / 10).toFixed(1)); // convert dec to hex, hex to dec and add floating point
 
-                        self.useExtendedErase = (data[7] == self.command.extended_erase);
+                        self.useExtendedErase = (data[7] === self.command.extended_erase);
 
                         // proceed to next step
                         self.upload_procedure(3);

--- a/src/js/serial_backend.js
+++ b/src/js/serial_backend.js
@@ -36,7 +36,7 @@ function initializeSerialBackend() {
     });
 
     $('div.connect_controls a.connect').click(function () {
-        if (GUI.connect_lock != true) { // GUI control overrides the user control
+        if (GUI.connect_lock !== true) { // GUI control overrides the user control
 
             var thisElement = $(this);
             var clicks = thisElement.data('clicks');
@@ -54,7 +54,7 @@ function initializeSerialBackend() {
             if (selected_port === 'DFU') {
                 GUI.log(i18n.getMessage('dfu_connect_message'));
             }
-            else if (selected_port != '0') {
+            else if (selected_port !== '0') {
                 if (!clicks) {
                     console.log('Connecting to: ' + selected_port);
                     GUI.connecting_to = selected_port;
@@ -192,7 +192,7 @@ function onOpen(openInfo) {
         // save selected port with chrome.storage if the port differs
         ConfigStorage.get('last_used_port', function (result) {
             if (result.last_used_port) {
-                if (result.last_used_port != GUI.connected_to) {
+                if (result.last_used_port !== GUI.connected_to) {
                     // last used port doesn't match the one found in local db, we will store the new one
                     ConfigStorage.set({'last_used_port': GUI.connected_to});
                 }
@@ -369,7 +369,7 @@ function onConnect() {
             }
         });
 
-        if (CONFIG.boardType == 0) {
+        if (CONFIG.boardType === 0) {
             if (classes.indexOf("osd-required") >= 0) {
                 found = false;
             }
@@ -390,7 +390,7 @@ function onConnect() {
         MSP.send_message(MSPCodes.MSP_STATUS_EX, false, false);
         MSP.send_message(MSPCodes.MSP_DATAFLASH_SUMMARY, false, false);
 
-        if (CONFIG.boardType == 0 || CONFIG.boardType == 2) {
+        if (CONFIG.boardType === 0 || CONFIG.boardType === 2) {
             startLiveDataRefreshTimer();
         }
     }
@@ -472,7 +472,7 @@ function sensor_status(sensors_detected) {
     }
 
     // update UI (if necessary)
-    if (sensor_status.previous_sensors_detected == sensors_detected) {
+    if (sensor_status.previous_sensors_detected === sensors_detected) {
         return;
     }
 
@@ -490,7 +490,7 @@ function sensor_status(sensors_detected) {
         $('.accicon', e_sensor_status).removeClass('active');
     }
 
-    if ((CONFIG.boardType == 0 || CONFIG.boardType == 2) && have_sensor(sensors_detected, 'gyro')) {
+    if ((CONFIG.boardType === 0 || CONFIG.boardType === 2) && have_sensor(sensors_detected, 'gyro')) {
         $('.gyro', e_sensor_status).addClass('on');
         $('.gyroicon', e_sensor_status).addClass('active');
     } else {
@@ -562,7 +562,7 @@ function update_live_status() {
        display: 'inline-block'
     });
 
-    if (GUI.active_tab != 'cli') {
+    if (GUI.active_tab !== 'cli') {
         MSP.send_message(MSPCodes.MSP_BOXNAMES, false, false);
         MSP.send_message(MSPCodes.MSP_STATUS_EX, false, false);
         MSP.send_message(MSPCodes.MSP_ANALOG, false, false);
@@ -571,7 +571,7 @@ function update_live_status() {
     var active = ((Date.now() - ANALOG.last_received_timestamp) < 300);
 
     for (var i = 0; i < AUX_CONFIG.length; i++) {
-       if (AUX_CONFIG[i] == 'ARM') {
+       if (AUX_CONFIG[i] === 'ARM') {
                if (bit_check(CONFIG.mode, i)) {
                        $(".armedicon").css({
                                'background-image': 'url(images/icons/cf_icon_armed_active.svg)'
@@ -582,7 +582,7 @@ function update_live_status() {
                            });
                }
        }
-       if (AUX_CONFIG[i] == 'FAILSAFE') {
+       if (AUX_CONFIG[i] === 'FAILSAFE') {
                if (bit_check(CONFIG.mode, i)) {
                        $(".failsafeicon").css({
                                'background-image': 'url(images/icons/cf_icon_failsafe_active.svg)'
@@ -594,9 +594,9 @@ function update_live_status() {
                }
        }
     }
-    if (ANALOG != undefined) {
+    if (ANALOG != null) {
     var nbCells = Math.floor(ANALOG.voltage / BATTERY_CONFIG.vbatmaxcellvoltage) + 1;
-    if (ANALOG.voltage == 0) {
+    if (ANALOG.voltage === 0) {
            nbCells = 1;
     }
 
@@ -638,7 +638,7 @@ function specificByte(num, pos) {
 }
 
 function bit_check(num, bit) {
-    return ((num >> bit) % 2 != 0);
+    return ((num >> bit) % 2 !== 0);
 }
 
 function bit_set(num, bit) {

--- a/src/js/workers/hex_parser.js
+++ b/src/js/workers/hex_parser.js
@@ -7,7 +7,7 @@ function read_hex_file(data) {
     data = data.split("\n");
 
     // check if there is an empty line in the end of hex file, if there is, remove it
-    if (data[data.length - 1] == "") {
+    if (data[data.length - 1] === "") {
         data.pop();
     }
 
@@ -33,7 +33,7 @@ function read_hex_file(data) {
 
         switch (record_type) {
             case 0x00: // data record
-                if (address != next_address || next_address == 0) {
+                if (address !== next_address || next_address === 0) {
                     result.data.push({'address': extended_linear_address + address, 'bytes': 0, 'data': []});
                 }
 
@@ -57,7 +57,7 @@ function read_hex_file(data) {
                 crc = (~crc + 1) & 0xFF;
 
                 // verify
-                if (crc != checksum) {
+                if (crc !== checksum) {
                     hexfile_valid = false;
                 }
                 break;
@@ -66,13 +66,13 @@ function read_hex_file(data) {
                 break;
             case 0x02: // extended segment address record
                 // not implemented
-                if (parseInt(content, 16) != 0) { // ignore if segment is 0
+                if (parseInt(content, 16) !== 0) { // ignore if segment is 0
                     console.log('extended segment address record found - NOT IMPLEMENTED !!!');
                 }
                 break;
             case 0x03: // start segment address record
                 // not implemented
-                if (parseInt(content, 16) != 0) { // ignore if segment is 0
+                if (parseInt(content, 16) !== 0) { // ignore if segment is 0
                     console.log('start segment address record found - NOT IMPLEMENTED !!!');
                 }
                 break;


### PR DESCRIPTION
AI Generated pull-request

Stage 4 of 4 `eqeqeq` cleanup — Serial/protocol core batch. Converts 53 loose-equality
comparisons to strict in `gui.js`(16), `serial_backend.js`(15), `port_handler.js`(6),
`msp.js`(3), `protocols/stm32.js`(7), `workers/hex_parser.js`(6).

Every comparison verified same-type at the call site before conversion (per-comparison
operand-type trace, not bulk auto-fix):
- Port paths and `GUI.active_tab` always strings.
- MSP-decoded fields (`boardType`, `CONFIG.mode`, MSP callback `code`) and byte-array
  values (STM32 bootloader replies, hex-parser bytes) always numbers.
- `serial_backend.js`'s `ANALOG != undefined` converted to `!= null` (eqeqeq smart-mode
  exempt) instead of narrowing to `!==` — preserves matching both `null` and `undefined`,
  same idiom applied in prior batches (PR #696, #700).

0 new lint warnings (337 → 284). All 6 files clean of `eqeqeq`; `msp.js`/`port_handler.js`
still carry pre-existing `complexity` warnings tracked separately under #693, untouched by
this diff.

Hardware-tested against 2 live FCs (HELIOSPRING + FOXEERF405) simultaneously connected:
connect/disconnect, port picker + auto-connect, tab switching incl. CLI, sensor status
icons (ARM/FAILSAFE aux, battery voltage), and a full DFU firmware flash (exercises
`stm32.js`/`hex_parser.js` write+verify path). All pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency and reliability across connection, serial communication, protocol handling, port management, and file parsing.
  * Tightened validation of device responses, checksums, addresses, and status values to prevent unintended type conversions.
  * Added clearer handling for unsupported extended address records during HEX file parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->