### PR TITLE
fix(auxiliary): red-highlight ARM mode when arm switch active but arming blocked

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -1754,6 +1754,9 @@
     "auxiliaryModeLogicOR": {
         "message": "OR"
     },
+    "auxiliaryDisabled": {
+        "message": "(DISABLED)"
+    },
     "adjustmentsHelp": {
         "message": "Configure adjustment switches. See the 'in-flight adjustments' section of the manual for details. The changes that adjustment functions make are not saved automatically."
     },

--- a/src/css/tabs/auxiliary.css
+++ b/src/css/tabs/auxiliary.css
@@ -25,24 +25,24 @@
     color: black;
 }
 
-.tab-auxiliary .mode.on:nth-child(odd) .info {
-    background: var(--accent);
-}
-
 .tab-auxiliary .mode.off .info {
     background: #cb4747;
     background: #828885;
     color: white;
 }
 
-.tab-auxiliary .mode.off:nth-child(odd) .info {
-    background: #cb4747;
-    background: #828885;
-}
-
 .tab-auxiliary .mode.disabled .info {
     background: var(--error);
     color: white;
+}
+
+.tab-auxiliary .mode.on:nth-child(odd) .info {
+    background: var(--accent);
+}
+
+.tab-auxiliary .mode.off:nth-child(odd) .info {
+    background: #cb4747;
+    background: #828885;
 }
 
 .tab-auxiliary .mode.disabled:nth-child(odd) .info {

--- a/src/css/tabs/auxiliary.css
+++ b/src/css/tabs/auxiliary.css
@@ -26,7 +26,6 @@
 }
 
 .tab-auxiliary .mode.off .info {
-    background: #cb4747;
     background: #828885;
     color: white;
 }
@@ -41,7 +40,6 @@
 }
 
 .tab-auxiliary .mode.off:nth-child(odd) .info {
-    background: #cb4747;
     background: #828885;
 }
 

--- a/src/css/tabs/auxiliary.css
+++ b/src/css/tabs/auxiliary.css
@@ -40,6 +40,15 @@
     background: #828885;
 }
 
+.tab-auxiliary .mode.disabled .info {
+    background: var(--error);
+    color: white;
+}
+
+.tab-auxiliary .mode.disabled:nth-child(odd) .info {
+    background: var(--error);
+}
+
 #tab-auxiliary-templates {
     display: none;
 }

--- a/src/css/tabs/setup.css
+++ b/src/css/tabs/setup.css
@@ -311,6 +311,8 @@
 
 .disarm-flag {
     padding-left: 5px;
+    color: var(--error);
+    font-weight: bold;
 }
 
 }

--- a/src/js/tabs/auxiliary.js
+++ b/src/js/tabs/auxiliary.js
@@ -436,7 +436,10 @@ TABS.auxiliary.initialize = function (callback) {
                         && (CONFIG.armingDisableFlags & (1 << (CONFIG.armingDisableCount - 1))) > 0) {
                     // ARM_SWITCH is the highest arming-disable bit: arm switch is on but arming is blocked
                     $('.mode .name').eq(i).data('modeElement').removeClass('on').removeClass('off').addClass('disabled');
-                    $('.mode .name').eq(i).html(AUX_CONFIG[i] + '<br>' + i18n.getMessage('auxiliaryDisabled'));
+                    $('.mode .name').eq(i).empty()
+                        .append(document.createTextNode(AUX_CONFIG[i]))
+                        .append(document.createElement('br'))
+                        .append(document.createTextNode(i18n.getMessage('auxiliaryDisabled')));
                 } else {
                     $('.mode .name').eq(i).data('modeElement').removeClass('on').removeClass('disabled').addClass('off');
                     if (i === 0) {

--- a/src/js/tabs/auxiliary.js
+++ b/src/js/tabs/auxiliary.js
@@ -423,14 +423,25 @@ TABS.auxiliary.initialize = function (callback) {
                 let modeElement = $('#mode-' + i);
                 if (modeElement.find(' .range').length === 0 && modeElement.find(' .link').length === 0) {
                     // if the mode is unused, skip it
-                    modeElement.removeClass('off').removeClass('on');
+                    modeElement.removeClass('off').removeClass('on').removeClass('disabled');
                     continue;
                 }
-                
+
                 if (bit_check(CONFIG.mode, i)) {
-                    $('.mode .name').eq(i).data('modeElement').addClass('on').removeClass('off');
+                    $('.mode .name').eq(i).data('modeElement').addClass('on').removeClass('off').removeClass('disabled');
+                    if (i === 0) {
+                        $('.mode .name').eq(i).text(AUX_CONFIG[i]);
+                    }
+                } else if (i === 0 && CONFIG.armingDisableCount > 0
+                        && (CONFIG.armingDisableFlags & (1 << (CONFIG.armingDisableCount - 1))) > 0) {
+                    // ARM_SWITCH is the highest arming-disable bit: arm switch is on but arming is blocked
+                    $('.mode .name').eq(i).data('modeElement').removeClass('on').removeClass('off').addClass('disabled');
+                    $('.mode .name').eq(i).html(AUX_CONFIG[i] + '<br>' + i18n.getMessage('auxiliaryDisabled'));
                 } else {
-                    $('.mode .name').eq(i).data('modeElement').removeClass('on').addClass('off');
+                    $('.mode .name').eq(i).data('modeElement').removeClass('on').removeClass('disabled').addClass('off');
+                    if (i === 0) {
+                        $('.mode .name').eq(i).text(AUX_CONFIG[i]);
+                    }
                 }
                 hasUsedMode = true;
             }


### PR DESCRIPTION
AI Generated pull-request

## Summary
- Closes #710. Ports BFC's `ARMING_DISABLED_ARMSWITCH` special-case for the ARM mode row (index 0) in the Auxiliary/Modes tab, missing since EFC forked: when the arm switch is in its configured range but the highest `armingDisableFlags` bit is set, the ARM box now gets a `.disabled` class and turns red instead of staying grey, with a "(DISABLED)" label appended.
- Also adds a color rule to `.disarm-flag` in the Setup tab's arming-disable-flag list, which never had one in EFC's history (verified: BFC never had one there either, in any version checked).

## Test plan
- [x] `yarn lint`: 0 errors (8 pre-existing unrelated complexity warnings)
- [x] `yarn dev` builds and launches cleanly
- [x] Hardware-tested by reporter via `feature RX_MSP`: AUX5 driven into the ARM range with USB-only power (arming blocked) — ARM box now turns red with "(DISABLED)" label, confirmed working

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a clear “DISABLED” status for Auxiliary ARM modes when arming is unavailable.
  * Disabled modes now display distinct error styling for improved visibility.

* **Style**
  * Enhanced the disarm indicator with bold, error-colored text.
  * Improved visual consistency when Auxiliary modes switch between on, off, and disabled states.
  * Refined disabled-mode presentation to make unavailable controls easier to recognize at a glance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->