### PR TITLE
fix: eqeqeq cleanup for grouped App/util misc batch

### DIFF
--- a/src/js/Beepers.js
+++ b/src/js/Beepers.js
@@ -83,7 +83,7 @@ Beepers.prototype.generateElements = function (template, destination) {
             input_e.attr('id', 'beeper-' + i);
             input_e.attr('name', self._beepers[i].name);
             input_e.attr('title', self._beepers[i].name);
-            input_e.prop('checked', bit_check(self._beeperMask, self._beepers[i].bit) == 0);
+            input_e.prop('checked', bit_check(self._beeperMask, self._beepers[i].bit) === false);
             input_e.data('bit', self._beepers[i].bit);
 
             label_e.attr('for', 'beeper-' + i);

--- a/src/js/DarkTheme.js
+++ b/src/js/DarkTheme.js
@@ -31,7 +31,7 @@ var DarkTheme = {
 };
 
 DarkTheme.setConfig = function(result) {
-    if (this.configEnabled != result) {
+    if (this.configEnabled !== result) {
         this.configEnabled = result;
 
         if (this.configEnabled) {

--- a/src/js/Features.js
+++ b/src/js/Features.js
@@ -165,7 +165,7 @@ Features.prototype.findFeatureByBit = function (bit) {
     var self = this;
 
     for (var i = 0; i < self._features.length; i++) {
-        if (self._features[i].bit == bit) {
+        if (self._features[i].bit === bit) {
             return self._features[i];
         }
     }
@@ -175,7 +175,7 @@ Features.prototype.findFeatureByName = function (name) {
     var self = this;
 
     for (var i = 0; i < self._features.length; i++) {
-        if (self._features[i].name == name) {
+        if (self._features[i].name === name) {
             return self._features[i];
         }
     }
@@ -185,7 +185,7 @@ Features.prototype.findBitValueByName = function (name) {
     var self = this;
 
     for (var i = 0; i < self._features.length; i++) {
-        if (self._features[i].name == name) {
+        if (self._features[i].name === name) {
             return self._features[i].bit;
         }
     }

--- a/src/js/LogoManager.js
+++ b/src/js/LogoManager.js
@@ -52,8 +52,8 @@ LogoManager.init = function (font, logoStartIndex) {
              */
             test: img => {
                 var constraint = this.constraints.imageSize;
-                if (img.width != constraint.expectedWidth
-                    || img.height != constraint.expectedHeight) {
+                if (img.width !== constraint.expectedWidth
+                    || img.height !== constraint.expectedHeight) {
                     GUI.log(i18n.getMessage("osdSetupCustomLogoImageSizeError", {
                         width: img.width,
                         height: img.height,
@@ -237,7 +237,7 @@ LogoManager.replaceLogoInFont = function (img) {
                 colorKey = rgbPixel.join("-");
             line += this.constants.MCM_COLORMAP[colorKey]
                 || this.constants.MCM_COLORMAP['default'];
-            if (line.length == 8) {
+            if (line.length === 8) {
                 char.push(line);
                 line = "";
             }

--- a/src/js/RateCurve.js
+++ b/src/js/RateCurve.js
@@ -65,7 +65,7 @@ var RateCurve = function (useLegacyCurve) {
 
         var currentValue = this.rcCommandRawToDegreesPerSecond(rcData, rate, rcRate, rcExpo, superExpoActive, deadband, limit);
 
-        if(rcData!=undefined) {
+        if(rcData != null) {
             context.save();
             context.fillStyle = stickColor || '#000000';
 

--- a/src/js/default_huffman_tree.js
+++ b/src/js/default_huffman_tree.js
@@ -266,7 +266,7 @@ var defaultHuffmanLenIndex = function()
     var result = Array(defaultHuffmanTree.length).fill(-1);
 
     for (var i = 0; i < defaultHuffmanTree.length; ++i) {
-        if (result[defaultHuffmanTree[i].codeLen] == -1) {
+        if (result[defaultHuffmanTree[i].codeLen] === -1) {
             result[defaultHuffmanTree[i].codeLen] = i;
         }
     }

--- a/src/js/huffman.js
+++ b/src/js/huffman.js
@@ -11,13 +11,13 @@ function huffmanDecodeBuf(inBuf, inBufCharacterCount, huffmanTree, huffmanLenInd
     var eof = false;
     var outBuf = [];
 
-    while (!eof && inBuf.byteLength != 0) {
-        if (outBuf.length == inBufCharacterCount) {
+    while (!eof && inBuf.byteLength !== 0) {
+        if (outBuf.length === inBufCharacterCount) {
             // we've exhausted the input stream, discard any odd bits on the end
             break;
         }
 
-        if (inBuf.byteLength == 0) {
+        if (inBuf.byteLength === 0) {
             throw new Error('unexpected');
         }
 
@@ -28,20 +28,20 @@ function huffmanDecodeBuf(inBuf, inBufCharacterCount, huffmanTree, huffmanLenInd
             code |= 0x01;
         }
         testBit >>= 1;
-        if (testBit == 0) {
+        if (testBit === 0) {
             testBit = 0x80;
             inBuf = inBuf.subarray(1);
         }
 
         // check if the code is a leaf node or an interior node
-        if (huffmanLenIndex[codeLen] != -1) {
+        if (huffmanLenIndex[codeLen] !== -1) {
             // look for the code in the tree, only leaf nodes are stored in the tree
-            for (var i = huffmanLenIndex[codeLen]; (i < huffmanTree.length) && (huffmanTree[i].codeLen == codeLen); ++i) {
-                if (huffmanTree[i].code == code) {
+            for (var i = huffmanLenIndex[codeLen]; (i < huffmanTree.length) && (huffmanTree[i].codeLen === codeLen); ++i) {
+                if (huffmanTree[i].code === code) {
                     // we've found the code, so it is a leaf node
                     var value = huffmanTree[i].value;
 
-                    if (value == HUFFMAN_EOF) {
+                    if (value === HUFFMAN_EOF) {
                         eof = true;
                     } else {
                         // output the value

--- a/src/js/jenkins_loader.js
+++ b/src/js/jenkins_loader.js
@@ -89,7 +89,7 @@ JenkinsLoader.prototype.loadBuilds = function (jobName, callback) {
                 GUI.log(i18n.getMessage('buildServerLoaded', [jobName]));
 
                 // filter successful builds
-                var builds = buildsInfo.builds.filter(build => build.result == 'SUCCESS')
+                var builds = buildsInfo.builds.filter(build => build.result === 'SUCCESS')
                     .map(build => ({
                         number: build.number,
                         artifacts: build.artifacts.map(artifact => artifact.relativePath),

--- a/src/js/localization.js
+++ b/src/js/localization.js
@@ -165,7 +165,7 @@ function getStoredUserLocale(cb) {
 
 function getValidLocale(userLocale) {
 
-    if (userLocale == 'DEFAULT') {
+    if (userLocale === 'DEFAULT') {
         userLocale = window.navigator.userLanguage || window.navigator.language;
         console.log('Detected locale ' + userLocale);
 
@@ -174,13 +174,13 @@ function getValidLocale(userLocale) {
         // If at some moment we get rid of the Chrome localization we can remove all of this
         userLocale = userLocale.replace('-','_');
         // Locale not found
-        if (languagesAvailables.indexOf(userLocale) == -1) {
+        if (languagesAvailables.indexOf(userLocale) === -1) {
             // Is a composite locale?
             var underscorePosition = userLocale.indexOf('_');
-            if (underscorePosition != -1) {                
+            if (underscorePosition !== -1) {
                 userLocale = userLocale.substring(0, underscorePosition);
                 // Locale dialect fallback not found
-                if (languagesAvailables.indexOf(userLocale) == -1) {
+                if (languagesAvailables.indexOf(userLocale) === -1) {
                     userLocale = 'en'; // Fallback language
                 }
             } else {

--- a/src/js/model.js
+++ b/src/js/model.js
@@ -51,7 +51,7 @@ var Model = function (wrapper, canvas) {
     var model_file = useWebGLRenderer ? mixerList[MIXER_CONFIG.mixer - 1].model : 'fallback';
 
     // Temporary workaround for 'custom' model until akfreak's custom model is merged.
-    if (model_file == 'custom') { model_file = 'fallback'; }
+    if (model_file === 'custom') { model_file = 'fallback'; }
 
     // setup scene
     this.scene = new THREE.Scene();

--- a/src/js/tabs/help.js
+++ b/src/js/tabs/help.js
@@ -4,7 +4,7 @@ TABS.help = {};
 TABS.help.initialize = function (callback) {
     var self = this;
 
-    if (GUI.active_tab != 'help') {
+    if (GUI.active_tab !== 'help') {
         GUI.active_tab = 'help';
     }
 

--- a/src/js/tabs/setup_osd.js
+++ b/src/js/tabs/setup_osd.js
@@ -6,7 +6,7 @@ TABS.setup_osd = {
 TABS.setup_osd.initialize = function (callback) {
     var self = this;
 
-    if (GUI.active_tab != 'setup_osd') {
+    if (GUI.active_tab !== 'setup_osd') {
         GUI.active_tab = 'setup_osd';
     }
 

--- a/src/js/tabs/static_tab.js
+++ b/src/js/tabs/static_tab.js
@@ -4,7 +4,7 @@ TABS.staticTab = {};
 TABS.staticTab.initialize = function (staticTabName, callback) {
     var self = this;
 
-    if (GUI.active_tab != staticTabName) {
+    if (GUI.active_tab !== staticTabName) {
         GUI.active_tab = staticTabName;
     }
     var tabFile = './tabs/' + staticTabName + '.html';

--- a/src/js/utils/VtxDeviceStatus/SmartAudioDeviceStatus.js
+++ b/src/js/utils/VtxDeviceStatus/SmartAudioDeviceStatus.js
@@ -33,7 +33,7 @@ class VtxDeviceStatusSmartAudio extends VtxDeviceStatus {
                 result = i18n.getMessage("vtxType_255");
         }
 
-        if (16 == this._mode) {
+        if (16 === this._mode) {
             result = i18n.getMessage("vtxSmartAudioUnlocked", {"version": result});
         }
 


### PR DESCRIPTION
AI Generated pull-request

## Summary

Final batch of the `eqeqeq` cleanup (ESLint stage 4 of 4). Converts 28 loose-equality
comparisons to strict equality across 14 grouped App/util files: `localization.js`(4),
`huffman.js`(8), `LogoManager.js`(3), `Features.js`(3), and 10 single-warning files
(`utils/VtxDeviceStatus/SmartAudioDeviceStatus.js`, `tabs/static_tab.js`, `tabs/setup_osd.js`,
`tabs/help.js`, `model.js`, `jenkins_loader.js`, `default_huffman_tree.js`, `RateCurve.js`,
`DarkTheme.js`, `Beepers.js`).

Every site verified by tracing both operands to their declaration/assignment. Two sites needed
non-obvious handling instead of a plain swap:

- `Beepers.js`: `bit_check(self._beeperMask, self._beepers[i].bit) == 0` — `bit_check()` returns
  a **boolean** (`(num >> bit) % 2 !== 0`), not a number. `false == 0` is `true` under loose
  equality but `false === 0` is always `false`, so a naive `=== 0` swap would have inverted the
  checkbox state. Converted to `=== false` instead.
- `RateCurve.js`: `rcData != undefined` guards a value read from `RC.channels[i]`, which is
  populated via `DataView.readU16()` (`injected_methods.js`) — that function returns `null` on a
  truncated buffer, not just `undefined` for an unset channel. Converted to `!= null` to keep
  matching both cases (per this project's established null/undefined idiom), not `!== undefined`.

All other 26 sites (string tab-name/mode comparisons, MSP-decoded numeric fields, huffman
tree/code/length numeric comparisons, `indexOf()` results) are same-type direct swaps — verified
via source trace, no casts needed.

This closes out the entire `eqeqeq` cleanup stage — see
[IT #703](https://github.com/emuflight/EmuConfigurator/issues/703) for the full batch history
(12 prior merged PRs).

## Test plan

- [x] `yarn lint` — 0 `eqeqeq` warnings in all 14 touched files (28 → 0); repo-wide lint now
      shows only the 8 pre-existing `complexity` warnings tracked under IT #693
- [x] `node --check` on all 14 touched files — syntax valid
- [x] `yarn dev` boot check — blocked in this sandbox by a known, pre-existing
      Electron/Chromium GPU crash (`MESA-INTEL: Haswell Vulkan support incomplete` → `GPU
      process isn't usable. Goodbye.`), confirmed unrelated to this diff (reproduces identically
      on unmodified worktrees). Build itself completes cleanly before the crash. User's own
      `yarn dev` run confirmed working (see manual smoke test below).
- [x] Manual UI smoke test — user-confirmed PASS: `Beepers.js`/`Features.js` (Configuration tab
      beeper/feature checkboxes) and `DarkTheme.js` (dark/light mode toggle) both working.
      `LogoManager.js` (OSD custom logo upload), `RateCurve.js` (PID Tuning rate-curve/stick
      canvas), locale switcher (`localization.js`), static tabs (Help, mixer calc), and
      `SmartAudioDeviceStatus.js` (SmartAudio VTX status) were not separately exercised — no
      CodeRabbit findings on any of the underlying comparisons, low risk given every site was
      a same-type direct swap (or the 2 explicitly-verified non-obvious sites above).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved consistency when evaluating settings, feature values, device states, locale selections, and tab activity.
  - Updated data-processing checks to handle empty or unset values more reliably.
  - Refined checkbox, theme, logo, rate-curve, and build-status state handling.
  - Strengthened decoding and configuration comparisons to prevent unintended type conversions.
  - No new user-facing features or interface changes were introduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
